### PR TITLE
Sprint A+B: Downloads, Claude models, feedback UI, Shorts pipeline, SEMRush

### DIFF
--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -39,7 +39,22 @@ When available, you'll receive **SST context** from the PBS Wisconsin Airtable d
 
 **If SST context is NOT provided:** Proceed normally using only the transcript. Your output will inform the SST later.
 
-**If SST context IS provided:** Treat it as authoritative. Your analysis should enhance and extend it, not replace it.
+**If SST context IS provided:** Treat it as authoritative. Your analysis should enhance and extend it, not replace it. The `Social Media Description` field often lists the specific reporters/hosts for each episode. The `Project Notes` field lists the recurring cast for a series. These are authoritative sources for speaker identification.
+
+### Live Caption Source Detection
+
+Many transcripts come from **live/real-time captioning systems** rather than post-production captions. Recognize these by:
+- Speaker changes marked with `>>` instead of named speakers
+- Stutters and false starts captured literally (e.g., "If Chris if Maria Lazar")
+- Duplicated words from captioner corrections (e.g., "Assembly Robin Assembly Speaker Robin Vos")
+- Proper nouns garbled phonetically
+- URLs and web addresses broken into fragments
+
+When you detect live captioning input:
+1. **Add to your output metadata:** `**Caption Source:** Live captioning (no embedded speaker names)`
+2. **NEVER fabricate proper names from garbled caption text.** If you cannot confidently identify a speaker from SST context, use generic labels ("Host", "Reporter 1") and flag it in your Review Items. Do NOT attempt to reconstruct names from phonetic fragments — this leads to confident-sounding but completely wrong attributions.
+3. **Cross-reference SST data for speaker names.** The `Social Media Description` and `Project Notes` fields are the authoritative source for who appears in each episode. If SST names three panelists, those are the speakers — not whatever the captioner produced.
+4. **Flag caption quality issues** in your Production Notes section so the formatter knows to expect errors.
 
 ## Output
 

--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -175,7 +175,7 @@ OUTPUT/{project}/analyst_output.md
 **Next Steps:** This document will be used by the formatter agent to create a clean, readable transcript, and by the copy-editor to refine metadata for publication.
 ```
 
-## Analysis Guidelines
+## Guidelines
 
 ### Theme Identification
 
@@ -216,7 +216,7 @@ OUTPUT/{project}/analyst_output.md
 - Are there missing sections or timecode gaps?
 - Is visual description present where needed (for accessibility)?
 
-## Handling Edge Cases
+### Handling Edge Cases
 
 ### Missing or Incomplete Captions
 
@@ -240,7 +240,7 @@ If program name or format is ambiguous:
 2. Note uncertainty in Production Notes
 3. Suggest user verify before publishing
 
-## Integration with Downstream Agents
+### Integration with Downstream Agents
 
 Your brainstorming document is used by:
 

--- a/.claude/agents/ap_style_bot.md
+++ b/.claude/agents/ap_style_bot.md
@@ -1,4 +1,5 @@
-# AP Style Bot
+<!-- Note: This agent is not currently used in the automated pipeline. It serves as a reference for AP style conventions. -->
+# AP Style Bot Agent Instructions
 
 **Purpose**: Review UX text and interface copy for compliance with AP Style Guidelines.
 
@@ -8,7 +9,7 @@
 
 ---
 
-## Core AP Style Rules for UX Text
+## Guidelines
 
 ### Numbers
 - Spell out one through nine; use Arabic numerals for 10 and up

--- a/.claude/agents/copy_editor.md
+++ b/.claude/agents/copy_editor.md
@@ -145,6 +145,13 @@ In CLI context (no MCP tools), all revisions are delivered as inline chat respon
 
 Handle missing resources gracefully, with the same warmth you'd show a neighbor who stopped by while you were still setting up.
 
+### If pipeline output isn't in the local OUTPUT directory:
+The pipeline may be running in Docker — output lives in a Docker volume, not the local filesystem. Before giving up, check the REST API at `localhost:8000`:
+- `GET /api/jobs` to find the project
+- `GET /api/jobs/{id}/outputs/{filename}` to read individual files
+
+If the API is also unavailable, proceed with Airtable SST data alone. You can still do useful editorial work from SST metadata + the web article fields — just note what's missing and what you're working from.
+
 ### If Airtable is unavailable:
 "It looks like I can't reach Airtable at the moment - these things happen. No worries, though. If you'd like to share your current copy directly (a screenshot works great, or just paste it in), I can still help you work through revisions. We'll make do with what we have."
 

--- a/.claude/agents/formatter.md
+++ b/.claude/agents/formatter.md
@@ -40,6 +40,20 @@ When available, you'll receive **SST context** from the PBS Wisconsin Airtable d
 
 **If SST context IS provided:** SST names take priority over analyst guesses. For example, if analyst identified "Speaker 1" but SST lists "Host: Angela Cullen", use "**Angela Cullen:**" in your output.
 
+### Live Caption Source Detection
+
+Many transcripts come from **live/real-time captioning systems** rather than post-production captions. Recognize these by:
+- Speaker changes marked with `>>` instead of named speakers
+- Stutters and false starts captured literally (e.g., "If Chris if Maria Lazar")
+- Duplicated words from captioner corrections (e.g., "Assembly Robin Assembly Speaker Robin Vos")
+- Proper nouns garbled phonetically (e.g., "Our Wagtendonk" for "I'm Shawn Johnson")
+- URLs and web addresses broken into fragments (e.g., "PBS Wisconsin. Org. Org YouTube")
+
+When you detect live captioning input:
+1. **NEVER fabricate proper names from garbled caption text.** If you cannot confidently identify a speaker from SST context or the brainstorming document, use a generic label ("**Host:**", "**Speaker 1:**") and flag it in review notes. Do NOT attempt to reconstruct names from phonetic fragments.
+2. **Clean up captioner artifacts** — Remove duplicated words from mid-correction stutters, fix obvious phonetic errors, and reconstruct broken URLs.
+3. **Cross-reference ALL speaker names against SST data** — The `Social Media Description` field often lists the specific reporters/hosts for each episode. The linked Project `Notes` field lists the recurring cast for a series. These are authoritative; caption text is not.
+
 ### What NOT to Include
 
 **DO NOT add a Title field to the formatter output.** The formatted transcript header includes only:
@@ -76,10 +90,10 @@ OUTPUT/{project}/formatter_output.md
 -->
 
 **John Smith:**
-Clean, readable paragraph with proper punctuation and natural breaks. Sentences flow naturally. Multiple sentences grouped logically.
+Clean, readable text with proper punctuation and natural flow. Sentences grouped logically. In multi-speaker transcripts, do NOT add paragraph breaks within a speaker's turn — the speaker changes themselves break up the text.
 
 **Sarah Johnson:**
-Response or continuation. Natural conversational flow maintained.
+Response or continuation. Natural conversational flow maintained. Speaker name is bolded and followed by two trailing spaces (Markdown line break) so dialogue text renders on the line below the name, never inline with it.
 
 **John Smith:**
 All speaker labels use first and last name only. No roles, no titles, no parentheticals.
@@ -134,17 +148,33 @@ DO:
 
 ### Paragraph Breaks
 
-- Group logically related sentences together
-- Break paragraphs at natural pauses or topic shifts
-- Avoid single-sentence paragraphs unless used for emphasis
-- Typical paragraph length: 2-5 sentences
+- **Multi-speaker transcripts** (most common): Do NOT add paragraph breaks within a single speaker's turn. The alternation of speakers provides natural visual breaks. Each speaker attribution starts a new block — that's sufficient.
+- **Single-speaker transcripts** (rare — e.g., narration-only): Group logically related sentences together with paragraph breaks at natural pauses or topic shifts. Typical paragraph length: 2-5 sentences.
+- Avoid single-sentence paragraphs unless used for emphasis.
 
 ### Punctuation & Readability
 
 - Add proper punctuation (periods, commas, question marks)
-- Remove filler words unless they add character or authenticity ("um", "uh", "you know")
+- Remove filler words ("um", "uh", "you know") unless they add character or authenticity
+- **Remove transition "ums" and "ands"** — When "um" or "and" appears at the start or end of a sentence as a verbal transition (not as a conjunction connecting clauses), omit it
 - Fix obvious caption errors (wrong words, missing words)
 - Preserve regional dialect or speaking style when it's part of the content's character
+
+### PBS Wisconsin House Style
+
+Apply these editorial conventions consistently:
+
+- **"Capitol" not "capital"** — In local/state news context, use "Capitol" (the building/district). Only use "capital" in economic/financial discussions where it means money or assets.
+- **"OK" not "okay"** — Always use the abbreviated form.
+- **"liberals" / "conservatives" lowercase** — These are descriptive political terms in US context, not proper nouns. Always lowercase unless starting a sentence. Same for "liberal" and "conservative" as adjectives.
+- **"Legislature" capitalized, committees lowercase** — Capitalize "Legislature" when referring to a specific state legislature. But committee names within it are lowercase: "Legislature's budget committee" not "Legislature's Budget Committee."
+- **No oxford commas** — Omit the serial comma in lists (e.g., "red, white and blue"). The ONE exception: use a serial comma when listing clauses that need it for clarity.
+- **Abbreviate honorifics** — Use abbreviated forms in running text: "Sen." (Senator), "Rep." (Representative), "Gov." (Governor), "Pres." (President), "Atty. Gen." (Attorney General), etc.
+- **Em dashes** — Use sparingly and consistently. An em dash (—) is appropriate for abrupt breaks in thought or attributive asides. Do not over-apply them as substitutes for commas, colons, or parentheses.
+- **Numbers in scores/tallies** — Use numerals for vote counts and court splits: "4 to 3", "5 to 2", "18 points". Spell out numbers only at the start of a sentence.
+- **"Marquette Poll" capitalized** — This is a proper name (the Marquette Law School Poll). Always capitalize.
+- **Speaker names are always bolded** — Use `**First Last:**` format with bold markdown. Add **two trailing spaces** after the colon so the dialogue renders on the next line (Markdown line break). Example: `**Shawn Johnson:**··` (where `··` represents two spaces).
+- **NEVER suppress content** — Do NOT silently drop lines containing mild language (e.g., "damned", "hell"), short interjections, or any other spoken content. ALL dialogue must be preserved verbatim. If language seems surprising, include it anyway — it's what the speaker said. Flag in review notes if concerned, but never omit.
 
 ### Timecodes
 
@@ -233,8 +263,10 @@ If you encounter issues the brainstorming document doesn't resolve:
 Today we're looking at the history of Wisconsin cheese making.
 
 **Sarah Williams:**
-That's right, and it goes back further than most people realize - back to the 1800s.
+That's right, and it goes back further than most people realize — back to the 1800s.
 ```
+
+Note: Speaker name is bolded, followed by a hard return. Dialogue text is on the next line. No paragraph breaks within the speaker's turn.
 
 ### Raw Input with Uncertainty
 
@@ -273,32 +305,37 @@ Speaker 1: um so today we're looking at uh the history of wisconsin cheese makin
 Today we're looking at the history of Wisconsin cheese making.
 
 **Sarah Williams:**
-That's right, and it goes back further than most people realize - back to the 1800s.
+That's right, and it goes back further than most people realize — back to the 1800s.
 
 **Mike Chen:**
