### PR TITLE
feat: upgrade MCP server to Streamable HTTP transport

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -69,7 +69,7 @@ services:
       - "8080:8080"
     env_file: .env
     environment:
-      - MCP_TRANSPORT=sse
+      - MCP_TRANSPORT=http
       - EDITORIAL_API_URL=http://api:8000
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - "8080:8080"
     env_file: .env
     environment:
-      - MCP_TRANSPORT=sse
+      - MCP_TRANSPORT=http
       - EDITORIAL_API_URL=http://api:8000
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,4 +1,5 @@
 # MCP Server Dependencies
-mcp>=1.0.0
+mcp>=1.27.0
+sse-starlette>=2.0.0
 httpx>=0.26.0
 pydantic>=2.5.0

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,6 +23,7 @@ NOTE: Airtable access is READ-ONLY. No write operations are permitted.
 """
 
 import asyncio
+import contextlib
 import importlib.util
 import json
 import logging
@@ -1481,44 +1482,39 @@ async def main():
 
     Supports two transport modes:
     - stdio (default): For local Claude Desktop subprocess spawning
-    - sse: For Docker/HTTP environments where subprocess spawning isn't available
+    - http: For Docker/HTTP environments with Streamable HTTP transport
 
-    Set MCP_TRANSPORT=sse to use SSE transport on port 8080.
+    Set MCP_TRANSPORT=http to use Streamable HTTP transport on port 8080.
+    Legacy value MCP_TRANSPORT=sse is accepted for backward compatibility.
     """
     transport = os.environ.get("MCP_TRANSPORT", "stdio")
 
-    if transport == "sse":
-        # SSE transport for Docker/HTTP environments
+    if transport in ("http", "sse"):  # Accept "sse" for backward compat
         import uvicorn
-        from mcp.server.sse import SseServerTransport
+        from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
         from starlette.applications import Starlette
-        from starlette.responses import Response
-        from starlette.routing import Route
+        from starlette.routing import Mount
 
-        # Create SSE transport
-        sse = SseServerTransport("/messages")
+        session_manager = StreamableHTTPSessionManager(
+            app=server,
+            json_response=False,
+            stateless=False,
+            session_idle_timeout=1800,  # 30 min idle cleanup
+        )
 
-        async def handle_sse(request):
-            """Handle SSE connection endpoint."""
-            async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
-                await server.run(streams[0], streams[1], server.create_initialization_options())
-            return Response()
+        @contextlib.asynccontextmanager
+        async def lifespan(app):
+            async with session_manager.run():
+                yield
 
-        async def handle_post_message(request):
-            """Handle message POST endpoint."""
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-            return Response()
-
-        # Create Starlette app with SSE routes
         app = Starlette(
             debug=False,
+            lifespan=lifespan,
             routes=[
-                Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_post_message, methods=["POST"]),
+                Mount("/mcp", app=session_manager.handle_request),
             ],
         )
 
-        # Run SSE server (must use async serve() since we're already in an event loop)
         config = uvicorn.Config(app, host="0.0.0.0", port=8080, log_level="info")
         srv = uvicorn.Server(config)
         await srv.serve()

--- a/nginx.conf
+++ b/nginx.conf
@@ -45,18 +45,19 @@ http {
             proxy_set_header X-API-Key "${CARDIGAN_API_KEY}";
         }
 
-        # MCP SSE endpoint (optional — for Claude Desktop via Docker)
+        # MCP Streamable HTTP endpoint (optional — for Claude Desktop via Docker)
         location /mcp/ {
-            proxy_pass http://mcp:8080/;
+            proxy_pass http://mcp:8080/mcp/;
             proxy_buffering off;
             proxy_cache off;
-            proxy_set_header Connection '';
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            # SSE requires chunked transfer encoding
+            proxy_set_header Connection '';
+            # Streaming support for server-initiated events
             chunked_transfer_encoding on;
+            proxy_read_timeout 3600;
         }
 
         # SPA fallback — serve index.html for all other routes

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,5 @@ black>=23.12.0
 watchfiles>=0.21.0
 
 # MCP Server (for Claude Desktop integration)
-mcp>=1.0.0
+mcp>=1.27.0
+sse-starlette>=2.0.0


### PR DESCRIPTION
## Summary
- Replaces deprecated `SseServerTransport` with `StreamableHTTPSessionManager` from MCP SDK 1.27.0
- Consolidates `/sse` + `/messages` endpoints into a single `/mcp` endpoint with session management and 30-min idle timeout
- Updates nginx proxy, Docker Compose configs, and dependency pins to match
- Backward compatible: `MCP_TRANSPORT=sse` still works (routes to the new HTTP transport)

## Test plan
- [ ] Verify `python -m mcp_server.server` starts in stdio mode (default, no env var)
- [ ] Verify `MCP_TRANSPORT=http python -m mcp_server.server` starts uvicorn on port 8080
- [ ] Verify `MCP_TRANSPORT=sse` still works (backward compat)
- [ ] Test with `curl -X POST http://localhost:8080/mcp` JSON-RPC initialize request
- [ ] Run `docker compose --profile mcp up mcp` and confirm container starts
- [ ] Run `pytest` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)