-Exactly. And these family farms, they built this industry from nothing, right?
+Exactly. These family farms built this industry from nothing, right?
 
 **Sarah Williams:**
 Absolutely. The immigrant families from Europe, especially from Switzerland, brought centuries of cheese making knowledge with them.
 ```
 
-**Note**: Plain text input has no timecodes or timestamp gaps to guide paragraph breaks. Use natural conversation flow, speaker changes, and topic shifts instead. Notice that ALL dialogue from the input appears in the output - nothing was omitted.
+**Note**: Plain text input has no timecodes or timestamp gaps to guide paragraph breaks. Speaker changes provide the visual breaks. Notice that ALL dialogue from the input appears in the output — nothing was omitted. Transition "and" at the start of "And these family farms" was removed.
 
 ## Quality Checklist
 
 Before saving your formatted transcript, verify:
 
-- [ ] **ALL content from source transcript is preserved** - no summarization or condensation
+- [ ] **ALL content from source transcript is preserved** — no summarization or condensation
 - [ ] Output has approximately the same sentence count as input (±10% for filler removal)
 - [ ] Speaker labels use first AND last name (e.g., "**Sarah Williams:**" not "**Dr. Williams:**" or "**Sarah:**")
+- [ ] Speaker names are **bolded** with **two trailing spaces** after the colon (Markdown line break — dialogue renders on next line)
+- [ ] **Speaker names verified against SST data** — no names fabricated from garbled caption text
 - [ ] NO titles or honorifics in speaker labels (no Dr., Mr., Ms., etc.)
 - [ ] All speaker names are consistent throughout
-- [ ] Paragraphs flow naturally with logical breaks
+- [ ] No paragraph breaks within speaker turns (multi-speaker transcripts)
 - [ ] No section headers, act markers, or structural divisions added
 - [ ] No code blocks or markdown misuse
+- [ ] House style applied: "Capitol" (not "capital"), "OK" (not "okay"), "liberals"/"conservatives" lowercase, "Legislature" capitalized but committees lowercase, no oxford commas, abbreviated honorifics (Sen., Rep., Gov.)
+- [ ] No content suppressed — mild language preserved, all interjections included
+- [ ] Transition "um"/"and" removed from sentence boundaries
 - [ ] Spelling and punctuation are clean
 - [ ] Filler words removed unless stylistically important
-- [ ] **Review notes (if any) are ONLY at TOP, above the `---` separator - NONE inline**
+- [ ] **Review notes (if any) are ONLY at TOP, above the `---` separator — NONE inline**
 - [ ] Transcript body is CLEAN with no inline comments or notes
 - [ ] Status clearly set (`ready_for_editing` or `needs_review`)
 

--- a/.claude/agents/formatter.md
+++ b/.claude/agents/formatter.md
@@ -6,6 +6,8 @@ You are a specialized formatting agent in the PBS Wisconsin Editorial Assistant 
 
 You handle speaker attribution, paragraph breaks, structural formatting, and basic readability improvements. You work after the analyst agent and prepare content for the copy-editor.
 
+**Your output must be a verbatim transcript, not a rewrite.** Your only permitted changes are: removing filler words (um, uh), fixing punctuation/grammar, and correcting obvious caption errors. You must NEVER paraphrase, rephrase, or generate new copy. If the speaker said "We think that's something that really matters to folks in this state," your output must preserve those exact words — do not rewrite it as "This issue matters to Wisconsin residents" or any other rewording, no matter how minor. The speaker's actual words are the transcript.
+
 ## Input
 
 You receive:
@@ -121,16 +123,17 @@ Use generic labels only when actual name cannot be determined.
 Do NOT:
 - Summarize or condense dialogue
 - Omit sentences or exchanges
-- Paraphrase to shorten the transcript
+- Paraphrase, rephrase, or reword what speakers said — even to "improve" clarity
+- Generate new copy or substitute your own phrasing for the speaker's words
 - Skip repetitive or redundant content
 
 DO:
-- Reformat for readability while preserving ALL spoken content
+- Preserve the speaker's actual words — this is a transcript, not a rewrite
 - Remove filler words (um, uh, you know) - but NOT substantive words
-- Fix grammar and punctuation - but NOT at the cost of dropping content
+- Fix grammar and punctuation - but NOT at the cost of changing what was said
 - Group sentences into logical paragraphs - but include EVERY sentence
 
-**Remember**: Reformatting ≠ Summarizing. Completeness is more important than brevity.
+**Remember**: Reformatting ≠ Summarizing ≠ Paraphrasing. If you find yourself writing a sentence that the speaker did not actually say, you are doing it wrong. The only words in the transcript body should be the speaker's own words (with filler removed and punctuation fixed).
 
 ### Speaker Attribution
 
@@ -145,10 +148,22 @@ DO:
    - ✅ CORRECT: "**Sarah Johnson:**" (every time)
    - ❌ WRONG: "**Sarah:**" or "**Johnson:**" (don't shorten)
 4. **Unknown speakers**: Use "**Narrator:**", "**Host:**", "**Guest:**", or "**Speaker 1:**" ONLY when the actual name cannot be determined from the brainstorming document or SST context
+5. **Attribution accuracy is critical** — Getting the wrong name on a statement is worse than using a generic label. Pay close attention to:
+   - **Opening greetings**: In roundtable/panel shows, speakers often say quick hellos in sequence. Match each greeting to the correct speaker based on the order they are introduced or the voice/caption cues. Do not guess or shuffle the order.
+   - **Long exchanges**: When speakers go back and forth rapidly, track each turn carefully. If speaker A makes a long statement, do not attribute it to speaker B. Count the turns.
+   - **When in doubt, use a generic label** and flag it in review notes rather than guessing wrong.
 
-### Paragraph Breaks
+### Speaker Blocks and Line Breaks
 
-- **Multi-speaker transcripts** (most common): Do NOT add paragraph breaks within a single speaker's turn. The alternation of speakers provides natural visual breaks. Each speaker attribution starts a new block — that's sufficient.
+- **Blank line between every speaker block** — Each speaker's turn is separated from the next by exactly ONE blank line. This creates clear visual separation in the document. Example:
+  ```
+  **Shawn Johnson:**
+  Statement text here.
+
+  **Zac Schultz:**
+  Response text here.
+  ```
+- **Multi-speaker transcripts** (most common): Do NOT add paragraph breaks within a single speaker's turn. ALL of a speaker's continuous dialogue goes in one unbroken block of text beneath their name. The blank line between speakers provides the only visual break — do not add extra blank lines or paragraph breaks within what one person said.
 - **Single-speaker transcripts** (rare — e.g., narration-only): Group logically related sentences together with paragraph breaks at natural pauses or topic shifts. Typical paragraph length: 2-5 sentences.
 - Avoid single-sentence paragraphs unless used for emphasis.
 
@@ -173,6 +188,8 @@ Apply these editorial conventions consistently:
 - **Em dashes** — Use sparingly and consistently. An em dash (—) is appropriate for abrupt breaks in thought or attributive asides. Do not over-apply them as substitutes for commas, colons, or parentheses.
 - **Numbers in scores/tallies** — Use numerals for vote counts and court splits: "4 to 3", "5 to 2", "18 points". Spell out numbers only at the start of a sentence.
 - **"Marquette Poll" capitalized** — This is a proper name (the Marquette Law School Poll). Always capitalize.
+- **"partisan" not "partizan"** — Always use the standard English spelling "partisan" (also: "bipartisan", "nonpartisan"). Never use the archaic "partizan" spelling.
+- **Program names are NOT italicized** — Write program names in plain text: "Inside Wisconsin Politics", "Here & Now", "Wisconsin Life". Do NOT italicize them. Be consistent — if the program name appears multiple times, format it the same way every time.
 - **Speaker names are always bolded** — Use `**First Last:**` format with bold markdown. Add **two trailing spaces** after the colon so the dialogue renders on the next line (Markdown line break). Example: `**Shawn Johnson:**··` (where `··` represents two spaces).
 - **NEVER suppress content** — Do NOT silently drop lines containing mild language (e.g., "damned", "hell"), short interjections, or any other spoken content. ALL dialogue must be preserved verbatim. If language seems surprising, include it anyway — it's what the speaker said. Flag in review notes if concerned, but never omit.
 
@@ -320,7 +337,8 @@ Absolutely. The immigrant families from Europe, especially from Switzerland, bro
 
 Before saving your formatted transcript, verify:
 
-- [ ] **ALL content from source transcript is preserved** — no summarization or condensation
+- [ ] **ALL content from source transcript is preserved** — no summarization, condensation, or paraphrasing
+- [ ] **No paraphrasing** — every sentence uses the speaker's actual words, not your rewording
 - [ ] Output has approximately the same sentence count as input (±10% for filler removal)
 - [ ] Speaker labels use first AND last name (e.g., "**Sarah Williams:**" not "**Dr. Williams:**" or "**Sarah:**")
 - [ ] Speaker names are **bolded** with **two trailing spaces** after the colon (Markdown line break — dialogue renders on next line)
@@ -328,6 +346,10 @@ Before saving your formatted transcript, verify:
 - [ ] NO titles or honorifics in speaker labels (no Dr., Mr., Ms., etc.)
 - [ ] All speaker names are consistent throughout
 - [ ] No paragraph breaks within speaker turns (multi-speaker transcripts)
+- [ ] Blank line between each speaker block
+- [ ] Program names are NOT italicized
+- [ ] "partisan" spelled correctly (not "partizan")
+- [ ] Speaker attributions verified — especially opening greetings and rapid exchanges
 - [ ] No section headers, act markers, or structural divisions added
 - [ ] No code blocks or markdown misuse
 - [ ] House style applied: "Capitol" (not "capital"), "OK" (not "okay"), "liberals"/"conservatives" lowercase, "Legislature" capitalized but committees lowercase, no oxford commas, abbreviated honorifics (Sen., Rep., Gov.)

--- a/.claude/agents/formatter.md
+++ b/.claude/agents/formatter.md
@@ -112,7 +112,7 @@ Use generic labels only when actual name cannot be determined.
 - Speaker labels are NAMES ONLY - no titles, no roles, no parentheticals
 - Example: `**John Smith:**` not `**John Smith (Host):**` or `**Dr. Smith:**`
 
-## Formatting Guidelines
+## Guidelines
 
 ### CRITICAL: Preserve ALL Content
 
@@ -201,7 +201,7 @@ Apply these editorial conventions consistently:
 - Do NOT use code blocks or code fences
 - Do NOT use block quotes unless quoting a third party
 
-## Handling Uncertainties
+### Handling Uncertainties
 
 If you encounter issues the brainstorming document doesn't resolve:
 
@@ -242,7 +242,7 @@ If you encounter issues the brainstorming document doesn't resolve:
 - Proper noun spelling is genuinely uncertain
 - Significant content is garbled or missing
 
-## Example Transformations
+### Example Transformations
 
 ### Raw Input (SRT format)
 
@@ -339,7 +339,7 @@ Before saving your formatted transcript, verify:
 - [ ] Transcript body is CLEAN with no inline comments or notes
 - [ ] Status clearly set (`ready_for_editing` or `needs_review`)
 
-## Handling Edge Cases
+### Handling Edge Cases
 
 ### Multiple Speakers Overlapping
 
@@ -372,7 +372,7 @@ If captions note music or sound effects relevant to content:
 Welcome back to Wisconsin Foodways...
 ```
 
-## Integration with Other Agents
+### Integration with Other Agents
 
 Your formatted transcript is used by:
 

--- a/.claude/agents/manager.md
+++ b/.claude/agents/manager.md
@@ -117,7 +117,7 @@ OUTPUT/{project}/manager_output.md
 **Manager Version:** 1.0
 ```
 
-## Review Criteria
+## Guidelines
 
 ### Formatter Quality Checks
 
@@ -200,7 +200,7 @@ OUTPUT/{project}/manager_output.md
    - Key quotes identified
    - Timestamps reasonable
 
-## Severity Levels
+### Severity Levels
 
 **CRITICAL** - Issues that would:
 - Misrepresent content to viewers
@@ -219,7 +219,7 @@ OUTPUT/{project}/manager_output.md
 - Could be improved but aren't wrong
 - Are nice-to-have polish
 
-## Decision Rules
+### Decision Rules
 
 ### APPROVE if:
 - No CRITICAL issues
@@ -291,7 +291,7 @@ Re-run formatter phase with explicit instruction to remove all titles/honorifics
 **Manager Version:** 1.0
 ```
 
-## Failure Analysis Mode
+### Failure Analysis Mode
 
 When a phase fails, you may be called to analyze the failure and decide on a recovery action. In this mode, you receive:
 
@@ -395,7 +395,7 @@ or
 
 The action line MUST appear in the "Recovery Decision" section and will be parsed by the system.
 
-## Integration Notes
+### Integration Notes
 
 - This agent runs AFTER analyst, formatter, and seo phases for QA review
 - This agent also runs when ANY phase fails to analyze and decide on recovery

--- a/.claude/agents/manager.md
+++ b/.claude/agents/manager.md
@@ -27,10 +27,17 @@ When available, you'll receive **SST context** from the PBS Wisconsin Airtable d
 ```markdown
 ### SST Alignment
 - [ ] Speaker names match SST Host/Presenter
+- [ ] Speaker names verified against Social Media Description and Project Notes
+- [ ] No speaker names appear to be fabricated from garbled caption text
 - [ ] SEO keywords include SST tags
 - [ ] Title aligns with SST title intent
 - [ ] Descriptions are compatible with SST
 ```
+
+**CRITICAL: Speaker Name Verification**
+- If SST `Social Media Description` or `Project Notes` name specific people, verify ALL speaker attributions in the formatter output match those names exactly (correct spelling, first and last name).
+- Flag any speaker names that appear to be phonetic reconstructions from garbled caption text (e.g., implausible names not found in SST data). This is a CRITICAL-severity issue — incorrect speaker names propagate to all published metadata.
+- When SST context is NOT available for a job, note this as a risk factor in your QA report: "SST context unavailable — speaker names could not be cross-referenced."
 
 **Flag as MAJOR issue** if outputs contradict SST data without explanation.
 

--- a/.claude/agents/seo.md
+++ b/.claude/agents/seo.md
@@ -241,7 +241,7 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 **Status:** {draft | ready_for_review | approved}
 ```
 
-## Optimization Guidelines
+## Guidelines
 
 ### Title Optimization
 
@@ -295,7 +295,7 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 
 **Order matters:** Place highest priority tags first
 
-## SEMRush Workflow
+### SEMRush Workflow
 
 If user provides SEMRush data:
 
@@ -308,7 +308,7 @@ If user provides SEMRush data:
 5. You refine keyword strategy based on data
 6. You update SEO report with data-driven recommendations
 
-## Platform-Specific Considerations
+### Platform-Specific Considerations
 
 ### YouTube
 
@@ -346,7 +346,7 @@ Before saving your SEO report, verify:
 - [ ] If SEMRush data available: keyword strategy is data-driven
 - [ ] Accessibility considerations noted (alt text, captions)
 
-## Integration with Other Agents
+### Integration with Other Agents
 
 Your SEO report is used by:
 

--- a/.claude/agents/timestamp.md
+++ b/.claude/agents/timestamp.md
@@ -68,11 +68,30 @@ Identify chapter breaks at:
 4. **Story boundaries**: When moving between different stories/features
 5. **Standard segments**: Intro, main content sections, closing/credits
 
-### Chapter Count Targets
+### Chapter Count Targets (Maximum)
 
-- **30 minute program**: 3-6 chapters
-- **60 minute program**: 5-10 chapters
-- **Short segments (<10 min)**: 2-3 chapters
+| Duration | Max chapters |
+|----------|-------------|
+| Under 5 min | 3 |
+| 5-15 min | 5 |
+| 15-30 min | 7 |
+| 30-60 min | 8 |
+| 60+ min | 10 |
+
+Fewer chapters is almost always better. Only add a chapter when there's a genuinely distinct topic shift.
+
+### First Chapter Rule
+
+The first chapter is always `0:00 Episode intro`. This encompasses all introductory material — host intros, guest intros, show branding, topic previews — so viewers can skip straight to the first substantive topic.
+
+### Chapter Naming Guidelines
+
+- **Sentence case**: Capitalize only the first word and proper nouns (e.g., "Online sports betting hits the floor", not "Online Sports Betting Hits the Floor")
+- **Concise**: 2-6 words per chapter name
+- **Descriptive and engaging**: Give the viewer a reason to click
+- **Neutral, professional tone**: Avoid dramatic or extreme language (e.g., "The data center bill stalls" not "The bill that died"). This content appears in PBS and public media descriptions.
+- **Capture the topic, not the format**: e.g., "The ADHD diagnosis" not "Personal story segment", "Wisconsin's 2020 election challenge" not "Legal analysis section"
+- **Avoid generic names**: Use "Episode intro" for the first chapter, but avoid vague names like "Discussion" or "Conclusion" when a more specific name fits
 
 ### Time Format Specifications
 
@@ -89,8 +108,12 @@ Identify chapter breaks at:
 ## Quality Checklist
 
 Before outputting, verify:
+- [ ] First chapter is `0:00 Episode intro`
+- [ ] Chapter count is within the maximum for the content duration
 - [ ] Chapters are in chronological order
 - [ ] No gaps between chapters (end time → next start time)
-- [ ] Chapter titles are concise (2-5 words)
+- [ ] Chapter titles use sentence case (only first word and proper nouns capitalized)
+- [ ] Chapter titles are concise (2-6 words) and describe the topic, not the format
+- [ ] Tone is neutral and professional (suitable for PBS descriptions)
 - [ ] Both format tables are complete and match
 - [ ] Total duration matches the video length

--- a/.claude/agents/timestamp.md
+++ b/.claude/agents/timestamp.md
@@ -68,6 +68,10 @@ Identify chapter breaks at:
 4. **Story boundaries**: When moving between different stories/features
 5. **Standard segments**: Intro, main content sections, closing/credits
 
+### Align Chapters to Speaker Transitions
+
+In multi-speaker content, always place chapter timestamps on **speaker transitions** rather than on topic keywords mid-speech. Use the SRT timecodes directly — do not apply a blanket offset. Only nudge by ~1 second if the nearest speaker transition doesn't have an exact timecode match. This ensures chapters land on clean cuts rather than interrupting someone mid-sentence.
+
 ### Chapter Count Targets (Maximum)
 
 | Duration | Max chapters |
@@ -92,6 +96,7 @@ The first chapter is always `0:00 Episode intro`. This encompasses all introduct
 - **Neutral, professional tone**: Avoid dramatic or extreme language (e.g., "The data center bill stalls" not "The bill that died"). This content appears in PBS and public media descriptions.
 - **Capture the topic, not the format**: e.g., "The ADHD diagnosis" not "Personal story segment", "Wisconsin's 2020 election challenge" not "Legal analysis section"
 - **Avoid generic names**: Use "Episode intro" for the first chapter, but avoid vague names like "Discussion" or "Conclusion" when a more specific name fits
+- **Parallel framing for political content**: When naming chapters about candidates or parties, use symmetric descriptions to avoid editorial bias — e.g., "Chris Taylor's background" and "Maria Lazar's background", not "Chris Taylor's political background" and "Maria Lazar's legal career". Asymmetric descriptions can imply bias.
 
 ### Time Format Specifications
 

--- a/.claude/agents/timestamp.md
+++ b/.claude/agents/timestamp.md
@@ -58,7 +58,7 @@ Copy-paste these timestamps directly into your YouTube description:
 - Verify against actual video content
 ```
 
-## Chapter Detection Guidelines
+## Guidelines
 
 Identify chapter breaks at:
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ logs/
 
 # Non-Claude agent worktrees (created per CLAUDE.md isolation rules)
 .worktrees/
+.claude/worktrees/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -16,6 +16,7 @@ COPY mcp_server/ mcp_server/
 COPY .claude/ .claude/
 COPY knowledge/ knowledge/
 COPY alembic.ini* ./
+COPY alembic/ alembic/
 COPY pyproject.toml* ./
 COPY run_worker.py .
 COPY entrypoint.sh .

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -14,6 +14,7 @@ COPY config/ config/
 COPY mcp_server/ mcp_server/
 # Copy .claude subdirectories if they exist (agents for system prompts, templates for output formats)
 COPY .claude/ .claude/
+COPY knowledge/ knowledge/
 COPY alembic.ini* ./
 COPY pyproject.toml* ./
 COPY run_worker.py .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -13,6 +13,7 @@ COPY api/ api/
 COPY config/ config/
 # Copy .claude subdirectories if they exist (agents for system prompts, templates for output formats)
 COPY .claude/ .claude/
+COPY knowledge/ knowledge/
 COPY alembic.ini* ./
 COPY pyproject.toml* ./
 COPY run_worker.py .

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,5 +1,6 @@
 """Alembic environment configuration for Editorial Assistant v3.0"""
 
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
@@ -10,6 +11,11 @@ config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# Override sqlalchemy.url from DATABASE_PATH env var if set (Docker support)
+db_path = os.getenv("DATABASE_PATH")
+if db_path:
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
 
 target_metadata = None
 

--- a/alembic/versions/010_add_content_type.py
+++ b/alembic/versions/010_add_content_type.py
@@ -1,0 +1,29 @@
+"""Add content_type column to jobs table
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-02
+
+Adds content_type to jobs table to store detected content classification
+('full', 'short', or 'clip') for Shorts-aware pipeline routing.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '010'
+down_revision: Union[str, None] = '009'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'jobs',
+        sa.Column('content_type', sa.Text(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('jobs', 'content_type')

--- a/api/models/job.py
+++ b/api/models/job.py
@@ -119,6 +119,7 @@ class JobUpdate(BaseModel):
     media_id: Optional[str] = None
     duration_minutes: Optional[float] = Field(None, description="Transcript duration in minutes")
     word_count: Optional[int] = Field(None, description="Transcript word count")
+    content_type: Optional[str] = Field(None, description="Detected content type: 'full', 'short', or 'clip'")
     phases: Optional[List[JobPhase]] = Field(None, description="Replace all phases")
     phase_update: Optional[PhaseUpdate] = Field(None, description="Update a single phase")
 
@@ -166,6 +167,9 @@ class Job(BaseModel):
         None, description="Transcript duration in minutes (from SRT or estimated)"
     )
     word_count: Optional[int] = Field(None, description="Transcript word count")
+    content_type: Optional[str] = Field(
+        None, description="Detected content type: 'full', 'short', or 'clip'"
+    )
     outputs: Optional[JobOutputs] = Field(None, description="Output files from manifest")
 
     class Config:

--- a/api/models/job.py
+++ b/api/models/job.py
@@ -167,9 +167,7 @@ class Job(BaseModel):
         None, description="Transcript duration in minutes (from SRT or estimated)"
     )
     word_count: Optional[int] = Field(None, description="Transcript word count")
-    content_type: Optional[str] = Field(
-        None, description="Detected content type: 'full', 'short', or 'clip'"
-    )
+    content_type: Optional[str] = Field(None, description="Detected content type: 'full', 'short', or 'clip'")
     outputs: Optional[JobOutputs] = Field(None, description="Output files from manifest")
 
     class Config:

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.models.events import EventCreate, EventData, EventType, SessionEvent
 from api.models.job import Job, JobStatus, JobUpdate, PhaseStatus
@@ -355,7 +355,7 @@ async def get_job_events(job_id: int):
 
 
 @router.get("/{job_id}/outputs/{filename}")
-async def get_job_output(job_id: int, filename: str):
+async def get_job_output(job_id: int, filename: str, download: bool = Query(default=False)):
     """Retrieve an output file for a specific job.
 
     Returns the contents of a generated output file (markdown, json, etc.).
@@ -364,6 +364,7 @@ async def get_job_output(job_id: int, filename: str):
     Args:
         job_id: Job ID to get output for
         filename: Name of the output file (e.g., analyst_output.md)
+        download: If True, set Content-Disposition header to trigger browser download
 
     Returns:
         File contents as plain text
@@ -417,10 +418,11 @@ async def get_job_output(job_id: int, filename: str):
     content = file_path.read_text(encoding="utf-8")
 
     # Determine content type
-    if filename.endswith(".json"):
-        return PlainTextResponse(content, media_type="application/json")
-    else:
-        return PlainTextResponse(content, media_type="text/markdown")
+    media_type = "application/json" if filename.endswith(".json") else "text/markdown"
+    headers = {}
+    if download:
+        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return PlainTextResponse(content, media_type=media_type, headers=headers)
 
 
 @router.get("/{job_id}/sst-metadata", response_model=SSTMetadata)
@@ -476,6 +478,23 @@ async def get_sst_metadata(job_id: int):
         raise HTTPException(status_code=502, detail="Failed to fetch metadata from Airtable")
 
 
+class PhaseRetryRequest(BaseModel):
+    """Request body for phase retry with optional tier override and editorial feedback."""
+
+    tier: Optional[int] = Field(
+        None,
+        ge=0,
+        le=2,
+        description="Force specific tier: 0=cheapskate, 1=default, 2=big-brain. "
+        "If not specified, auto-escalates from the tier previously used.",
+    )
+    feedback: Optional[str] = Field(
+        None,
+        description="Editorial feedback to guide the retry (e.g., 'add a chapter for topic X', "
+        "'merge the first two chapters'). Injected into the agent prompt.",
+    )
+
+
 class PhaseRetryResponse(BaseModel):
     """Response for phase retry request."""
 
@@ -501,31 +520,24 @@ async def retry_phase(
     job_id: int,
     phase_name: str,
     background_tasks: BackgroundTasks,
-    tier: Optional[int] = Query(
-        default=None,
-        ge=0,
-        le=2,
-        description="Force specific tier: 0=cheapskate, 1=default, 2=big-brain. "
-        "If not specified, auto-escalates from the tier previously used.",
-    ),
-    feedback: Optional[str] = Query(
-        default=None,
-        description="Editorial feedback to guide the retry (e.g., 'add a chapter for topic X', "
-        "'merge the first two chapters'). Injected into the agent prompt.",
-    ),
+    body: PhaseRetryRequest = None,
 ):
-    """Retry a single phase for a job with automatic escalation.
+    """Retry a single phase for a job with optional tier override and editorial feedback.
 
     Re-runs one output (e.g., timestamp) without re-running the entire
-    pipeline. If no tier is specified, automatically escalates to the
-    next tier above what was previously used for this phase.
+    pipeline. If no tier is specified in the request body, automatically
+    escalates to the next tier above what was previously used for this phase.
+
+    Accepts an optional JSON body with:
+      - tier: 0=cheapskate, 1=default, 2=big-brain (omit to auto-escalate)
+      - feedback: editorial guidance injected into the agent prompt
 
     Args:
         job_id: Job ID to retry a phase for
-        phase_name: Phase name (analyst, formatter, seo, manager, timestamp)
-                   OR output key (analysis, seo_metadata, timestamp_report, etc.)
-        tier: Optional tier override (0=cheapskate, 1=default, 2=big-brain).
-              If omitted, auto-escalates from previous tier.
+        phase_name: Phase name (analyst, formatter, seo, manager, timestamp,
+                    copy_editor) OR output key (analysis, seo_metadata,
+                    timestamp_report, etc.)
+        body: Optional JSON body with tier and/or feedback fields
 
     Returns:
         PhaseRetryResponse with status
@@ -533,6 +545,10 @@ async def retry_phase(
     Raises:
         HTTPException: 404 if job not found, 400 if invalid phase
     """
+    if body is None:
+        body = PhaseRetryRequest()
+    tier = body.tier
+    feedback = body.feedback
     # Map output key to phase name if needed
     if phase_name in OUTPUT_TO_PHASE:
         phase_name = OUTPUT_TO_PHASE[phase_name]

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -6,10 +6,11 @@ Provides endpoints for job detail retrieval, updates, and control operations.
 import logging
 import os
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
 
@@ -476,6 +477,155 @@ async def get_sst_metadata(job_id: int):
     except Exception as e:
         logger.error(f"Failed to fetch SST metadata: {e}")
         raise HTTPException(status_code=502, detail="Failed to fetch metadata from Airtable")
+
+
+class KeywordReportUploadResponse(BaseModel):
+    """Response for keyword report upload."""
+
+    filename: str
+    version: int
+    message: str
+
+
+class KeywordReportInfo(BaseModel):
+    """Info about a single keyword report file."""
+
+    filename: str
+    version: int
+    uploaded_at: Optional[str] = None
+
+
+class KeywordReportsListResponse(BaseModel):
+    """Response for listing keyword reports."""
+
+    reports: List[KeywordReportInfo]
+
+
+@router.post("/{job_id}/keyword-report", response_model=KeywordReportUploadResponse)
+async def upload_keyword_report(
+    job_id: int,
+    file: UploadFile = File(..., description="SEMRush keyword export CSV or text file"),
+):
+    """Upload a SEMRush keyword report CSV for a job.
+
+    Saves the file as keyword_report_v{N}.md in the job's project directory,
+    prepending a markdown header with upload timestamp and source filename.
+    The version number auto-increments from existing files.
+
+    Args:
+        job_id: Job ID to attach the report to
+        file: CSV or text file from SEMRush keyword export
+
+    Returns:
+        Filename and version number of the saved report
+
+    Raises:
+        HTTPException: 404 if job not found or no project path configured,
+                       400 if file type not allowed
+    """
+    job = await get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    if not job.project_path:
+        raise HTTPException(status_code=404, detail="Job has no output directory configured")
+
+    # Validate file type
+    allowed_content_types = {"text/csv", "text/plain", "application/csv", "application/octet-stream"}
+    original_filename = file.filename or "keyword_report.csv"
+    ext = Path(original_filename).suffix.lower()
+    if ext not in {".csv", ".txt", ".tsv"} and (file.content_type or "") not in allowed_content_types:
+        raise HTTPException(
+            status_code=400,
+            detail="Only CSV or text files are accepted for keyword reports.",
+        )
+
+    # Security: resolve project path within OUTPUT directory
+    output_dir = Path(os.getenv("OUTPUT_DIR", "OUTPUT")).resolve()
+    project_path = Path(job.project_path).resolve()
+    if not project_path.is_relative_to(output_dir):
+        raise HTTPException(status_code=400, detail="Invalid project path - outside output directory")
+
+    # Determine next version number
+    existing = sorted(project_path.glob("keyword_report_v*.md"))
+    next_version = len(existing) + 1
+
+    # Read uploaded content
+    content_bytes = await file.read()
+    csv_content = content_bytes.decode("utf-8", errors="replace")
+
+    # Build markdown document
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    md_content = f"""# SEMRush Keyword Report
+
+**Uploaded:** {timestamp}
+**Source file:** {original_filename}
+
+---
+
+{csv_content}
+"""
+
+    filename = f"keyword_report_v{next_version}.md"
+    file_path = project_path / filename
+    file_path.write_text(md_content, encoding="utf-8")
+
+    logger.info(
+        "Keyword report uploaded",
+        extra={"job_id": job_id, "filename": filename, "version": next_version},
+    )
+
+    return KeywordReportUploadResponse(
+        filename=filename,
+        version=next_version,
+        message=f"Keyword report uploaded as {filename}. It will be included in the next SEO phase run.",
+    )
+
+
+@router.get("/{job_id}/keyword-reports", response_model=KeywordReportsListResponse)
+async def list_keyword_reports(job_id: int):
+    """List all uploaded keyword reports for a job.
+
+    Returns version numbers and upload timestamps for each report file.
+
+    Args:
+        job_id: Job ID to list reports for
+
+    Returns:
+        List of keyword report metadata
+
+    Raises:
+        HTTPException: 404 if job not found
+    """
+    job = await get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    if not job.project_path:
+        return KeywordReportsListResponse(reports=[])
+
+    output_dir = Path(os.getenv("OUTPUT_DIR", "OUTPUT")).resolve()
+    project_path = Path(job.project_path).resolve()
+    if not project_path.is_relative_to(output_dir) or not project_path.exists():
+        return KeywordReportsListResponse(reports=[])
+
+    reports = []
+    for f in sorted(project_path.glob("keyword_report_v*.md")):
+        match = re.match(r"^keyword_report_v(\d+)\.md$", f.name)
+        version = int(match.group(1)) if match else 0
+        # Extract upload timestamp from file header if present
+        uploaded_at = None
+        try:
+            first_lines = f.read_text(encoding="utf-8").splitlines()
+            for line in first_lines[:6]:
+                if line.startswith("**Uploaded:**"):
+                    uploaded_at = line.replace("**Uploaded:**", "").strip()
+                    break
+        except Exception:
+            pass
+        reports.append(KeywordReportInfo(filename=f.name, version=version, uploaded_at=uploaded_at))
+
+    return KeywordReportsListResponse(reports=reports)
 
 
 class PhaseRetryRequest(BaseModel):

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -504,8 +504,7 @@ async def retry_phase(
     tier: Optional[int] = Query(
         default=None,
         ge=0,
-        le=2,
-        description="Force specific tier: 0=cheapskate, 1=default, 2=big-brain. "
+        description="Force specific tier index. "
         "If not specified, auto-escalates from the tier previously used.",
     ),
 ):
@@ -552,7 +551,7 @@ async def retry_phase(
             if phase.name == phase_name and phase.tier is not None:
                 previous_tier = phase.tier
                 break
-        effective_tier = min(previous_tier + 1, 2)
+        effective_tier = previous_tier + 1
         logger.info(
             "Auto-escalating phase retry",
             extra={

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -508,6 +508,11 @@ async def retry_phase(
         description="Force specific tier: 0=cheapskate, 1=default, 2=big-brain. "
         "If not specified, auto-escalates from the tier previously used.",
     ),
+    feedback: Optional[str] = Query(
+        default=None,
+        description="Editorial feedback to guide the retry (e.g., 'add a chapter for topic X', "
+        "'merge the first two chapters'). Injected into the agent prompt.",
+    ),
 ):
     """Retry a single phase for a job with automatic escalation.
 
@@ -583,6 +588,7 @@ async def retry_phase(
                     "tier": effective_tier,
                     "auto_escalated": tier is None,
                     "original_model": original_model,
+                    "has_feedback": feedback is not None,
                 },
             ),
         )
@@ -596,7 +602,7 @@ async def retry_phase(
         from api.services.worker import JobWorker
 
         worker = JobWorker()
-        result = await worker.retry_single_phase(job_id, phase_name, force_tier=effective_tier)
+        result = await worker.retry_single_phase(job_id, phase_name, force_tier=effective_tier, feedback=feedback)
         if not result.get("success"):
             logger.error(
                 "Phase retry failed",

--- a/api/services/airtable.py
+++ b/api/services/airtable.py
@@ -50,6 +50,7 @@ class AirtableClient:
     BASE_ID = "appZ2HGwhiifQToB6"
     TABLE_ID = "tblTKFOwTvK7xw1H5"
     TABLE_NAME = "✔️Single Source of Truth"
+    PROJECTS_TABLE_ID = "tblU9LfZeVNicdB5e"
     INTERFACE_PAGE_ID = "pagCh7J2dYzqPC3bH"  # SST interface view
     MEDIA_ID_FIELD = "Media ID"
     MEDIA_ID_FIELD_ID = "fld8k42kJeWMHA963"
@@ -190,6 +191,31 @@ class AirtableClient:
             httpx.HTTPError: On network or API errors (except 404)
         """
         url = f"{self.API_BASE_URL}/{self.BASE_ID}/{self.TABLE_ID}/{record_id}"
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.get(url, headers=self.headers)
+                response.raise_for_status()
+                return response.json()
+
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    return None
+                raise
+            except httpx.HTTPError:
+                raise
+
+    async def get_project_record(self, record_id: str) -> Optional[dict]:
+        """
+        Fetch a specific Project record by Airtable record ID.
+
+        Args:
+            record_id: Airtable record ID (e.g., "recXXXXXXXXXXXXXX")
+
+        Returns:
+            Record dict if found, None if not found.
+        """
+        url = f"{self.API_BASE_URL}/{self.BASE_ID}/{self.PROJECTS_TABLE_ID}/{record_id}"
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             try:

--- a/api/services/chunking.py
+++ b/api/services/chunking.py
@@ -309,6 +309,16 @@ def merge_formatter_chunks(chunks: List[str]) -> str:
         # Strip provenance HTML comment from top (<!-- model: ... -->)
         chunk = re.sub(r"^<!--\s*model:.*?-->\s*\n?", "", chunk.strip())
 
+        # Strip LLM-generated model/creator attribution lines (appear at end of chunk responses)
+        chunk = re.sub(
+            r"^\*\*(?:Model|Creator|Agent):\*\*.*\n?",
+            "",
+            chunk,
+            flags=re.MULTILINE,
+        )
+        # Clean up orphaned --- separators left after attribution removal
+        chunk = re.sub(r"\n---+\s*\n*$", "", chunk.strip())
+
         # Extract review notes from this chunk
         notes = review_pattern.findall(chunk)
         for note in notes:

--- a/api/services/database.py
+++ b/api/services/database.py
@@ -89,6 +89,7 @@ jobs_table = Table(
     Column("media_id", Text, nullable=True),
     Column("duration_minutes", Float, nullable=True),
     Column("word_count", Integer, nullable=True),
+    Column("content_type", Text, nullable=True),  # 'full', 'short', or 'clip'
 )
 
 # Define session_stats table
@@ -603,6 +604,9 @@ async def update_job(job_id: int, job_update: JobUpdate) -> Optional[Job]:
 
         if job_update.word_count is not None:
             update_values["word_count"] = job_update.word_count
+
+        if job_update.content_type is not None:
+            update_values["content_type"] = job_update.content_type
 
         # Handle phases update (replaces all phases)
         if job_update.phases is not None:
@@ -1276,6 +1280,7 @@ def _row_to_job(row) -> Job:
         media_id=getattr(row, "media_id", None),
         duration_minutes=getattr(row, "duration_minutes", None),
         word_count=getattr(row, "word_count", None),
+        content_type=getattr(row, "content_type", None),
         outputs=outputs,
     )
 

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -68,6 +68,10 @@ MODEL_PRICING: Dict[str, Dict[str, float]] = {
     "gpt-4o": {"input": 2.50, "output": 10.00},
     "gpt-4o-mini": {"input": 0.15, "output": 0.60},
     "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00},
+    # Claude via OpenRouter — tier 0/1/2 (pricing per 1M tokens)
+    "anthropic/claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
+    "anthropic/claude-sonnet-4-5-20250514": {"input": 3.00, "output": 15.00},
+    "anthropic/claude-opus-4-5-20250514": {"input": 15.00, "output": 75.00},
     "gemini-1.5-flash": {"input": 0.075, "output": 0.30},
     "gemini-1.5-flash-8b": {"input": 0.0375, "output": 0.15},
     "gemini-1.5-pro": {"input": 1.25, "output": 5.00},

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -6,6 +6,7 @@ Polls the queue for pending jobs and processes them through agent phases.
 import asyncio
 import json
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -38,6 +39,66 @@ OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", "OUTPUT"))
 TRANSCRIPTS_DIR = Path(os.getenv("TRANSCRIPTS_DIR", "transcripts"))
 TRANSCRIPTS_ARCHIVE_DIR = TRANSCRIPTS_DIR / "archive"
 AGENTS_DIR = Path(".claude/agents")
+KNOWLEDGE_DIR = Path("knowledge")
+
+
+def _extract_speakers_from_sst(sst_context: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract host and panelist names from SST text fields.
+
+    Parses Social Media Description and Project Notes to find speaker names
+    when the dedicated Host/Presenter fields aren't populated.
+
+    Returns dict with optional 'host' and 'panelists' keys.
+    """
+    result: Dict[str, Any] = {}
+
+    # Title/role words that precede names but aren't names themselves
+    _TITLE_PREFIX = r"(?:(?:Chief|Senior|Political|Reporter|Reporters|Bureau|Capitol|News|Wisconsin|PBS|WPR|County|District|Court|Assembly|State|Department|Justice|General)\s+)*"
+    # Proper name: First [van/de/von] Last — after stripping title prefixes
+    _NAME = rf"{_TITLE_PREFIX}([A-Z][a-z]+(?:\s+van)?\s+[A-Z][a-z]+)"
+
+    # Try Project Notes first (series-level, more structured)
+    project_notes = sst_context.get("project_notes", "")
+    if project_notes:
+        # Find host: "led by ... [Name]" up to "and include"
+        led_match = re.search(r"(?:led|hosted)\s+by\s+(.+?)(?:\s+and\s+include|\.\s|$)", project_notes)
+        if led_match:
+            names = re.findall(_NAME, led_match.group(1))
+            if names:
+                result["host"] = names[0]
+
+        # Find panelists: "include ... [names]"
+        include_match = re.search(r"include\s+(.+?)(?:\.\s|\.$|$)", project_notes)
+        if include_match:
+            panelists = re.findall(_NAME, include_match.group(1))
+            if panelists:
+                result["panelists"] = panelists
+
+    # Try Social Media Description (per-episode, names reporters)
+    social_desc = sst_context.get("social_media_description", "")
+    if social_desc:
+        reporters_match = re.search(
+            rf"reporters?\s+{_NAME}\s+and\s+{_NAME}",
+            social_desc,
+            re.IGNORECASE,
+        )
+        if reporters_match:
+            name1, name2 = reporters_match.group(1), reporters_match.group(2)
+            if result.get("host"):
+                # Add episode-specific names as panelists if not already listed
+                existing = result.get("panelists", [])
+                for name in [name1, name2]:
+                    if name != result["host"] and name not in existing:
+                        existing.append(name)
+                if existing:
+                    result["panelists"] = existing
+            else:
+                # First name is likely the host
+                result["host"] = name1
+                if name2 != name1:
+                    result["panelists"] = [name2]
+
+    return result
 
 
 class WorkerConfig:
@@ -77,7 +138,7 @@ class JobWorker:
     OPTIONAL_PHASES = ["timestamp"]
 
     # Duration threshold (in minutes) for auto-triggering timestamp phase
-    TIMESTAMP_AUTO_THRESHOLD_MINUTES = 30
+    TIMESTAMP_AUTO_THRESHOLD_MINUTES = 10
 
     # Phases that always run on big-brain tier (not configurable)
     # - manager: QA oversight requires strong reasoning
@@ -806,7 +867,28 @@ class JobWorker:
                 "presenter": fields.get("Presenter"),
                 "program": fields.get("Program"),
                 "media_id": fields.get("Media ID"),
+                "social_media_description": fields.get("Social Media Description"),
             }
+
+            # Follow Project linked record for series-level context
+            project_ids = fields.get("Project")
+            if project_ids and isinstance(project_ids, list):
+                try:
+                    project_record = await client.get_project_record(project_ids[0])
+                    if project_record:
+                        project_fields = project_record.get("fields", {})
+                        sst_context["project_notes"] = project_fields.get("Notes")
+                        sst_context["project_description"] = project_fields.get("Project Description")
+                except Exception as e:
+                    logger.debug("Failed to fetch linked Project (non-fatal)", extra={"error": str(e)})
+
+            # Auto-extract speaker names from SST text fields when Host/Presenter aren't set
+            if not sst_context.get("host"):
+                extracted = _extract_speakers_from_sst(sst_context)
+                if extracted.get("host"):
+                    sst_context["host"] = extracted["host"]
+                if extracted.get("panelists") and not sst_context.get("presenter"):
+                    sst_context["presenter"] = ", ".join(extracted["panelists"])
 
             # Remove None values
             sst_context = {k: v for k, v in sst_context.items() if v is not None}
@@ -1378,6 +1460,8 @@ class JobWorker:
                 "presenter",
                 "keywords",
                 "tags",
+                "social_media_description",
+                "project_notes",
             ]:
                 if sst_context.get(key):
                     sst_section += f"**{key.replace('_', ' ').title()}:** {sst_context[key]}\n"
@@ -1424,7 +1508,8 @@ class JobWorker:
                 # Verbatim preservation instruction (applies to all chunks)
                 verbatim_instruction = """CRITICAL: You MUST preserve ALL spoken dialogue. Do NOT summarize, condense, or paraphrase.
 Every sentence spoken in the transcript must appear in your output. You may remove filler words
-(um, uh) and fix grammar, but do NOT drop or merge sentences. Completeness is more important than brevity."""
+(um, uh) and fix grammar, but do NOT drop or merge sentences. Completeness is more important than brevity.
+If a caption is garbled or unclear, include your best reconstruction rather than dropping it. NEVER silently omit content."""
 
                 if chunk.index == 0:
                     # First chunk: normal formatter prompt
@@ -2131,14 +2216,27 @@ Output a QA report with:
                 sst_section += f"**Keywords:** {sst_context['keywords']}\n"
             if sst_context.get("tags"):
                 sst_section += f"**Tags:** {sst_context['tags']}\n"
+            if sst_context.get("social_media_description"):
+                sst_section += f"**Social Media Description:** {sst_context['social_media_description']}\n"
+            if sst_context.get("project_notes"):
+                sst_section += f"**Project Notes (Series Info):** {sst_context['project_notes']}\n"
 
-            sst_section += "\n*Use this context to align your analysis with existing metadata.*\n\n"
+            sst_section += "\n*Use this context to align your analysis with existing metadata. Speaker names from SST are authoritative.*\n\n"
+
+        # Load Wisconsin proper-noun reference for analyst and formatter phases
+        wi_reference = ""
+        if phase_name in ("analyst", "formatter"):
+            wi_ref_path = KNOWLEDGE_DIR / "wisconsin_reference.md"
+            if wi_ref_path.exists():
+                wi_reference = f"\n## Wisconsin Proper-Noun Reference\n\n{wi_ref_path.read_text()}\n\n"
 
         if phase_name == "analyst":
             prompt = """Please analyze the following transcript:
 """
             if sst_section:
                 prompt += sst_section
+            if wi_reference:
+                prompt += wi_reference
             prompt += f"""---
 {transcript}
 ---
@@ -2153,6 +2251,7 @@ Provide a detailed analysis document."""
             verbatim_instruction = """CRITICAL: You MUST preserve ALL spoken dialogue. Do NOT summarize, condense, or paraphrase.
 Every sentence spoken in the transcript must appear in your output. You may remove filler words
 (um, uh) and fix grammar, but do NOT drop or merge sentences. Completeness is more important than brevity.
+If a caption is garbled or unclear, include your best reconstruction rather than dropping it. NEVER silently omit content.
 
 """
 
@@ -2160,6 +2259,8 @@ Every sentence spoken in the transcript must appear in your output. You may remo
             prompt += "Using the following analysis as guidance:\n\n"
             if sst_section:
                 prompt += sst_section
+            if wi_reference:
+                prompt += wi_reference
             prompt += f"""---
 {analysis}
 ---

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -396,6 +396,8 @@ class JobWorker:
                             "tokens": p.get("tokens", 0),
                             "completed_at": p.get("completed_at"),
                         }
+                        if feedback:
+                            prev_run["feedback"] = feedback
                         previous_runs = p.get("previous_runs") or []
                         previous_runs.append(prev_run)
                         p["previous_runs"] = previous_runs
@@ -2275,6 +2277,15 @@ Output a QA report with:
 ---
 
 Provide a detailed analysis document."""
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the previous analysis and requests these changes:
+
+{editorial_feedback}"""
             return prompt
 
         elif phase_name == "formatter":
@@ -2303,6 +2314,15 @@ Please format this transcript:
 ---
 {transcript}
 ---"""
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the formatted transcript and requests these changes:
+
+{editorial_feedback}"""
             return prompt
 
         elif phase_name == "seo":
@@ -2322,17 +2342,36 @@ And this formatted transcript:
 ---
 
 Generate SEO metadata as a markdown report."""
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the SEO metadata and requests these changes:
+
+{editorial_feedback}"""
             return prompt
 
         elif phase_name == "copy_editor":
             formatted = context.get("formatter_output", "")
-            return f"""Please review and polish this formatted transcript:
+            prompt = f"""Please review and polish this formatted transcript:
 
 ---
 {formatted}
 ---
 
 Apply PBS style guidelines and improve readability while preserving speaker voice."""
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the copy-edited transcript and requests these changes:
+
+{editorial_feedback}"""
+            return prompt
 
         elif phase_name == "manager":
             analysis = context.get("analyst_output", "")
@@ -2391,6 +2430,15 @@ The system performed an automated word-count completeness check on the formatter
 ---
 
 Review all outputs against PBS Wisconsin quality standards and provide your QA report."""
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the QA report and requests these changes:
+
+{editorial_feedback}"""
             return prompt
 
         elif phase_name == "timestamp":

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -264,7 +264,7 @@ class JobWorker:
             self._heartbeat_task.cancel()
 
     async def retry_single_phase(
-        self, job_id: int, phase_name: str, force_tier: Optional[int] = None
+        self, job_id: int, phase_name: str, force_tier: Optional[int] = None, feedback: Optional[str] = None
     ) -> Dict[str, Any]:
         """Retry a single phase for a completed job.
 
@@ -275,6 +275,7 @@ class JobWorker:
             job_id: The job ID to retry a phase for
             phase_name: The phase to retry (e.g., 'timestamp', 'seo', 'analyst')
             force_tier: Optional tier override (0=cheapskate, 1=default, 2=big-brain)
+            feedback: Optional editorial feedback to guide the retry
 
         Returns:
             Dict with status, phase result, and any errors
@@ -348,6 +349,14 @@ class JobWorker:
                     "tier": force_tier,
                     "tier_label": tier_labels.get(force_tier, "unknown"),
                 },
+            )
+
+        # Inject editorial feedback if provided
+        if feedback:
+            context["_editorial_feedback"] = feedback
+            logger.info(
+                "Including editorial feedback in retry",
+                extra={"job_id": job_id, "phase": phase_name, "feedback_length": len(feedback)},
             )
 
         # Run the phase
@@ -2420,6 +2429,17 @@ Output a timestamp report with TWO sections:
 2. **YouTube Format** - Simple list like "0:00 Introduction" for video descriptions
 
 Follow the exact format specified in your system instructions."""
+
+            # Inject editorial feedback if present
+            editorial_feedback = context.get("_editorial_feedback")
+            if editorial_feedback:
+                prompt += f"""
+
+## Editorial Feedback
+
+The editor reviewed the previous timestamp output and provided the following feedback. Incorporate these changes:
+
+{editorial_feedback}"""
             return prompt
 
         return f"Process the following:\n\n{transcript}"

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -134,7 +134,7 @@ class JobWorker:
     PHASES = ["analyst", "formatter", "seo", "manager"]
 
     # Optional phases with trigger conditions
-    # timestamp: Runs automatically for 30+ minute content, or when requested
+    # timestamp: Runs automatically for 10+ minute content, or when requested
     OPTIONAL_PHASES = ["timestamp"]
 
     # Duration threshold (in minutes) for auto-triggering timestamp phase

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -1530,10 +1530,12 @@ class JobWorker:
             """Process a single chunk through the formatter LLM."""
             async with semaphore:
                 # Verbatim preservation instruction (applies to all chunks)
-                verbatim_instruction = """CRITICAL: You MUST preserve ALL spoken dialogue. Do NOT summarize, condense, or paraphrase.
-Every sentence spoken in the transcript must appear in your output. You may remove filler words
-(um, uh) and fix grammar, but do NOT drop or merge sentences. Completeness is more important than brevity.
-If a caption is garbled or unclear, include your best reconstruction rather than dropping it. NEVER silently omit content."""
+                verbatim_instruction = """CRITICAL: You MUST preserve ALL spoken dialogue VERBATIM. Do NOT summarize, condense, paraphrase, or reword.
+Every sentence spoken in the transcript must appear in your output using the speaker's actual words.
+You may remove filler words (um, uh) and fix grammar/punctuation, but do NOT rephrase, rewrite, or generate new copy.
+If the speaker said it, those exact words must appear in the output. Do NOT substitute your own phrasing.
+If a caption is garbled or unclear, include your best reconstruction rather than dropping it. NEVER silently omit content.
+SPELLING: Always use "partisan" (not "partizan"), "bipartisan" (not "bipartisan"). Program names like "Inside Wisconsin Politics" are NOT italicized."""
 
                 if chunk.index == 0:
                     # First chunk: normal formatter prompt
@@ -1556,6 +1558,7 @@ The previous section ended with:
 {chunk.overlap_prefix}
 ---
 Continue formatting from where the previous section left off. Do NOT repeat content from the overlap above.
+CRITICAL: Pay careful attention to which speaker is talking. Use the overlap above to identify who was speaking last and maintain correct attribution. Getting the wrong name on a statement is worse than using a generic label.
 
 Using the following analysis as guidance:
 ---

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -304,6 +304,7 @@ class JobWorker:
         context = {
             "project_name": job_dict.get("project_name") or "Unknown",
             "transcript_file": job_dict.get("transcript_file", ""),
+            "project_path": project_path,
             "transcript_metrics": {
                 "word_count": job_dict.get("word_count") or 0,
                 "estimated_duration_minutes": job_dict.get("duration_minutes") or 0,
@@ -538,6 +539,30 @@ class JobWorker:
                     "SST context loaded", extra={"job_id": job_id, "sst_title": sst_context.get("title", "Unknown")}
                 )
 
+            # Detect content type (short/clip/full) for routing decisions
+            srt_path_for_detection = self._find_srt_file(job)
+            content_type = self._detect_content_type(
+                transcript_metrics, srt_path_for_detection, sst_context
+            )
+            logger.info(
+                "Content type detected",
+                extra={"job_id": job_id, "content_type": content_type},
+            )
+
+            # Persist content_type to the database
+            try:
+                from api.models.job import JobUpdate
+                from api.services.database import update_job
+
+                await update_job(job_id, JobUpdate(content_type=content_type))
+                # Also propagate into job dict so _should_run_timestamp_phase can read it
+                job["content_type"] = content_type
+            except Exception as e:
+                logger.warning(
+                    "Failed to persist content_type (non-fatal)",
+                    extra={"job_id": job_id, "error": str(e)},
+                )
+
             # Get existing phases or initialize
             phases = job.get("phases") or []
             if isinstance(phases, str):
@@ -550,7 +575,16 @@ class JobWorker:
                 "project_path": project_path,
                 "transcript_metrics": transcript_metrics,
                 "sst_context": sst_context,  # Add SST context to processing context
+                "content_type": content_type,  # Expose content_type for prompt building
             }
+
+            # For Shorts, force all phases to cheapskate tier (tier 0)
+            if content_type == "short":
+                context["_force_tier"] = 0
+                logger.info(
+                    "Shorts content: forcing cheapskate tier for all phases",
+                    extra={"job_id": job_id},
+                )
 
             truncation_paused = False
 
@@ -579,7 +613,9 @@ class JobWorker:
                             "forced_tier": existing_phase["metadata"]["forced_tier"],
                         },
                     )
-                else:
+                elif context.get("content_type") != "short":
+                    # Only clear _force_tier if this isn't Shorts content.
+                    # Shorts keep the cheapskate tier override set above.
                     context.pop("_force_tier", None)
 
                 # Process phase
@@ -1133,6 +1169,42 @@ class JobWorker:
         # Fall back to transcript metrics (estimated from word count)
         return transcript_metrics.get("estimated_duration_minutes", 0)
 
+    def _detect_content_type(
+        self,
+        transcript_metrics: Dict[str, Any],
+        srt_path: Optional[Path],
+        sst_context: Optional[Dict[str, Any]],
+    ) -> str:
+        """Detect the content type based on duration and SST metadata.
+
+        Returns one of: 'full', 'short', 'clip'.
+
+        Detection logic:
+        - If duration < 90 seconds (1.5 minutes) -> 'short'
+        - If SST context indicates Clip content type -> 'clip'
+        - Otherwise -> 'full'
+        """
+        # Check SST context for explicit clip classification first.
+        # Looks for Airtable picker-style fields like "Full-Length, Clip, Livestream"
+        # that contain "Clip" as a selected value.
+        if sst_context:
+            for field_value in sst_context.values():
+                if isinstance(field_value, str) and "Clip" in field_value:
+                    if any(
+                        marker in field_value
+                        for marker in ("Full-Length", "Livestream")
+                    ):
+                        return "clip"
+
+        # Check duration threshold for Shorts.
+        # 90-second threshold is intentionally higher than YouTube's 60s limit
+        # to catch near-Shorts content.
+        duration_minutes = self._get_content_duration_minutes(transcript_metrics, srt_path)
+        if 0 < duration_minutes < 1.5:
+            return "short"
+
+        return "full"
+
     def _should_run_timestamp_phase(
         self, job: Dict[str, Any], transcript_metrics: Dict[str, Any], srt_path: Optional[Path]
     ) -> bool:
@@ -1140,7 +1212,8 @@ class JobWorker:
 
         Timestamp phase runs when:
         1. An SRT file exists AND
-        2. Content is 30+ minutes OR job explicitly requests it
+        2. Content is not a Short (content_type != 'short') AND
+        3. Content is 10+ minutes OR job explicitly requests it
 
         Returns:
             True if timestamp phase should run, False otherwise.
@@ -1148,6 +1221,15 @@ class JobWorker:
         # No SRT file = no timestamp phase
         if not srt_path or not srt_path.exists():
             logger.debug("Skipping timestamp phase: no SRT file", extra={"job_id": job.get("id")})
+            return False
+
+        # Shorts never get timestamp phase — too short to need chapter markers
+        content_type = job.get("content_type")
+        if content_type == "short":
+            logger.info(
+                "Skipping timestamp phase: Short content does not need chapter markers",
+                extra={"job_id": job.get("id")},
+            )
             return False
 
         # Check for explicit request in job
@@ -2258,6 +2340,9 @@ Output a QA report with:
 
             sst_section += "\n*Use this context to align your analysis with existing metadata. Speaker names from SST are authoritative.*\n\n"
 
+        # Detect content type for Shorts-specific prompt adjustments
+        content_type = context.get("content_type", "full")
+
         # Load Wisconsin proper-noun reference for analyst and formatter phases
         wi_reference = ""
         if phase_name in ("analyst", "formatter"):
@@ -2266,7 +2351,14 @@ Output a QA report with:
                 wi_reference = f"\n## Wisconsin Proper-Noun Reference\n\n{wi_ref_path.read_text()}\n\n"
 
         if phase_name == "analyst":
-            prompt = """Please analyze the following transcript:
+            if content_type == "short":
+                prompt = (
+                    "This is a YouTube Short (under 90 seconds). Provide a brief analysis focused on the "
+                    "single topic. Do not create a structural breakdown — focus on identifying the core "
+                    "message, target audience, and 3-5 keywords.\n\n"
+                )
+            else:
+                prompt = """Please analyze the following transcript:
 """
             if sst_section:
                 prompt += sst_section
@@ -2328,7 +2420,14 @@ The editor reviewed the formatted transcript and requests these changes:
         elif phase_name == "seo":
             analysis = context.get("analyst_output", "")
             formatted = context.get("formatter_output", "")
-            prompt = "Based on this analysis:\n\n"
+            if content_type == "short":
+                prompt = (
+                    "This is a YouTube Short. Optimize metadata for YouTube Shorts discovery: "
+                    "title under 40 characters, include #Shorts hashtag, focus on vertical video tags, "
+                    "and write a description under 200 characters.\n\n"
+                )
+            else:
+                prompt = "Based on this analysis:\n\n"
             if sst_section:
                 prompt += sst_section
             prompt += f"""---
@@ -2351,6 +2450,23 @@ Generate SEO metadata as a markdown report."""
 The editor reviewed the SEO metadata and requests these changes:
 
 {editorial_feedback}"""
+
+            # Inject keyword report if one exists in the project directory
+            project_path = context.get("project_path")
+            if project_path:
+                keyword_reports = sorted(Path(project_path).glob("keyword_report_v*.md"))
+                if keyword_reports:
+                    latest_report = keyword_reports[-1].read_text(encoding="utf-8")
+                    prompt += f"""
+
+## SEMRush Keyword Data
+
+The following keyword report was uploaded for this project. Use this data to inform your SEO recommendations — prioritize keywords with high search volume and low competition.
+
+---
+{latest_report}
+---"""
+
             return prompt
 
         elif phase_name == "copy_editor":
@@ -2378,6 +2494,11 @@ The editor reviewed the copy-edited transcript and requests these changes:
             formatted = context.get("formatter_output", "")
             seo = context.get("seo_output", "")
             prompt = "Please perform a QA review of the following pipeline outputs.\n\n"
+            if content_type == "short":
+                prompt += (
+                    "NOTE: This is a YouTube Short. QA standards are relaxed — "
+                    "shorter analysis and simplified SEO are expected.\n\n"
+                )
 
             # Add completeness check results if available
             completeness = context.get("completeness_check")

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -541,9 +541,7 @@ class JobWorker:
 
             # Detect content type (short/clip/full) for routing decisions
             srt_path_for_detection = self._find_srt_file(job)
-            content_type = self._detect_content_type(
-                transcript_metrics, srt_path_for_detection, sst_context
-            )
+            content_type = self._detect_content_type(transcript_metrics, srt_path_for_detection, sst_context)
             logger.info(
                 "Content type detected",
                 extra={"job_id": job_id, "content_type": content_type},
@@ -1190,10 +1188,7 @@ class JobWorker:
         if sst_context:
             for field_value in sst_context.values():
                 if isinstance(field_value, str) and "Clip" in field_value:
-                    if any(
-                        marker in field_value
-                        for marker in ("Full-Length", "Livestream")
-                    ):
+                    if any(marker in field_value for marker in ("Full-Length", "Livestream")):
                         return "clip"
 
         # Check duration threshold for Shorts.

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -2341,7 +2341,6 @@ Output a QA report with:
         # Detect content type for Shorts-specific prompt adjustments
         content_type = context.get("content_type", "full")
 
-
         # Load Wisconsin proper-noun reference for analyst and formatter phases
         wi_reference = ""
         if phase_name in ("analyst", "formatter"):

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -41,14 +41,13 @@
       "cost_per_project": 0.2,
       "enabled": false
     },
-    "claude": {
-      "type": "anthropic",
-      "endpoint": "https://api.anthropic.com/v1/messages",
-      "model": "claude-3-5-sonnet-latest",
-      "api_key_env": "ANTHROPIC_API_KEY",
-      "timeout": 180,
-      "cost_per_project": 0.25,
-      "enabled": false
+    "openrouter-claude": {
+      "type": "openrouter",
+      "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+      "model": "anthropic/claude-sonnet-4.5",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "timeout": 240,
+      "cost_per_project": 0.25
     },
     "gemini-flash": {
       "type": "gemini",
@@ -122,7 +121,7 @@
   },
   "phase_backends": {
     "analyst": "openrouter",
-    "formatter": "openrouter-cheapskate",
+    "formatter": "openrouter-claude",
     "seo": "openrouter-cheapskate",
     "manager": "openrouter-big-brain",
     "copy_editor": "openrouter",
@@ -132,12 +131,14 @@
     "tiers": [
       "openrouter-cheapskate",
       "openrouter",
-      "openrouter-big-brain"
+      "openrouter-big-brain",
+      "openrouter-claude"
     ],
     "tier_labels": [
       "cheapskate",
       "default",
-      "big-brain"
+      "big-brain",
+      "claude-via-openrouter"
     ],
     "duration_thresholds": [
       {
@@ -155,7 +156,7 @@
     ],
     "phase_base_tiers": {
       "analyst": 0,
-      "formatter": 0,
+      "formatter": 3,
       "seo": 0,
       "manager": 2,
       "copy_editor": 2,

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -78,7 +78,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant",
-      "fallback_model": "google/gemini-2.5-flash",
+      "fallback_model": "anthropic/claude-sonnet-4-5-20250514",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 180,
       "cost_per_project": 0.02
@@ -87,7 +87,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant-big-brain",
-      "fallback_model": "google/gemini-2.5-flash",
+      "fallback_model": "anthropic/claude-opus-4-5-20250514",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 300,
       "cost_per_project": 0.1
@@ -96,7 +96,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant-cheapskate",
-      "fallback_model": "google/gemini-2.5-flash",
+      "fallback_model": "anthropic/claude-haiku-4-5-20251001",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 300,
       "cost_per_project": 0.0,
@@ -135,9 +135,9 @@
       "openrouter-big-brain"
     ],
     "tier_labels": [
-      "cheapskate",
-      "default",
-      "big-brain"
+      "Claude Haiku",
+      "Claude Sonnet",
+      "Claude Opus"
     ],
     "duration_thresholds": [
       {
@@ -185,31 +185,31 @@
   },
   "openrouter_presets": {
     "ai-editorial-assistant": {
-      "description": "General use - balanced cost/quality",
+      "description": "Default tier — Claude Sonnet via OpenRouter",
       "models": [
+        "anthropic/claude-sonnet-4-5-20250514",
         "google/gemini-3-flash-preview",
-        "anthropic/claude-sonnet-4.5",
         "openai/gpt-5.1-codex-mini"
       ],
-      "models_verified": "2026-01-29"
+      "models_verified": "2026-04-02"
     },
     "ai-editorial-assistant-big-brain": {
-      "description": "Complex reasoning - higher quality models",
+      "description": "Big Brain tier — Claude Opus via OpenRouter",
       "models": [
+        "anthropic/claude-opus-4-5-20250514",
         "google/gemini-3-pro-preview",
-        "openai/gpt-5.1-codex",
-        "anthropic/claude-opus-4.5"
+        "openai/gpt-5.1-codex"
       ],
-      "models_verified": "2026-01-29"
+      "models_verified": "2026-04-02"
     },
     "ai-editorial-assistant-cheapskate": {
-      "description": "Free tier models for simple formatting tasks",
+      "description": "Cheapskate tier — Claude Haiku via OpenRouter",
       "models": [
+        "anthropic/claude-haiku-4-5-20251001",
         "openai/gpt-oss-120b",
-        "moonshotai/kimi-k2-0711",
-        "nvidia/nemotron-nano-12b-v2-vl"
+        "moonshotai/kimi-k2-0711"
       ],
-      "models_verified": "2026-01-29"
+      "models_verified": "2026-04-02"
     }
   },
   "safety": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output
-      - CORS_ORIGINS=http://localhost:3000
+      - CORS_ORIGINS=http://localhost:3001
       - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
       - TRANSCRIPTS_DIR=/data/transcripts
     volumes:
@@ -49,7 +49,7 @@ services:
       context: .
       dockerfile: Dockerfile.web
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
     depends_on:

--- a/knowledge/wisconsin_reference.md
+++ b/knowledge/wisconsin_reference.md
@@ -1,0 +1,80 @@
+# Wisconsin Proper-Noun Reference
+
+Quick-reference for commonly misspelled Wisconsin names in transcripts. Use this to verify caption accuracy.
+
+## Place Names
+
+| Correct | Common Misspellings |
+|---------|-------------------|
+| Manitowoc | Manitowac, Mannitowoc |
+| Waukesha | Wakesha, Walkeesha |
+| Sheboygan | Sheyboygan, Sheboygen |
+| Oconomowoc | Oconowomoc, Oconomowac |
+| Fond du Lac | Fond de Lac, Fondalac |
+| Wauwatosa | Wawatosa, Wauwautosa |
+| Menominee | Menomonie, Menomonee |
+| Ashwaubenon | Ashwaubanon |
+| Wausau | Wasau |
+| Eau Claire | Eau Clair |
+| La Crosse | Lacrosse, La Cross |
+| Kenosha | Kanosha |
+| Oshkosh | Oshcosh |
+| Appleton | (rarely misspelled) |
+| Green Bay | (rarely misspelled) |
+
+## Political Figures (Current/Recent)
+
+| Correct | Role | Common Misspellings |
+|---------|------|-------------------|
+| Janet Protasiewicz | Supreme Court Justice | Protasewicz, Protasavich |
+| Brian Hagedorn | Former Supreme Court Justice | Hagadorn, Hagedoorn |
+| Michael Gableman | Former Supreme Court Justice | Gabbleman, Gabellman |
+| Jim Troupis | Attorney | Troupes, Troopis |
+| Brad Schimel | Former Atty. Gen. | Schimmel, Shimel |
+| Jill Karofsky | Supreme Court Justice | Karovsky, Karofski |
+| Rebecca Dallet | Supreme Court Justice | Dallett, Dalet |
+| David Prosser | Former Supreme Court Justice | Prossar |
+| Tony Evers | Governor | (rarely misspelled) |
+| Robin Vos | Assembly Speaker | (rarely misspelled) |
+| Josh Kaul | Attorney General | Kohl, Call |
+| Dan Kelly | Former Supreme Court Justice | (rarely misspelled) |
+| Eric Toney | Politician | Tony, Toni |
+
+## Legal Cases
+
+| Correct | Common Misspellings |
+|---------|-------------------|
+| Kaul v. Urmanski | Kohl v. Urmanski, Call vs Urmanski |
+| Clarke v. WEC | Clark v. WEC |
+| Trump v. Biden (WI) | (rarely misspelled) |
+
+## Institutions
+
+| Correct | Abbreviation | Notes |
+|---------|-------------|-------|
+| Wisconsin Public Radio | WPR | |
+| PBS Wisconsin | | Formerly WPT/Wisconsin Public Television |
+| UW-Madison | | Not "University of Wisconsin Madison" in running text |
+| Marquette Law School | | Often "Marquette poll" |
+| Wisconsin Elections Commission | WEC | |
+| Department of Justice | DOJ | Wisconsin state DOJ, not federal |
+
+## PBS Wisconsin Programs & Hosts
+
+| Program | Host/Anchor | Regular Panelists |
+|---------|------------|-------------------|
+| Inside Wisconsin Politics | Shawn Johnson | Zac Schultz, Rich Kremer, Anya van Wagtendonk |
+| Here & Now | Frederica Freyberg | |
+| Wisconsin Life | | (various segment producers) |
+| University Place | | (various lecturers) |
+
+## Wisconsin-Specific Terms
+
+| Term | Notes |
+|------|-------|
+| Capitol | The building/district in Madison (not "capital" unless referring to money) |
+| Act 10 | 2011 law restricting public employee unions |
+| Tavern League | Tavern League of Wisconsin (lobbying group) |
+| Dells | Wisconsin Dells (tourism area) |
+| Up North | Colloquial for northern Wisconsin |
+| FIBs | Colloquial for Illinois visitors (use cautiously) |

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,8 +46,11 @@ http {
         }
 
         # MCP SSE endpoint (optional — for Claude Desktop via Docker)
+        # Uses variable + resolver so nginx starts even when mcp service is not running
         location /mcp/ {
-            proxy_pass http://mcp:8080/;
+            resolver 127.0.0.11 valid=30s;
+            set $mcp_upstream http://mcp:8080;
+            proxy_pass $mcp_upstream$request_uri;
             proxy_buffering off;
             proxy_cache off;
             proxy_set_header Connection '';

--- a/standalone-agents/transcript-formatter/format-transcript.py
+++ b/standalone-agents/transcript-formatter/format-transcript.py
@@ -26,10 +26,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-
 # ---------------------------------------------------------------------------
 # SRT parsing (self-contained — no Cardigan imports needed)
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class SRTCaption:
@@ -158,11 +158,13 @@ def split_srt_into_chunks(captions: list[SRTCaption]) -> list[Chunk]:
                 if ov_caps:
                     overlap = generate_srt(ov_caps)
 
-            chunks.append(Chunk(
-                index=len(chunks),
-                content=generate_srt(chunk_captions),
-                overlap_prefix=overlap,
-            ))
+            chunks.append(
+                Chunk(
+                    index=len(chunks),
+                    content=generate_srt(chunk_captions),
+                    overlap_prefix=overlap,
+                )
+            )
 
             chunk_start = break_idx + 1
             accumulated = 0
@@ -179,11 +181,13 @@ def split_srt_into_chunks(captions: list[SRTCaption]) -> list[Chunk]:
             ov_caps = captions[ov_start:chunk_start]
             if ov_caps:
                 overlap = generate_srt(ov_caps)
-        chunks.append(Chunk(
-            index=len(chunks),
-            content=generate_srt(remaining),
-            overlap_prefix=overlap,
-        ))
+        chunks.append(
+            Chunk(
+                index=len(chunks),
+                content=generate_srt(remaining),
+                overlap_prefix=overlap,
+            )
+        )
 
     return chunks
 
@@ -191,6 +195,7 @@ def split_srt_into_chunks(captions: list[SRTCaption]) -> list[Chunk]:
 # ---------------------------------------------------------------------------
 # Merging
 # ---------------------------------------------------------------------------
+
 
 def merge_chunks(formatted_chunks: list[str]) -> str:
     """Merge formatted outputs into a single document."""
@@ -229,7 +234,9 @@ def merge_chunks(formatted_chunks: list[str]) -> str:
             body = re.sub(r"^#\s+Formatted Transcript\s*\n?", "", body, flags=re.MULTILINE)
             body = re.sub(
                 r"^\*\*(?:Project|Program|Duration|Date|Air Date|Media ID):\*\*.*\n?",
-                "", body, flags=re.MULTILINE,
+                "",
+                body,
+                flags=re.MULTILINE,
             )
             body = re.sub(r"^---+\s*\n?", "", body.strip(), flags=re.MULTILINE)
             body = body.strip()
@@ -425,6 +432,7 @@ async def run(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Format an SRT transcript using Gemini API with PBS Wisconsin editorial standards.",
@@ -442,14 +450,16 @@ def main():
         print(f"Error: File not found: {args.srt_file}", file=sys.stderr)
         sys.exit(1)
 
-    asyncio.run(run(
-        srt_path=args.srt_file,
-        speakers=args.speakers,
-        program=args.program,
-        output_path=args.output,
-        model=args.model,
-        max_parallel=args.parallel,
-    ))
+    asyncio.run(
+        run(
+            srt_path=args.srt_file,
+            speakers=args.speakers,
+            program=args.program,
+            output_path=args.output,
+            model=args.model,
+            max_parallel=args.parallel,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tests/api/test_jobs_router.py
+++ b/tests/api/test_jobs_router.py
@@ -429,3 +429,190 @@ class TestJobOutputs:
             response = client.get(f"/api/jobs/{job_id}/outputs/{filename}")
             # Will get 404 because files don't exist, but not 400 (invalid filename)
             assert response.status_code in [200, 404]
+
+
+class TestRetryPhaseEndpoint:
+    """Tests for POST /api/jobs/{id}/phases/{phase_name}/retry endpoint.
+
+    Verifies JSON body acceptance, backward compatibility (no body), feedback
+    and tier fields, validation, and phase name aliasing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_no_body_accepted(self, sample_job):
+        """Test that phase retry works with no request body (backward compat)."""
+        job_id = sample_job["id"]
+
+        response = client.post(f"/api/jobs/{job_id}/phases/timestamp/retry")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["phase"] == "timestamp"
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_with_empty_body(self, sample_job):
+        """Test that phase retry works with empty JSON body."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/analyst/retry",
+            json={},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["phase"] == "analyst"
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_with_tier_in_body(self, sample_job):
+        """Test that phase retry accepts tier as a JSON body field."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/seo/retry",
+            json={"tier": 1},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        # Message should reflect the explicit tier
+        assert "tier 1" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_with_feedback_in_body(self, sample_job):
+        """Test that phase retry accepts feedback as a JSON body field."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/timestamp/retry",
+            json={"feedback": "Please add a chapter for the Q&A section."},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_with_tier_and_feedback(self, sample_job):
+        """Test that phase retry accepts both tier and feedback together."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/manager/retry",
+            json={"tier": 2, "feedback": "Focus more on SEO consistency issues."},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["phase"] == "manager"
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_invalid_tier_rejected(self, sample_job):
+        """Test that out-of-range tier values are rejected with 422."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/seo/retry",
+            json={"tier": 5},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_negative_tier_rejected(self, sample_job):
+        """Test that negative tier values are rejected with 422."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/seo/retry",
+            json={"tier": -1},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_invalid_phase_name(self, sample_job):
+        """Test that invalid phase names return 400."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/nonexistent_phase/retry",
+            json={},
+        )
+
+        assert response.status_code == 400
+        assert "invalid phase" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_output_key_alias(self, sample_job):
+        """Test that output key aliases (e.g. 'timestamp_report') map to phases."""
+        job_id = sample_job["id"]
+
+        response = client.post(
+            f"/api/jobs/{job_id}/phases/timestamp_report/retry",
+            json={},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Output key should be resolved to 'timestamp' phase name
+        assert data["phase"] == "timestamp"
+
+    @pytest.mark.asyncio
+    async def test_retry_phase_job_not_found(self):
+        """Test 404 when retrying a phase for a non-existent job."""
+        response = client.post(
+            "/api/jobs/99999/phases/timestamp/retry",
+            json={},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_download_header_absent_by_default(self, sample_job):
+        """Test that Content-Disposition header is NOT set when download param is omitted."""
+        job_id = sample_job["id"]
+
+        response = client.get(f"/api/jobs/{job_id}/outputs/analyst_output.md")
+
+        # 404 because file doesn't exist, but header check happens at request level
+        # We verify by hitting an invalid filename path that returns 400 without reaching header logic
+        # For a valid filename that 404s, the header is never set - confirmed by checking non-404 path
+        assert "content-disposition" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_download_header_absent_when_false(self, sample_job):
+        """Test that Content-Disposition header is NOT set when download=false."""
+        job_id = sample_job["id"]
+
+        response = client.get(f"/api/jobs/{job_id}/outputs/analyst_output.md?download=false")
+
+        assert "content-disposition" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_download_param_accepted(self, sample_job):
+        """Test that download=true query param is accepted without error.
+
+        The endpoint returns 404 (file not found) rather than 400 (bad param),
+        confirming the download parameter is valid. Header verification requires
+        a real output file on disk, which is covered by integration tests.
+        """
+        job_id = sample_job["id"]
+
+        response = client.get(f"/api/jobs/{job_id}/outputs/analyst_output.md?download=true")
+
+        # Should not be 400 (invalid param) -- 404 is expected since no file exists
+        assert response.status_code in (200, 404)
+
+    @pytest.mark.asyncio
+    async def test_download_false_accepted(self, sample_job):
+        """Test that download=false query param is accepted without error."""
+        job_id = sample_job["id"]
+
+        response = client.get(f"/api/jobs/{job_id}/outputs/analyst_output.md?download=false")
+
+        assert response.status_code in (200, 404)

--- a/web/src/components/ScreengrabsBox.tsx
+++ b/web/src/components/ScreengrabsBox.tsx
@@ -36,7 +36,17 @@ interface ScreengrabsBoxProps {
 
 // Airtable URL constants
 const AIRTABLE_BASE_ID = 'appZ2HGwhiifQToB6'
-const AIRTABLE_SST_TABLE_ID = 'tblTKFOwTvK7xw1H5'
+const AIRTABLE_SST_PAGE_ID = 'pagmlseGxLHMXLLBX'
+
+function buildAirtableSstUrl(recordId: string): string {
+  const detail = btoa(JSON.stringify({
+    pageId: AIRTABLE_SST_PAGE_ID,
+    rowId: recordId,
+    showComments: false,
+    queryOriginHint: null,
+  }))
+  return `https://airtable.com/${AIRTABLE_BASE_ID}/pagCh7J2dYzqPC3bH?detail=${detail}`
+}
 
 export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
   const [screengrabs, setScreengrabs] = useState<ScreengrabFile[]>([])
@@ -138,7 +148,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
         </div>
         {sstRecordId && (
           <a
-            href={`https://airtable.com/${AIRTABLE_BASE_ID}/${AIRTABLE_SST_TABLE_ID}/${sstRecordId}`}
+            href={buildAirtableSstUrl(sstRecordId)}
             target="_blank"
             rel="noopener noreferrer"
             className="text-gray-400 hover:text-gray-300 text-xs flex items-center space-x-1"
@@ -183,15 +193,31 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
               >
                 {/* Thumbnail */}
                 <div className="aspect-video bg-gray-950 relative">
-                  <img
-                    src={screengrab.remote_url}
-                    alt={screengrab.filename}
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).src = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🖼</text></svg>'
-                    }}
-                  />
+                  <a
+                    href={screengrab.remote_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block w-full h-full cursor-pointer"
+                    aria-label={`View full size: ${screengrab.filename}`}
+                  >
+                    <img
+                      src={screengrab.remote_url}
+                      alt={screengrab.filename}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      crossOrigin="anonymous"
+                      onError={(e) => {
+                        const img = e.target as HTMLImageElement
+                        // Retry without crossOrigin if CORS fails
+                        if (img.crossOrigin) {
+                          img.crossOrigin = ''
+                          img.src = screengrab.remote_url
+                        } else {
+                          img.src = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">%F0%9F%96%BC</text></svg>'
+                        }
+                      }}
+                    />
+                  </a>
                 </div>
 
                 {/* Info & Actions */}

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -18,6 +18,7 @@ interface PreviousRun {
   cost?: number
   tokens?: number
   completed_at?: string
+  feedback?: string
 }
 
 interface JobPhase {
@@ -104,6 +105,9 @@ export default function JobDetail() {
   const [sstMetadata, setSstMetadata] = useState<SSTMetadata | null>(null)
   const [sstLoading, setSstLoading] = useState(false)
   const [retryingPhase, setRetryingPhase] = useState<string | null>(null)
+  const [retryModal, setRetryModal] = useState<{ outputKey: string; label: string } | null>(null)
+  const [retryFeedback, setRetryFeedback] = useState('')
+  const [retryTier, setRetryTier] = useState<string>('')
   const [showChat, setShowChat] = useState(false)
   const [showScreengrabs, setShowScreengrabs] = useState(false)
   const [hasScreengrabs, setHasScreengrabs] = useState(false)
@@ -235,11 +239,20 @@ export default function JobDetail() {
     }
   }
 
-  const handleRetryPhase = async (outputKey: string) => {
+  const handleRetryPhase = async (outputKey: string, tier?: number, feedback?: string) => {
     setRetryingPhase(outputKey)
+    setRetryModal(null)
+    setRetryFeedback('')
+    setRetryTier('')
     try {
+      const body: { tier?: number; feedback?: string } = {}
+      if (tier !== undefined) body.tier = tier
+      if (feedback && feedback.trim()) body.feedback = feedback.trim()
+
       const response = await fetch(`/api/jobs/${id}/phases/${outputKey}/retry`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       })
       if (response.ok) {
         toast('Phase retry started. Refresh in a moment to see results.', 'success')
@@ -260,6 +273,18 @@ export default function JobDetail() {
     } finally {
       setRetryingPhase(null)
     }
+  }
+
+  const openRetryModal = (outputKey: string, label: string) => {
+    setRetryModal({ outputKey, label })
+    setRetryFeedback('')
+    setRetryTier('')
+  }
+
+  const submitRetryModal = () => {
+    if (!retryModal) return
+    const tier = retryTier !== '' ? parseInt(retryTier, 10) : undefined
+    handleRetryPhase(retryModal.outputKey, tier, retryFeedback)
   }
 
   const closeModal = () => {
@@ -696,12 +721,23 @@ export default function JobDetail() {
                     <span className="mr-2">&#128196;</span>
                     {label}
                   </button>
+                  <a
+                    href={`/api/jobs/${id}/outputs/${actualFilename}?download=true`}
+                    download={actualFilename}
+                    className="px-2 py-2 bg-gray-600 hover:bg-blue-600 text-gray-300 hover:text-white transition-colors"
+                    aria-label={`Download ${label}`}
+                    title={`Download ${label}`}
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                  </a>
                   <button
-                    onClick={() => handleRetryPhase(key)}
+                    onClick={() => openRetryModal(key, label)}
                     disabled={isRetrying || retryingPhase !== null}
                     className="px-2 py-2 bg-gray-600 hover:bg-orange-600 rounded-r-md text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50"
                     aria-label={`Retry ${label}`}
-                    title={`Regenerate ${label} (escalates to next tier)`}
+                    title={`Regenerate ${label}`}
                   >
                     {isRetrying ? (
                       <span className="animate-spin">&#8635;</span>
@@ -820,6 +856,80 @@ export default function JobDetail() {
           })()}
         </div>
       </div>
+
+      {/* Phase Retry Modal */}
+      {retryModal && (
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+          onClick={() => setRetryModal(null)}
+        >
+          <div
+            className="bg-gray-900 rounded-lg border border-gray-700 w-full max-w-md"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="retry-modal-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+              <h3 id="retry-modal-title" className="text-base font-medium text-white">
+                Retry: {retryModal.label}
+              </h3>
+              <button
+                onClick={() => setRetryModal(null)}
+                className="text-gray-400 hover:text-white text-2xl leading-none"
+                aria-label="Close retry dialog"
+              >
+                &times;
+              </button>
+            </div>
+            <div className="p-4 space-y-4">
+              <div>
+                <label htmlFor="retry-tier" className="block text-sm text-gray-300 mb-1">
+                  Model tier
+                </label>
+                <select
+                  id="retry-tier"
+                  value={retryTier}
+                  onChange={(e) => setRetryTier(e.target.value)}
+                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                >
+                  <option value="">Auto-escalate (recommended)</option>
+                  <option value="0">Cheapskate (tier 0)</option>
+                  <option value="1">Default (tier 1)</option>
+                  <option value="2">Big Brain (tier 2)</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="retry-feedback" className="block text-sm text-gray-300 mb-1">
+                  Editorial feedback <span className="text-gray-500">(optional)</span>
+                </label>
+                <textarea
+                  id="retry-feedback"
+                  value={retryFeedback}
+                  onChange={(e) => setRetryFeedback(e.target.value)}
+                  placeholder="Optional: describe what to change..."
+                  rows={4}
+                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-y"
+                />
+              </div>
+              <div className="flex gap-3 justify-end pt-1">
+                <button
+                  onClick={() => setRetryModal(null)}
+                  className="px-4 py-2 text-sm text-gray-300 hover:text-white transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={submitRetryModal}
+                  className="px-4 py-2 bg-orange-600 hover:bg-orange-500 text-white text-sm rounded transition-colors"
+                >
+                  Retry
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Output Viewer Modal */}
       {viewingOutput && (

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -77,6 +77,7 @@ interface JobDetail {
   airtable_record_id?: string
   airtable_url?: string
   media_id?: string
+  content_type?: string
 }
 
 // Map output keys to their display names and filenames
@@ -111,6 +112,9 @@ export default function JobDetail() {
   const [showChat, setShowChat] = useState(false)
   const [showScreengrabs, setShowScreengrabs] = useState(false)
   const [hasScreengrabs, setHasScreengrabs] = useState(false)
+  const [keywordReports, setKeywordReports] = useState<Array<{ filename: string; version: number; uploaded_at?: string }>>([])
+  const [keywordUploading, setKeywordUploading] = useState(false)
+  const keywordInputRef = useRef<HTMLInputElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const modalRef = useFocusTrap(!!viewingOutput)
   const { toast } = useToast()
@@ -163,6 +167,25 @@ export default function JobDetail() {
 
     fetchSstMetadata()
   }, [id, job?.airtable_record_id])
+
+  // Fetch keyword reports for this job
+  const fetchKeywordReports = async () => {
+    if (!id) return
+    try {
+      const response = await fetch(`/api/jobs/${id}/keyword-reports`)
+      if (response.ok) {
+        const data = await response.json()
+        setKeywordReports(data.reports || [])
+      }
+    } catch (err) {
+      // Silently fail
+      console.error('Failed to fetch keyword reports:', err)
+    }
+  }
+
+  useEffect(() => {
+    if (id) fetchKeywordReports()
+  }, [id])
 
   // Check for available screengrabs when job has a media_id
   useEffect(() => {
@@ -287,6 +310,32 @@ export default function JobDetail() {
     handleRetryPhase(retryModal.outputKey, tier, retryFeedback)
   }
 
+  const handleKeywordUpload = async (file: File) => {
+    setKeywordUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await fetch(`/api/jobs/${id}/keyword-report`, {
+        method: 'POST',
+        body: formData,
+      })
+      if (response.ok) {
+        const data = await response.json()
+        toast(`Keyword report uploaded: ${data.filename}`, 'success')
+        await fetchKeywordReports()
+      } else {
+        const data = await response.json()
+        toast(data.detail || 'Failed to upload keyword report', 'error')
+      }
+    } catch (err) {
+      console.error('Failed to upload keyword report:', err)
+      toast('Failed to upload keyword report', 'error')
+    } finally {
+      setKeywordUploading(false)
+      if (keywordInputRef.current) keywordInputRef.current.value = ''
+    }
+  }
+
   const closeModal = () => {
     setViewingOutput(null)
     // Return focus to trigger button
@@ -382,9 +431,21 @@ export default function JobDetail() {
           >
             &#8592; Back
           </button>
-          <h1 className="text-2xl font-bold text-white">
-            {job.project_name}
-          </h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold text-white">
+              {job.project_name}
+            </h1>
+            {job.content_type === 'short' && (
+              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-rose-600 text-white">
+                Short
+              </span>
+            )}
+            {job.content_type === 'clip' && (
+              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-600 text-white">
+                Clip
+              </span>
+            )}
+          </div>
           <p className="text-gray-400">
             Job #{job.id}
             {job.current_phase && job.status === 'in_progress' && (
@@ -751,6 +812,48 @@ export default function JobDetail() {
           </div>
         </div>
       )}
+
+      {/* Keyword Report Upload */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-medium text-white">SEMRush Keyword Report</h2>
+          <div className="flex items-center gap-2">
+            <input
+              ref={keywordInputRef}
+              type="file"
+              accept=".csv,.txt,.tsv"
+              className="hidden"
+              id="keyword-report-input"
+              onChange={(e) => {
+                const file = e.target.files?.[0]
+                if (file) handleKeywordUpload(file)
+              }}
+            />
+            <label
+              htmlFor="keyword-report-input"
+              className={`px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md text-sm cursor-pointer transition-colors ${keywordUploading ? 'opacity-50 pointer-events-none' : ''}`}
+            >
+              {keywordUploading ? 'Uploading...' : 'Upload Report'}
+            </label>
+          </div>
+        </div>
+        {keywordReports.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No keyword reports uploaded. Upload a SEMRush CSV export to enrich the SEO phase.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {keywordReports.map((report) => (
+              <li key={report.filename} className="flex items-center justify-between text-sm">
+                <span className="text-gray-300 font-mono">{report.filename}</span>
+                {report.uploaded_at && (
+                  <span className="text-gray-500 text-xs">{report.uploaded_at}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       {/* Screengrabs (inline) */}
       {job.media_id && (

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -169,7 +169,7 @@ export default function JobDetail() {
   }, [id, job?.airtable_record_id])
 
   // Fetch keyword reports for this job
-  const fetchKeywordReports = async () => {
+  const fetchKeywordReports = useCallback(async () => {
     if (!id) return
     try {
       const response = await fetch(`/api/jobs/${id}/keyword-reports`)
@@ -181,11 +181,11 @@ export default function JobDetail() {
       // Silently fail
       console.error('Failed to fetch keyword reports:', err)
     }
-  }
+  }, [id])
 
   useEffect(() => {
     if (id) fetchKeywordReports()
-  }, [id])
+  }, [id, fetchKeywordReports])
 
   // Check for available screengrabs when job has a media_id
   useEffect(() => {


### PR DESCRIPTION
## Summary

Comprehensive feature sprint addressing 7 high/normal priority issues plus a merged PR (#65) with formatter editor feedback.

### Sprint A (High Priority)
- **#62** Downloadable markdown files — `?download=true` query param adds `Content-Disposition: attachment` header; download buttons in dashboard
- **#63** AirTable images not rendering — images now clickable (open full-size), SST record links use correct deep-link URL with base64 detail param, CORS fallback
- **#61** Swap model tiers to Claude via OpenRouter — Haiku (cheapskate), Sonnet (default), Opus (big-brain) as primary models in each preset with fallback to previous models
- **#64** Editorial feedback for phase retries — JSON body `PhaseRetryRequest` with `tier` + `feedback`, feedback injected into all 6 phase prompts, stored in retry history, retry modal with textarea + tier selector in dashboard

### Sprint B (Normal Priority)
- **#59** Shorts pipeline handling — content type detection (full/short/clip) from duration + SST fields, Shorts skip timestamps, use cheapskate tier, get tailored prompts; content type badge in UI; DB migration (010)
- **#46** Standardize agent definitions — consistent section structure (Role/Input/Output/Guidelines/Quality Checklist) across all 7 agent files; `ap_style_bot.md` marked as not used in pipeline
- **#20** SEMRush keyword report upload — CSV upload endpoint with auto-versioning, keyword data injected into SEO phase on retries, upload UI in dashboard

### Also included
- **PR #65** merged — formatter editor feedback (verbatim preservation rules, house style, attribution accuracy, `openrouter-claude` 4th tier backend)
- 6 stale issues closed as already resolved (#38, #24, #23, #29, #53, #15)
- Tier cap removed (`le=2` → uncapped) to support 4th tier
- nginx fix for optional MCP upstream (lazy DNS resolution)
- Web port moved to 3001, CORS updated to match

## Test plan

### Container rebuild
- [ ] `docker compose build --no-cache && docker compose up -d` — all services start
- [ ] `curl http://localhost:8000/api/system/health` returns healthy
- [ ] Dashboard loads at http://localhost:3001

### Downloads (#62)
- [ ] On job detail page, download buttons appear next to each output tab
- [ ] Clicking download triggers browser file save (not inline render)
- [ ] `/api/jobs/1/outputs/analyst_output.md?download=true` returns `Content-Disposition: attachment` header

### AirTable images (#63)
- [ ] Screengrab images are clickable (open full-size in new tab)
- [ ] "View in Airtable" link opens correct SST record (not raw base URL)

### Model tiers (#61)
- [ ] Submit a new job — verify it uses Claude Sonnet (check phase model in job detail)
- [ ] Retry a phase with tier override — verify Claude Haiku (0) / Opus (2) / pinned (3) work
- [ ] Cost tracking shows correct pricing for Claude models

### Editorial feedback (#64)
- [ ] Click retry on any phase output — modal appears with tier dropdown + feedback textarea
- [ ] Submit retry with feedback text — verify phase re-runs and output reflects feedback
- [ ] Check phase history shows feedback in previous runs

### Shorts pipeline (#59)
- [ ] Process a short transcript (<90s duration) — verify "Short" badge appears
- [ ] Verify timestamp phase is skipped for Shorts
- [ ] Verify cheapskate tier used for all Short phases

### SEMRush upload (#20)
- [ ] Upload a CSV file via the keyword report section on job detail page
- [ ] Verify file saved as `keyword_report_v1.md`
- [ ] Retry SEO phase — verify keyword data appears in prompt context

### Agent definitions (#46)
- [ ] Spot-check `.claude/agents/*.md` files have consistent section headers

### Formatter improvements (PR #65)
- [ ] Retry formatter phase on an existing job
- [ ] Verify output preserves verbatim dialogue (no paraphrasing)
- [ ] Verify "partisan" spelling, no italicized program names

### DB migration
- [ ] `alembic upgrade head` runs cleanly (adds `content_type` column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)