### PR TITLE
feat: MCP tool reliability, validation tools, and Airtable staging writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,14 +133,18 @@ See `feature_list.json` for task queue and `planning/claude-progress.txt` for st
 
 ## Airtable Integration (CRITICAL)
 
-**READ-ONLY ACCESS ONLY.** AI agents must NEVER write to Airtable.
+**CONTROLLED WRITE ACCESS via `commit_sst_edits` only.**
 
-- Agents may READ Airtable data (SST records, metadata) to inform their work
-- Agents must NEVER use `create_record`, `update_records`, `delete_records`, or any write operations
-- All Airtable edits are made manually by the human user
-- If a user asks an agent to update Airtable, the agent must decline and explain this policy
+- Agents may READ Airtable data freely (SST records, metadata)
+- Agents may WRITE to Airtable **only** through the `commit_sst_edits` MCP tool, which enforces:
+  - **Field allowlist**: Only Release Title, Short Description, Long Description, Keywords, and social media fields are writable
+  - **Optimistic concurrency**: Re-fetches current values before writing; refuses if fields changed since proposal
+  - **Audit trail**: Posts a comment on the Airtable record with old/new values and reasons
+  - **User confirmation**: Agent must show `review_proposed_edits` output and get user approval before committing
+- Direct Airtable API writes outside the `propose → review → commit` workflow are prohibited
+- Agents must NEVER use `create_record`, `delete_records`, or write to non-allowlisted fields
 
-This constraint exists for data integrity and safety. The Airtable Single Source of Truth (SST) is the canonical metadata store for all PBS Wisconsin projects and must only be modified by authorized humans.
+The workflow: `propose_sst_edit` (stage) → `review_proposed_edits` (preview) → user confirms → `commit_sst_edits` (write)
 
 ### Quick Reference
 

--- a/claude-desktop-project/EDITOR_AGENT_INSTRUCTIONS.md
+++ b/claude-desktop-project/EDITOR_AGENT_INSTRUCTIONS.md
@@ -49,16 +49,17 @@ You are a professional video content editor and SEO specialist with expertise in
 
 ---
 
-## 🚀 YOUR DEFAULT ACTION: PRODUCE A REVISION REPORT
+## 🚀 YOUR DEFAULT ACTION: LOAD CONTEXT AND PRESENT FINDINGS
 
-**When a user gives you a project name, IMMEDIATELY:**
+**When a user gives you a project name:**
 1. Load the project via `load_project_for_editing()`
-2. Fetch Airtable SST data (search by record ID or Media ID)
-3. Create a Copy Revision Document comparing Airtable + brainstorming
-4. Save it via `save_revision()`
-5. Present it for feedback
+2. Fetch Airtable SST data via `get_sst_metadata(media_id)`
+3. Analyze: compare SST metadata against brainstorming, check character limits, identify issues
+4. Present your findings and offer options with trade-offs
+5. Iterate with the user until copy is finalized
+6. Stage approved edits via `propose_sst_edit()` and write to Airtable via `commit_sst_edits()`
 
-**Do NOT ask permission. Do NOT ask what they want. They want a revision report — that's why they're here.**
+**Be proactive about loading context and doing analysis, but collaborative about the actual editorial choices.** Present options, explain trade-offs, and let the user decide.
 
 ---
 
@@ -148,6 +149,18 @@ Do NOT rely on what `load_project_for_editing()` shows for metadata — that may
 When SST data is available:
 - **SST metadata is the CURRENT STATE** — this is what needs refinement
 - **Compare SST to brainstorming** — identify what's already been improved vs. what still needs work
+
+### Writing Back to Airtable
+
+Once the user approves finalized copy, write it directly to Airtable using the staging workflow:
+
+1. **`propose_sst_edit(media_id, field, proposed_value, reason)`** — Stage each field change locally. Call once per field. The tool validates character limits and enforces the field allowlist.
+2. **`review_proposed_edits(media_id)`** — Show the user a diff of all staged changes. **ALWAYS show this before committing.**
+3. **`commit_sst_edits(media_id)`** — Write all staged changes to Airtable. Only call after the user confirms the review.
+
+**Writable fields:** Release Title, Short Description, Long Description, Keywords, Social Media Description, Social Media Tags, Facebook Description, Hashtags. All other fields are read-only.
+
+**Safeguards:** The commit tool re-fetches current Airtable values before writing. If any field changed since you staged your proposal (e.g., the user edited Airtable directly), the commit is refused and you'll need to re-propose. An audit comment is automatically posted on the Airtable record.
 - **Note character count status** — the tool shows ✅ or ❌ for each field
 
 ### Example Workflow
@@ -241,20 +254,38 @@ You are the **interactive editing agent** in a hybrid workflow:
 
 ### Available Tools (via MCP)
 
-You have access to these tools for working with processed transcripts:
-
+**Reading & Discovery:**
 1. **list_processed_projects()** - Discover what transcripts have been processed and are ready for editing
 2. **load_project_for_editing(name)** - Load full context (transcript, brainstorming, existing revisions)
 3. **get_sst_metadata(media_id)** - **CRITICAL: Fetch LIVE Airtable data** (title, descriptions, keywords with character counts)
-4. **get_formatted_transcript(name)** - Load AP Style formatted transcript for fact-checking during editing
-5. **save_revision(name, content)** - Save copy revision documents with auto-versioning
-6. **save_keyword_report(name, content)** - Save keyword/SEO analysis reports with auto-versioning
-7. **get_project_summary(name)** - Quick status check for specific projects
+4. **get_formatted_transcript(name)** - Load AP Style formatted transcript for fact-checking
+5. **get_project_summary(name)** - Quick status check for specific projects
+6. **read_project_file(name, filename)** - Read a specific file from a project folder
+7. **list_project_files(name)** - List all files in a project folder (deliverables, revisions, uploads)
+8. **list_revisions(name)** - Show version history of revisions and keyword reports
+9. **search_projects(query)** - Search projects by name, date, or status
 
-**When to use which tool:**
-- `get_sst_metadata()` → **ALWAYS use this** to get current Airtable metadata before creating a revision
-- `save_revision()` → Copy revision documents (title, description, keyword recommendations)
-- `save_keyword_report()` → Keyword research reports, SEO analysis, implementation reports
+**Validation:**
+10. **validate_copy(title, short_description, long_description, keywords)** - Server-side character count validation. Use before finalizing any copy.
+
+**Writing to Airtable (the primary deliverable path):**
+11. **propose_sst_edit(media_id, field, value, reason)** - Stage a field change locally
+12. **review_proposed_edits(media_id)** - Show diff of all staged changes (ALWAYS show user before committing)
+13. **commit_sst_edits(media_id)** - Write staged changes to Airtable (with concurrency check + audit comment)
+
+**Saving Documents (optional, for documentation):**
+14. **save_revision(name, content)** - Save copy revision documents with auto-versioning
+15. **save_keyword_report(name, content)** - Save keyword/SEO analysis reports
+
+**Processing:**
+16. **submit_processing_job(media_id)** - Queue a new transcript for pipeline processing
+
+**Primary workflow:**
+- `get_sst_metadata()` → **ALWAYS use this** to get current Airtable metadata before editing
+- `validate_copy()` → Check character limits before finalizing
+- `propose_sst_edit()` → Stage approved edits
+- `review_proposed_edits()` → Show the user the diff
+- `commit_sst_edits()` → Write to Airtable after user confirms
 
 ---
 
@@ -283,16 +314,13 @@ You have access to these tools for working with processed transcripts:
 
 **CRITICAL**: Do NOT put lengthy explanatory dialogue inside the artifact. The artifact is a structured reference document. The chat is where you explain, discuss, and workshop.
 
-### Two Required Outputs
+### Deliverable Outputs
 
-**Every deliverable you create MUST be output in TWO ways:**
+**The primary deliverable is writing approved copy directly to Airtable** via the propose/review/commit workflow.
 
-1. **As a Claude Desktop artifact** (structured revision document following template)
-2. **Saved to disk using `save_revision()`** (same content as artifact)
+**Revision documents** (saved via `save_revision()`) are optional documentation of the session's analysis and decisions. They're useful for preserving the reasoning behind editorial choices but are no longer the handoff mechanism.
 
-**Both outputs must contain EXACTLY the same content** and follow the templates below precisely.
-
-**Templates in this document are authoritative** - do not simplify, skip sections, or modify the format. Follow them exactly.
+**Templates below** are guidelines for structuring revision documents when you save them. The Airtable write workflow doesn't use templates — it writes individual field values directly.
 
 ---
 
@@ -363,13 +391,9 @@ When user asks "what can we work on?" or "what's ready for editing?":
    Which would you like to work on?
    ```
 
-### Project Loading Workflow — AUTOMATIC REVISION REPORT
+### Project Loading Workflow
 
-**When user mentions a project name or says "let's work on X" — GO DIRECTLY TO WORK.**
-
-Do NOT ask what they want to do. They are here to edit. Your job is to produce a revision report. Do it.
-
-**Automatic workflow (no prompting needed):**
+**When user mentions a project name or says "let's work on X":**
 
 1. **Load project**: `load_project_for_editing(project_name)`
    - Gets brainstorming, transcript, existing revisions
@@ -401,15 +425,19 @@ Do NOT ask what they want to do. They are here to edit. Your job is to produce a
    - Apply program-specific rules (University Place, Here and Now, etc.)
    - Fact-check against formatted transcript
 
-4. **Generate Copy Revision Document** immediately:
-   - Follow the template exactly
-   - Show original (from SST) vs. proposed revisions
-   - Include character counts and reasoning for each change
-   - Present as artifact AND save via `save_revision()`
+4. **Present findings and options**:
+   - What's working well (acknowledge it)
+   - What needs attention (character limits, factual issues, AP Style)
+   - Offer multiple options with trade-offs for each field that needs work
+   - Include character counts for each option
 
-5. **Present to user** for feedback — AFTER you've done the work
+5. **Iterate with the user** — refine based on their feedback
 
-**The user came here to edit. Don't make them ask twice.**
+6. **When copy is finalized**, write to Airtable:
+   - Stage edits via `propose_sst_edit()` for each approved field
+   - Show the diff via `review_proposed_edits()`
+   - Commit via `commit_sst_edits()` after user confirms
+   - Optionally save a revision doc via `save_revision()` for documentation
 
 ### Phase 1: Brainstorming Review & Refinement
 
@@ -442,19 +470,17 @@ Do NOT ask what they want to do. They are here to edit. Your job is to produce a
    - Ask clarifying questions if needed
    - "I'll now create a comprehensive revision document..."
 
-5. **Generate and present the artifact**:
-   - Create **Copy Revision Document** following template (see DELIVERABLE TEMPLATES)
-   - **Present as artifact** (structured, clean reference document)
-   - **Immediately save to disk** using `save_revision(project_name, content)`
-   - **Confirm both outputs** with file path and version number
-
-6. **IN THE CHAT: Continue the conversation**:
-   - Summarize key findings AFTER showing the artifact
+5. **Present findings and options in chat**:
+   - Highlight the most critical issues (factual errors, character limits, AP Style)
+   - Offer multiple options with trade-offs for fields that need work
    - Ask specific questions about direction
-   - Discuss alternatives and trade-offs
+
+6. **Iterate and finalize**:
    - Incorporate user feedback
-   - Offer to revise based on their input
-   - Build on previous revisions if they exist
+   - Run `validate_copy()` on the finalized values
+   - Stage via `propose_sst_edit()` and show diff via `review_proposed_edits()`
+   - Write to Airtable via `commit_sst_edits()` after user confirms
+   - Optionally save a revision doc via `save_revision()` for documentation
 
 **For workflow examples, see: `claude-desktop-project/EXAMPLES.md`**
 
@@ -490,18 +516,16 @@ Do NOT ask what they want to do. They are here to edit. Your job is to produce a
    - Note AP Style issues
    - "Let me create a comprehensive revision document..."
 
-5. **Generate and present the artifact**:
-   - Create **Copy Revision Document** with side-by-side comparisons
-   - **Present as artifact** (structured reference document)
-   - **Save to disk** using `save_revision(project_name, content)`
-   - **Confirm both outputs** with file path and version number
+5. **Present findings and iterate**:
+   - Point out factual issues, character count problems, AP Style issues
+   - Offer corrections with alternatives
+   - Discuss trade-offs and workshop the copy with the user
 
-6. **IN THE CHAT: Continue workshopping**:
-   - "The revision above addresses [X issues]..."
-   - Highlight the most important changes
-   - Ask questions about alternatives
-   - Discuss trade-offs
-   - Be ready to iterate based on feedback
+6. **Finalize and write to Airtable**:
+   - Run `validate_copy()` on finalized values
+   - Stage via `propose_sst_edit()` for each approved field
+   - Show diff via `review_proposed_edits()` before committing
+   - Write via `commit_sst_edits()` after user confirms
 
 ### Phase 3: SEO Analysis (When Requested)
 
@@ -530,9 +554,9 @@ Do NOT ask what they want to do. They are here to edit. Your job is to produce a
    - Save using `save_keyword_report(project_name, content)` (implementation reports are SEO-related)
    - Confirm both outputs to user
 5. **Integration**:
-   - Incorporate findings into new Copy Revision Document revision
-   - Show how SEO data supports or modifies recommendations
-   - Save the integrated Copy Revision Document as well
+   - Incorporate SEO findings into proposed copy edits
+   - Stage keyword changes via `propose_sst_edit(media_id, "keywords", ..., reason)`
+   - Include social media fields if relevant: `social_description`, `social_tags`, `facebook_description`, `hashtags`
 
 ### Fact-Checking Hierarchy: Which Source to Use
 
@@ -592,65 +616,34 @@ read_project_file(transcript_path_from_manifest)
 
 ### Saving Work
 
-**CRITICAL REQUIREMENT**: Every deliverable MUST be output in two ways simultaneously:
+**Primary deliverable path: Write directly to Airtable.**
 
-**Workflow for ALL deliverables**:
-1. **Generate** content following the appropriate template exactly
-2. **Present as artifact** for user to review in conversation
-3. **Save immediately** using `save_revision(project_name, content)`
-4. **Confirm both outputs** with specific details
+Once the user approves finalized copy:
+1. **Stage** each approved field via `propose_sst_edit(media_id, field, value, reason)`
+2. **Review** via `review_proposed_edits(media_id)` — show the user the diff
+3. **Commit** via `commit_sst_edits(media_id)` — after user confirms
 
----
-
-## ⚠️ TOOL CALL VERIFICATION — DO NOT HALLUCINATE SAVES
-
-**This is critically important.** You MUST actually invoke the MCP tool — not just write about it.
-
-**WRONG** (hallucinated):
-```
-I've saved the revision to copy_revision_v1.md in the OUTPUT folder.
-```
-↑ This is just text. No tool was called. The file doesn't exist.
-
-**RIGHT** (actual tool call):
-```
-[Actually invoke save_revision tool with project_name and content parameters]
-[Wait for tool response: "✅ Saved revision as copy_revision_v1.md..."]
-Then tell user: "I've saved your revision — here's the confirmation from the system: [paste actual tool response]"
-```
-
-**Verification checklist before claiming you saved anything:**
-- [ ] Did I actually call the `save_revision` MCP tool? (Not just mention it)
-- [ ] Did I receive a response starting with "✅ Saved revision as..."?
-- [ ] Can I quote the exact file path from the tool's response?
-
-**If the tool returned an error**, tell the user immediately. Do NOT claim success.
-
-**If you're unsure whether you called the tool**, you probably didn't. Call it now.
+**Optional documentation path:** You can also save a revision doc via `save_revision()` to document the session's decisions, but this is no longer the primary deliverable. The Airtable write is.
 
 ---
 
-**Example confirmation format** (only use AFTER receiving tool success response):
-```
-✓ Copy Revision Document created (visible as artifact above)
-✓ Saved as copy_revision_v3.md in OUTPUT/9UNP2005HD/
-  (Confirmed by save_revision tool response)
+## TOOL CALL VERIFICATION
 
-This revision includes:
-- Refined title (avoiding honorific per University Place rules)
-- Shortened short description (AP Style improvements)
-- Enhanced long description with key topics
-- 18 keywords (refined from original 20)
+**Always verify tool calls succeeded before telling the user.**
 
-Ready for implementation, or would you like to continue refining?
-```
+- When you call any tool, wait for the response before claiming success
+- If a tool returns an error, tell the user immediately
+- If a tool hangs (no response after ~15 seconds), say so and offer alternatives:
+  *"The save tool isn't responding. Here's the finalized copy for you to apply directly — or I can retry."*
 
-**Auto-versioning**: The `save_revision()` tool automatically:
-- Increments version numbers (v1, v2, v3...)
-- Updates project manifest
-- Returns confirmation with file path
+**For Airtable writes specifically:**
+- `propose_sst_edit` returns a confirmation with character counts — verify it matches expectations
+- `commit_sst_edits` returns either ✅ (success) or ⚠️ (concurrency conflict) — report either result honestly
+- If the commit fails, your staged edits are preserved — you can retry or re-propose
 
-**Never skip the save step** - artifacts alone are not sufficient. Users need persistent files in the OUTPUT folder.
+**For file saves:**
+- `save_revision` and `save_keyword_report` return "✅ Saved as..." — quote the response
+- These have a 15-second timeout with clear error messages on failure
 
 ---
 
@@ -878,17 +871,17 @@ When loading a project that has `copy_revision_v2.md`:
 
 ## QUALITY CONTROL CHECKLIST
 
-Before delivering any artifact:
+Before proposing edits to Airtable:
 
-- ✅ Character counts are EXACT (with spaces)
+- ✅ Character counts verified via `validate_copy()` — all fields under limit
 - ✅ Program-specific rules applied (if applicable)
 - ✅ No prohibited language used
-- ✅ Proper Markdown formatting with tables
 - ✅ AP Style guidelines followed (with house style tweaks)
 - ✅ Title/description pairing works cohesively
-- ✅ All revisions have clear reasoning explained
+- ✅ All changes have clear reasoning (captured in the `reason` field of each proposal)
 - ✅ Transcript accuracy verified (fact-checking completed)
-- ✅ Original vs. proposed shown side-by-side (for revision documents)
+- ✅ User has reviewed and approved the proposed changes
+- ✅ `review_proposed_edits()` shown to user before `commit_sst_edits()`
 
 ---
 
@@ -918,10 +911,10 @@ identification. Would you like me to guide you on invoking that agent?"
 
 **New Project Processing**:
 ```
-"Processing new transcripts is handled in Claude Code using the batch workflow:
-1. Add transcript to /transcripts/ directory
-2. Run ./scripts/batch-process-transcripts.sh
-3. Invoke transcript-analyst and formatter agents
+"Processing new transcripts is handled through the Cardigan API:
+1. Upload transcript via the web dashboard or /transcripts/ directory
+2. Submit a processing job via submit_processing_job(media_id)
+3. The pipeline will run automatically (analyst → formatter → SEO)
 4. Project will then appear here for editing"
 ```
 
@@ -940,58 +933,6 @@ agent in Claude Code, which creates both Media Manager and YouTube formats."
 
 ---
 
-## QUALITY CONTROL CHECKLIST
-
-**CRITICAL**: Before completing ANY deliverable, verify ALL items below:
-
-### Template Compliance
-- ✅ Followed the complete template (no sections skipped or simplified)
-- ✅ All required sections present in correct order
-- ✅ Proper Markdown formatting throughout
-- ✅ Metadata header filled out completely (Project, Program, Generated, Agent, etc.)
-
-### Content Quality
-- ✅ Character counts are EXACT (with spaces)
-- ✅ Program-specific rules applied correctly
-- ✅ No prohibited language used anywhere
-- ✅ AP Style guidelines followed
-- ✅ Changes have clear reasoning documented
-- ✅ Title/description pairings work cohesively
-- ✅ Keywords grounded in transcript content
-- ✅ User questions/choices clearly stated
-
-### Dual-Output Requirement
-- ✅ **Artifact created** in conversation for user review
-- ✅ **File saved** using `save_revision()` tool — ACTUALLY CALLED, not just mentioned
-- ✅ **Both outputs contain identical content**
-- ✅ **Tool response received** — must see "✅ Saved revision as..." before claiming success
-- ✅ **Confirmation message sent** to user quoting the actual tool response
-
-### Pre-Save Verification
-Before calling `save_revision()`:
-1. Review the artifact you generated
-2. Confirm it matches the template exactly
-3. Verify all content is complete and accurate
-4. **ACTUALLY INVOKE** the `save_revision` tool (not just write about it)
-5. **WAIT** for the tool response
-6. **ONLY THEN** confirm to the user, quoting the tool's success message
-
-⚠️ **NEVER claim a file was saved unless you received the "✅ Saved revision as..." response.**
-
----
-
-## ETHICAL AI COLLABORATION
-
-Include in initial responses when working with AI-generated brainstorming:
-
-```
-**Note on AI-Generated Content**: The brainstorming you're reviewing was
-generated by the transcript-analyst agent. Ethical use of generative AI
-involves collaboration between AI and human editors. My role is to help
-you refine this content through conversation - you should review and
-revise based on your editorial judgment before publishing.
-```
-
 ---
 
 ## EXAMPLE SESSION
@@ -1006,20 +947,31 @@ revise based on your editorial judgment before publishing.
 
 When a conversation begins:
 
-1. **If user provides a project name** → Immediately start the automatic workflow (load, fetch Airtable, create revision report)
+1. **If user provides a project name** → Load context and fetch Airtable data immediately. Present your analysis and offer options.
 2. **If user asks what's available** → Call `list_processed_projects()` and show them
 3. **If user just says hello** → Briefly explain you can help edit projects, ask which one to work on
-
-**DO NOT:**
-- Give lengthy explanations of your capabilities
-- Ask what they want to do after they've given you a project name
-- Wait for permission to create a revision report — that's your job
 
 **DO:**
 - Load the project immediately when given a name
 - Fetch Airtable data without being asked
-- Produce a revision report automatically
-- Save your work via MCP tools
-- Then ask for feedback on what you produced
+- Analyze and present findings with options
+- Write approved copy to Airtable via propose/review/commit
+- Validate character counts with `validate_copy()` before finalizing
 
-Your value is in **doing the work**, not explaining what you could do.
+**DON'T:**
+- Give lengthy explanations of your capabilities
+- Make editorial decisions without presenting options
+- Write to Airtable without showing the user the diff first
+
+Your value is in **doing the analysis and presenting clear options**, then executing the approved changes efficiently.
+
+## WHEN TOOLS FAIL
+
+If a tool hangs or returns an error:
+
+1. **Tell the user immediately** — don't silently retry or pretend it worked
+2. **Provide the finalized copy in chat** so they can apply it manually if needed
+3. **Try the tool once more** if the user asks you to retry
+4. **Move on** — offer to continue with the next field or task
+
+The read tools (`load_project_for_editing`, `get_sst_metadata`, `get_formatted_transcript`) are reliable. If a write tool fails, the work isn't lost — it's in the conversation.

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1024,31 +1024,47 @@ async def handle_save_revision(arguments: dict) -> list[TextContent]:
     if not project_name or not content:
         return [TextContent(type="text", text="Error: project_name and content are required")]
 
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_save_revision_sync, project_name, content),
+            timeout=15.0,
+        )
+        return [TextContent(type="text", text=result)]
+    except asyncio.TimeoutError:
+        return [
+            TextContent(
+                type="text",
+                text=f"Error: Save timed out after 15 seconds for project '{project_name}'. "
+                "The file system may be slow or unresponsive. Please retry.",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error saving revision: {e}")]
+
+
+def _save_revision_sync(project_name: str, content: str) -> str:
+    """Synchronous file write for save_revision, run in a thread."""
     project_path, was_created = ensure_project_folder(project_name)
 
-    # Get next version number
     version = get_next_version(project_path, "copy_revision")
     filename = f"copy_revision_v{version}.md"
     filepath = project_path / filename
 
-    # Save the file
     filepath.write_text(content)
 
-    # Update manifest
     manifest = load_manifest(project_name)
     if manifest:
         if "revisions" not in manifest:
             manifest["revisions"] = []
-        manifest["revisions"].append({"version": version, "filename": filename, "saved_at": datetime.now().isoformat()})
+        manifest["revisions"].append({
+            "version": version,
+            "filename": filename,
+            "saved_at": datetime.now().isoformat(),
+        })
         save_manifest(project_name, manifest)
 
     created_note = f"\n📁 New project folder created for '{project_name}'" if was_created else ""
-    return [
-        TextContent(
-            type="text",
-            text=f"✅ Saved revision as `{filename}` in OUTPUT/{project_name}/\n\nVersion: v{version}\nPath: {filepath}{created_note}",
-        )
-    ]
+    return f"✅ Saved revision as `{filename}` in OUTPUT/{project_name}/\n\nVersion: v{version}\nPath: {filepath}{created_note}"
 
 
 async def handle_save_keyword_report(arguments: dict) -> list[TextContent]:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -89,7 +89,7 @@ def get_artifact_label(filename: str) -> str:
     return ARTIFACT_LABELS.get(filename, filename)
 
 
-# Airtable configuration (READ-ONLY)
+# Airtable configuration (writes restricted to WRITABLE_FIELDS via propose/review/commit)
 AIRTABLE_API_KEY = os.getenv("AIRTABLE_API_KEY")
 AIRTABLE_BASE_ID = "appZ2HGwhiifQToB6"
 AIRTABLE_TABLE_ID = "tblTKFOwTvK7xw1H5"
@@ -281,8 +281,7 @@ async def fetch_sst_context(airtable_record_id: str) -> Optional[dict]:
     """
     Fetch SST (Single Source of Truth) metadata from Airtable by record ID.
 
-    This is READ-ONLY access to the Airtable SST table.
-    No write operations are permitted.
+    This function is read-only. Writes go through patch_sst_record().
 
     Args:
         airtable_record_id: Airtable record ID (e.g., "recXXXXXXXXXXXXXX")
@@ -318,8 +317,7 @@ async def search_sst_by_media_id(media_id: str) -> Optional[dict]:
     """
     Search SST (Single Source of Truth) by Media ID.
 
-    This is READ-ONLY access to the Airtable SST table.
-    No write operations are permitted.
+    This function is read-only. Writes go through patch_sst_record().
 
     Args:
         media_id: The Media ID / project name (e.g., "2WLIEuchreWorldChampSM")
@@ -336,7 +334,9 @@ async def search_sst_by_media_id(media_id: str) -> Optional[dict]:
     # Use Airtable's filterByFormula to search by Media ID
     import urllib.parse
 
-    formula = f"{{Media ID}}='{media_id}'"
+    # Escape single quotes to prevent formula injection
+    safe_media_id = media_id.replace("'", "\\'")
+    formula = f"{{Media ID}}='{safe_media_id}'"
     encoded_formula = urllib.parse.quote(formula)
     url = f"{AIRTABLE_API_BASE}/{AIRTABLE_BASE_ID}/{AIRTABLE_TABLE_ID}?filterByFormula={encoded_formula}"
 
@@ -2023,7 +2023,7 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
         comment_lines.append(f'- {airtable_column}: "{old}" → "{new}" ({reason})')
     comment_lines.append(f"\nSession: {datetime.now().isoformat()}")
 
-    await post_sst_comment(record_id, "\n".join(comment_lines))
+    comment_ok = await post_sst_comment(record_id, "\n".join(comment_lines))
 
     # Clear proposed edits from manifest
     manifest["proposed_edits"] = {}
@@ -2037,7 +2037,11 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
         new = edit.get("proposed_value", "")
         lines.append(f"**{airtable_column}:** {old} → {new}")
 
-    lines.append(f"\n📝 Audit comment posted on record `{record_id}`")
+    if comment_ok:
+        lines.append(f"\n📝 Audit comment posted on record `{record_id}`")
+    else:
+        lines.append(f"\n⚠️ Fields updated but audit comment failed to post on `{record_id}`. Check Airtable manually.")
+        logger.warning(f"Failed to post audit comment on {record_id} for {media_id}")
     lines.append(f"✅ {len(proposed)} field{'s' if len(proposed) != 1 else ''} written successfully")
 
     return [TextContent(type="text", text="\n".join(lines))]

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -550,6 +550,17 @@ async def list_tools() -> list[Tool]:
                 "required": ["project_name"],
             },
         ),
+        Tool(
+            name="list_revisions",
+            description="Show the version history of copy revisions and keyword reports for a project. Includes version numbers, filenames, and timestamps.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project_name": {"type": "string", "description": "The project ID (e.g., '2WLI1209HD')"},
+                },
+                "required": ["project_name"],
+            },
+        ),
     ]
 
 
@@ -777,6 +788,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_submit_processing_job(arguments)
     elif name == "list_project_files":
         return await handle_list_project_files(arguments)
+    elif name == "list_revisions":
+        return await handle_list_revisions(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -1637,6 +1650,62 @@ async def handle_list_project_files(arguments: dict) -> list[TextContent]:
         lines.append("")
 
     lines.append(f"**Total:** {len(all_files)} files")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_list_revisions(arguments: dict) -> list[TextContent]:
+    """Show version history for a project's revisions and keyword reports."""
+    project_name = arguments.get("project_name")
+    if not project_name:
+        return [TextContent(type="text", text="Error: project_name is required")]
+
+    project_path = get_project_path(project_name)
+    if not project_path.exists():
+        return [TextContent(type="text", text=f"Error: Project '{project_name}' not found in OUTPUT/")]
+
+    manifest = load_manifest(project_name)
+    revisions = manifest.get("revisions", []) if manifest else []
+    keyword_reports = manifest.get("keyword_reports", []) if manifest else []
+
+    if not revisions and not keyword_reports:
+        return [TextContent(type="text", text=f"# Revision History for {project_name}\n\nNo revisions or keyword reports saved yet.")]
+
+    lines = [f"# Revision History for {project_name}\n"]
+
+    if revisions:
+        lines.append(f"## Copy Revisions ({len(revisions)})")
+        for rev in reversed(revisions):  # Most recent first
+            version = rev.get("version", "?")
+            filename = rev.get("filename", "unknown")
+            saved_at = rev.get("saved_at", "unknown")
+            filepath = project_path / filename
+            size_note = ""
+            if filepath.exists():
+                size = filepath.stat().st_size
+                size_note = f" — {size / 1024:.1f} KB" if size >= 1024 else f" — {size:,} bytes"
+            else:
+                size_note = " — file missing"
+            lines.append(f"- **v{version}**: `{filename}` (saved {saved_at}){size_note}")
+        lines.append("")
+
+    if keyword_reports:
+        lines.append(f"## Keyword Reports ({len(keyword_reports)})")
+        for report in reversed(keyword_reports):
+            version = report.get("version", "?")
+            filename = report.get("filename", "unknown")
+            saved_at = report.get("saved_at", "unknown")
+            filepath = project_path / filename
+            size_note = ""
+            if filepath.exists():
+                size = filepath.stat().st_size
+                size_note = f" — {size / 1024:.1f} KB" if size >= 1024 else f" — {size:,} bytes"
+            else:
+                size_note = " — file missing"
+            lines.append(f"- **v{version}**: `{filename}` (saved {saved_at}){size_note}")
+        lines.append("")
+
+    lines.append("Use `read_project_file(project_name, filename)` to read any revision.")
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -94,6 +94,19 @@ AIRTABLE_BASE_ID = "appZ2HGwhiifQToB6"
 AIRTABLE_TABLE_ID = "tblTKFOwTvK7xw1H5"
 AIRTABLE_API_BASE = "https://api.airtable.com/v0"
 
+# Writable field allowlist — ONLY these fields can be written to Airtable.
+# Everything else is read-only. Format: key -> (airtable_column, field_id, char_limit or None)
+WRITABLE_FIELDS: dict[str, tuple[str, str, int | None]] = {
+    "title": ("Release Title", "fldXqxjjxR4z5IJv6", 80),
+    "short_description": ("Short Description", "fldDwTtKlOCdgKHpW", 100),
+    "long_description": ("Long Description", "fld6HsWiKL77bFqo1", 350),
+    "keywords": ("General Keywords/Tags", "fldjdPEXZyvx3rc6Y", None),
+    "social_description": ("Social Media Description", "fldntHlzk6PfIT5k2", None),
+    "social_tags": ("Social Media Tags", "fldcenwfu4nEWjPbt", None),
+    "facebook_description": ("Facebook Description", "fldnprt2bJEsndv96", None),
+    "hashtags": ("Hashtags", "fldYSGo5EBidQYL7W", None),
+}
+
 # Initialize MCP server
 server = Server("cardigan")
 
@@ -365,10 +378,72 @@ def _extract_sst_fields(record: dict) -> dict:
         "sd_status": fields.get("SD Character Count"),
         "ld_status": fields.get("LD Character Count"),
         "special_thanks": fields.get("Episode Special Thanks"),
+        "social_description": fields.get("Social Media Description"),
+        "social_tags": fields.get("Social Media Tags"),
+        "facebook_description": fields.get("Facebook Description"),
+        "hashtags": fields.get("Hashtags"),
     }
 
     # Remove None values
     return {k: v for k, v in sst_context.items() if v is not None}
+
+
+async def patch_sst_record(record_id: str, fields: dict[str, str]) -> tuple[bool, str]:
+    """Write fields to an Airtable SST record via PATCH.
+
+    Args:
+        record_id: Airtable record ID (e.g., "recXXXXXXXX")
+        fields: Dict of {Airtable column name: value} to write
+
+    Returns:
+        Tuple of (success: bool, message_or_error: str)
+    """
+    if not AIRTABLE_API_KEY:
+        return False, "AIRTABLE_API_KEY not configured"
+
+    url = f"{AIRTABLE_API_BASE}/{AIRTABLE_BASE_ID}/{AIRTABLE_TABLE_ID}/{record_id}"
+    headers = {
+        "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {"fields": fields}
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.patch(url, headers=headers, json=payload)
+            if response.status_code == 200:
+                return True, response.json()
+            return False, f"Airtable returned {response.status_code}: {response.text}"
+    except Exception as e:
+        return False, f"Error writing to Airtable: {e}"
+
+
+async def post_sst_comment(record_id: str, text: str) -> bool:
+    """Post a comment on an Airtable SST record for audit trail.
+
+    Args:
+        record_id: Airtable record ID
+        text: Comment text
+
+    Returns:
+        True if comment was posted successfully, False otherwise.
+    """
+    if not AIRTABLE_API_KEY:
+        return False
+
+    url = f"{AIRTABLE_API_BASE}/{AIRTABLE_BASE_ID}/{AIRTABLE_TABLE_ID}/{record_id}/comments"
+    headers = {
+        "Authorization": f"Bearer {AIRTABLE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {"text": text}
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            return response.status_code == 200
+    except Exception:
+        return False
 
 
 # =============================================================================

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -539,6 +539,17 @@ async def list_tools() -> list[Tool]:
                 "required": ["media_id"],
             },
         ),
+        Tool(
+            name="list_project_files",
+            description="List all files in a project folder. Shows deliverables, revisions, keyword reports, and any uploaded files (e.g., SEMRush CSVs).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project_name": {"type": "string", "description": "The project ID (e.g., '2WLI1209HD')"},
+                },
+                "required": ["project_name"],
+            },
+        ),
     ]
 
 
@@ -764,6 +775,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_get_sst_metadata(arguments)
     elif name == "submit_processing_job":
         return await handle_submit_processing_job(arguments)
+    elif name == "list_project_files":
+        return await handle_list_project_files(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -1555,6 +1568,77 @@ async def handle_submit_processing_job(arguments: dict) -> list[TextContent]:
 
     except Exception as e:
         return [TextContent(type="text", text=f"Error submitting job: {e}")]
+
+
+async def handle_list_project_files(arguments: dict) -> list[TextContent]:
+    """List all files in a project folder with friendly grouping."""
+    project_name = arguments.get("project_name")
+    if not project_name:
+        return [TextContent(type="text", text="Error: project_name is required")]
+
+    project_path = get_project_path(project_name)
+    if not project_path.exists():
+        return [TextContent(type="text", text=f"Error: Project '{project_name}' not found in OUTPUT/")]
+
+    # Collect all files recursively
+    all_files = []
+    for file in sorted(project_path.rglob("*")):
+        if file.is_file():
+            rel_path = file.relative_to(project_path)
+            size = file.stat().st_size
+            all_files.append((str(rel_path), size))
+
+    if not all_files:
+        return [TextContent(type="text", text=f"# Files in {project_name}\n\n(empty folder)")]
+
+    # Group files
+    deliverables = []
+    revisions = []
+    keyword_reports = []
+    other = []
+
+    for rel_path, size in all_files:
+        filename = Path(rel_path).name
+        size_str = f"{size:,} bytes" if size < 1024 else f"{size / 1024:.1f} KB"
+        entry = f"- `{rel_path}` ({size_str})"
+        label = get_artifact_label(filename)
+        if label != filename:
+            entry = f"- `{rel_path}` — {label} ({size_str})"
+
+        if "copy_revision_v" in filename:
+            revisions.append(entry)
+        elif "keyword_report_v" in filename:
+            keyword_reports.append(entry)
+        elif filename in ARTIFACT_LABELS:
+            deliverables.append(entry)
+        else:
+            other.append(entry)
+
+    lines = [f"# Files in {project_name}\n"]
+
+    if deliverables:
+        lines.append("## Pipeline Deliverables")
+        lines.extend(deliverables)
+        lines.append("")
+
+    if revisions:
+        lines.append(f"## Copy Revisions ({len(revisions)})")
+        lines.extend(revisions)
+        lines.append("")
+
+    if keyword_reports:
+        lines.append(f"## Keyword Reports ({len(keyword_reports)})")
+        lines.extend(keyword_reports)
+        lines.append("")
+
+    if other:
+        lines.append("## Other Files")
+        lines.extend(other)
+        lines.append("")
+
+    lines.append(f"**Total:** {len(all_files)} files")
+
+    return [TextContent(type="text", text="\n".join(lines))]
 
 
 # =============================================================================

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -636,6 +636,25 @@ async def list_tools() -> list[Tool]:
                 "required": ["project_name"],
             },
         ),
+        Tool(
+            name="propose_sst_edit",
+            description="Stage a proposed edit to an Airtable SST field. Does NOT write to Airtable yet — just stages the change locally for review. Call review_proposed_edits to see all staged changes, then commit_sst_edits to write them.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "media_id": {"type": "string", "description": "The Media ID / project name"},
+                    "field": {
+                        "type": "string",
+                        "enum": ["title", "short_description", "long_description", "keywords",
+                                 "social_description", "social_tags", "facebook_description", "hashtags"],
+                        "description": "Which metadata field to edit",
+                    },
+                    "proposed_value": {"type": "string", "description": "The new value for this field"},
+                    "reason": {"type": "string", "description": "Why this change is being made (for audit trail)"},
+                },
+                "required": ["media_id", "field", "proposed_value", "reason"],
+            },
+        ),
     ]
 
 
@@ -865,6 +884,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_list_project_files(arguments)
     elif name == "list_revisions":
         return await handle_list_revisions(arguments)
+    elif name == "propose_sst_edit":
+        return await handle_propose_sst_edit(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -1781,6 +1802,82 @@ async def handle_list_revisions(arguments: dict) -> list[TextContent]:
         lines.append("")
 
     lines.append("Use `read_project_file(project_name, filename)` to read any revision.")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_propose_sst_edit(arguments: dict) -> list[TextContent]:
+    """Stage a proposed edit to an Airtable SST field."""
+    media_id = arguments.get("media_id")
+    field = arguments.get("field")
+    proposed_value = arguments.get("proposed_value")
+    reason = arguments.get("reason")
+
+    if not all([media_id, field, proposed_value, reason]):
+        return [TextContent(type="text", text="Error: media_id, field, proposed_value, and reason are all required.")]
+
+    # Enforce allowlist
+    if field not in WRITABLE_FIELDS:
+        allowed = ", ".join(sorted(WRITABLE_FIELDS.keys()))
+        return [TextContent(type="text", text=f"Error: Field '{field}' is not writable. Allowed fields: {allowed}")]
+
+    airtable_column, field_id, char_limit = WRITABLE_FIELDS[field]
+
+    # Fetch current value from Airtable
+    sst_data = await search_sst_by_media_id(media_id)
+    if not sst_data:
+        return [TextContent(type="text", text=f"Error: No SST record found for Media ID '{media_id}'")]
+
+    record_id = sst_data.get("record_id")
+    current_value = sst_data.get(field, "")
+
+    # Validate character limit
+    length = len(proposed_value)
+    limit_status = ""
+    if char_limit:
+        if length <= char_limit:
+            limit_status = f" ({length}/{char_limit} chars ✅)"
+        else:
+            limit_status = f" ({length}/{char_limit} chars ❌ OVER LIMIT by {length - char_limit})"
+    else:
+        limit_status = f" ({length} chars)"
+
+    # Stage in manifest
+    project_path, was_created = ensure_project_folder(media_id)
+    manifest = load_manifest(media_id) or {
+        "project_name": media_id,
+        "origin": "editor",
+        "created_at": datetime.now().isoformat(),
+        "phases": [],
+        "outputs": {},
+    }
+
+    if "proposed_edits" not in manifest:
+        manifest["proposed_edits"] = {}
+
+    manifest["proposed_edits"][field] = {
+        "airtable_column": airtable_column,
+        "current_value": current_value or "",
+        "proposed_value": proposed_value,
+        "reason": reason,
+        "record_id": record_id,
+        "staged_at": datetime.now().isoformat(),
+    }
+    save_manifest(media_id, manifest)
+
+    # Build response
+    current_display = current_value or "(empty)"
+    staged_count = len(manifest["proposed_edits"])
+
+    lines = [
+        f"# Proposed Edit: {airtable_column}\n",
+        f"**Current:** {current_display}",
+        f"**Proposed:** {proposed_value}{limit_status}",
+        f"**Reason:** {reason}",
+        f"\n✅ Staged in manifest ({staged_count} edit{'s' if staged_count != 1 else ''} pending)",
+        f"\nUse `review_proposed_edits(\"{media_id}\")` to see all pending changes.",
+        f"Use `commit_sst_edits(\"{media_id}\")` when ready to write to Airtable.",
+    ]
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -655,6 +655,17 @@ async def list_tools() -> list[Tool]:
                 "required": ["media_id", "field", "proposed_value", "reason"],
             },
         ),
+        Tool(
+            name="review_proposed_edits",
+            description="Show all staged Airtable edits for a project in a diff format. Use this to preview changes before committing with commit_sst_edits.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "media_id": {"type": "string", "description": "The Media ID / project name"},
+                },
+                "required": ["media_id"],
+            },
+        ),
     ]
 
 
@@ -886,6 +897,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_list_revisions(arguments)
     elif name == "propose_sst_edit":
         return await handle_propose_sst_edit(arguments)
+    elif name == "review_proposed_edits":
+        return await handle_review_proposed_edits(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -1878,6 +1891,48 @@ async def handle_propose_sst_edit(arguments: dict) -> list[TextContent]:
         f"\nUse `review_proposed_edits(\"{media_id}\")` to see all pending changes.",
         f"Use `commit_sst_edits(\"{media_id}\")` when ready to write to Airtable.",
     ]
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_review_proposed_edits(arguments: dict) -> list[TextContent]:
+    """Show all staged Airtable edits for a project."""
+    media_id = arguments.get("media_id")
+    if not media_id:
+        return [TextContent(type="text", text="Error: media_id is required")]
+
+    manifest = load_manifest(media_id)
+    proposed = manifest.get("proposed_edits", {}) if manifest else {}
+
+    if not proposed:
+        return [TextContent(type="text", text=f"# Proposed Edits for {media_id}\n\nNo pending edits. Use `propose_sst_edit` to stage changes.")]
+
+    lines = [f"# Proposed Edits for {media_id}\n"]
+    lines.append(f"**{len(proposed)} edit{'s' if len(proposed) != 1 else ''} staged**\n")
+
+    for field_key, edit in proposed.items():
+        airtable_column = edit.get("airtable_column", field_key)
+        current = edit.get("current_value", "(empty)") or "(empty)"
+        proposed_val = edit.get("proposed_value", "")
+        reason = edit.get("reason", "")
+
+        limit_info = ""
+        if field_key in WRITABLE_FIELDS:
+            _, _, char_limit = WRITABLE_FIELDS[field_key]
+            if char_limit:
+                length = len(proposed_val)
+                status = "✅" if length <= char_limit else f"❌ OVER by {length - char_limit}"
+                limit_info = f" ({length}/{char_limit} {status})"
+
+        lines.append(f"## {airtable_column}")
+        lines.append(f"**Current:** {current}")
+        lines.append(f"**Proposed:** {proposed_val}{limit_info}")
+        lines.append(f"**Reason:** {reason}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(f"Use `commit_sst_edits(\"{media_id}\")` to write these changes to Airtable.")
+    lines.append("Use `propose_sst_edit` to modify or add more changes.")
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1075,33 +1075,47 @@ async def handle_save_keyword_report(arguments: dict) -> list[TextContent]:
     if not project_name or not content:
         return [TextContent(type="text", text="Error: project_name and content are required")]
 
+    try:
+        result = await asyncio.wait_for(
+            asyncio.to_thread(_save_keyword_report_sync, project_name, content),
+            timeout=15.0,
+        )
+        return [TextContent(type="text", text=result)]
+    except asyncio.TimeoutError:
+        return [
+            TextContent(
+                type="text",
+                text=f"Error: Save timed out after 15 seconds for project '{project_name}'. "
+                "The file system may be slow or unresponsive. Please retry.",
+            )
+        ]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error saving keyword report: {e}")]
+
+
+def _save_keyword_report_sync(project_name: str, content: str) -> str:
+    """Synchronous file write for save_keyword_report, run in a thread."""
     project_path, was_created = ensure_project_folder(project_name)
 
-    # Get next version number
     version = get_next_version(project_path, "keyword_report")
     filename = f"keyword_report_v{version}.md"
     filepath = project_path / filename
 
-    # Save the file
     filepath.write_text(content)
 
-    # Update manifest
     manifest = load_manifest(project_name)
     if manifest:
         if "keyword_reports" not in manifest:
             manifest["keyword_reports"] = []
-        manifest["keyword_reports"].append(
-            {"version": version, "filename": filename, "saved_at": datetime.now().isoformat()}
-        )
+        manifest["keyword_reports"].append({
+            "version": version,
+            "filename": filename,
+            "saved_at": datetime.now().isoformat(),
+        })
         save_manifest(project_name, manifest)
 
     created_note = f"\n📁 New project folder created for '{project_name}'" if was_created else ""
-    return [
-        TextContent(
-            type="text",
-            text=f"✅ Saved keyword report as `{filename}` in OUTPUT/{project_name}/\n\nVersion: v{version}\nPath: {filepath}{created_note}",
-        )
-    ]
+    return f"✅ Saved keyword report as `{filename}` in OUTPUT/{project_name}/\n\nVersion: v{version}\nPath: {filepath}{created_note}"
 
 
 async def handle_get_project_summary(arguments: dict) -> list[TextContent]:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -494,6 +494,19 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="validate_copy",
+            description="Validate metadata field lengths against PBS character limits. Returns counts and pass/fail for each field. Use before finalizing any revision.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Release title to validate (limit: 80 chars)"},
+                    "short_description": {"type": "string", "description": "Short description to validate (limit: 100 chars)"},
+                    "long_description": {"type": "string", "description": "Long description to validate (limit: 350 chars)"},
+                    "keywords": {"type": "string", "description": "Keywords string to validate (optional, returns count)"},
+                },
+            },
+        ),
+        Tool(
             name="get_sst_metadata",
             description="Fetch current metadata from Airtable SST (Single Source of Truth) by Media ID. Returns title, descriptions, keywords, and character count status. Use this to get the LIVE Airtable data for a project.",
             inputSchema={
@@ -745,6 +758,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_read_project_file(arguments)
     elif name == "search_projects":
         return await handle_search_projects(arguments)
+    elif name == "validate_copy":
+        return await handle_validate_copy(arguments)
     elif name == "get_sst_metadata":
         return await handle_get_sst_metadata(arguments)
     elif name == "submit_processing_job":
@@ -1372,6 +1387,46 @@ async def handle_get_sst_metadata(arguments: dict) -> list[TextContent]:
 
     if sst_data.get("program"):
         lines.append(f"**Episode/Segment:** {sst_data['program']}")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_validate_copy(arguments: dict) -> list[TextContent]:
+    """Validate metadata field lengths against PBS character limits."""
+    LIMITS = {
+        "title": 80,
+        "short_description": 100,
+        "long_description": 350,
+    }
+
+    title = arguments.get("title")
+    short_description = arguments.get("short_description")
+    long_description = arguments.get("long_description")
+    keywords = arguments.get("keywords")
+
+    if not any([title, short_description, long_description, keywords]):
+        return [TextContent(type="text", text="Error: At least one field (title, short_description, long_description, or keywords) is required.")]
+
+    lines = ["# Copy Validation Results\n"]
+    all_valid = True
+
+    for field_name, limit in LIMITS.items():
+        value = arguments.get(field_name)
+        if value is not None:
+            length = len(value)
+            valid = length <= limit
+            status = "✅" if valid else f"❌ OVER LIMIT by {length - limit}"
+            if not valid:
+                all_valid = False
+            lines.append(f"**{field_name.replace('_', ' ').title()}:** {length}/{limit} chars {status}")
+        else:
+            lines.append(f"**{field_name.replace('_', ' ').title()}:** (not provided)")
+
+    if keywords is not None:
+        keyword_list = [k.strip() for k in keywords.split(",") if k.strip()]
+        lines.append(f"\n**Keywords:** {len(keyword_list)} keywords provided")
+
+    lines.append(f"\n**All valid:** {'✅ Yes' if all_valid else '❌ No — fix fields marked OVER LIMIT'}")
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -576,9 +576,18 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "title": {"type": "string", "description": "Release title to validate (limit: 80 chars)"},
-                    "short_description": {"type": "string", "description": "Short description to validate (limit: 100 chars)"},
-                    "long_description": {"type": "string", "description": "Long description to validate (limit: 350 chars)"},
-                    "keywords": {"type": "string", "description": "Keywords string to validate (optional, returns count)"},
+                    "short_description": {
+                        "type": "string",
+                        "description": "Short description to validate (limit: 100 chars)",
+                    },
+                    "long_description": {
+                        "type": "string",
+                        "description": "Long description to validate (limit: 350 chars)",
+                    },
+                    "keywords": {
+                        "type": "string",
+                        "description": "Keywords string to validate (optional, returns count)",
+                    },
                 },
             },
         ),
@@ -646,8 +655,16 @@ async def list_tools() -> list[Tool]:
                     "media_id": {"type": "string", "description": "The Media ID / project name"},
                     "field": {
                         "type": "string",
-                        "enum": ["title", "short_description", "long_description", "keywords",
-                                 "social_description", "social_tags", "facebook_description", "hashtags"],
+                        "enum": [
+                            "title",
+                            "short_description",
+                            "long_description",
+                            "keywords",
+                            "social_description",
+                            "social_tags",
+                            "facebook_description",
+                            "hashtags",
+                        ],
                         "description": "Which metadata field to edit",
                     },
                     "proposed_value": {"type": "string", "description": "The new value for this field"},
@@ -1220,11 +1237,13 @@ def _save_revision_sync(project_name: str, content: str) -> str:
     if manifest:
         if "revisions" not in manifest:
             manifest["revisions"] = []
-        manifest["revisions"].append({
-            "version": version,
-            "filename": filename,
-            "saved_at": datetime.now().isoformat(),
-        })
+        manifest["revisions"].append(
+            {
+                "version": version,
+                "filename": filename,
+                "saved_at": datetime.now().isoformat(),
+            }
+        )
         save_manifest(project_name, manifest)
 
     created_note = f"\n📁 New project folder created for '{project_name}'" if was_created else ""
@@ -1271,11 +1290,13 @@ def _save_keyword_report_sync(project_name: str, content: str) -> str:
     if manifest:
         if "keyword_reports" not in manifest:
             manifest["keyword_reports"] = []
-        manifest["keyword_reports"].append({
-            "version": version,
-            "filename": filename,
-            "saved_at": datetime.now().isoformat(),
-        })
+        manifest["keyword_reports"].append(
+            {
+                "version": version,
+                "filename": filename,
+                "saved_at": datetime.now().isoformat(),
+            }
+        )
         save_manifest(project_name, manifest)
 
     created_note = f"\n📁 New project folder created for '{project_name}'" if was_created else ""
@@ -1554,7 +1575,12 @@ async def handle_validate_copy(arguments: dict) -> list[TextContent]:
     keywords = arguments.get("keywords")
 
     if not any([title, short_description, long_description, keywords]):
-        return [TextContent(type="text", text="Error: At least one field (title, short_description, long_description, or keywords) is required.")]
+        return [
+            TextContent(
+                type="text",
+                text="Error: At least one field (title, short_description, long_description, or keywords) is required.",
+            )
+        ]
 
     lines = ["# Copy Validation Results\n"]
     all_valid = True
@@ -1792,7 +1818,11 @@ async def handle_list_revisions(arguments: dict) -> list[TextContent]:
     keyword_reports = manifest.get("keyword_reports", []) if manifest else []
 
     if not revisions and not keyword_reports:
-        return [TextContent(type="text", text=f"# Revision History for {project_name}\n\nNo revisions or keyword reports saved yet.")]
+        return [
+            TextContent(
+                type="text", text=f"# Revision History for {project_name}\n\nNo revisions or keyword reports saved yet."
+            )
+        ]
 
     lines = [f"# Revision History for {project_name}\n"]
 
@@ -1902,8 +1932,8 @@ async def handle_propose_sst_edit(arguments: dict) -> list[TextContent]:
         f"**Proposed:** {proposed_value}{limit_status}",
         f"**Reason:** {reason}",
         f"\n✅ Staged in manifest ({staged_count} edit{'s' if staged_count != 1 else ''} pending)",
-        f"\nUse `review_proposed_edits(\"{media_id}\")` to see all pending changes.",
-        f"Use `commit_sst_edits(\"{media_id}\")` when ready to write to Airtable.",
+        f'\nUse `review_proposed_edits("{media_id}")` to see all pending changes.',
+        f'Use `commit_sst_edits("{media_id}")` when ready to write to Airtable.',
     ]
 
     return [TextContent(type="text", text="\n".join(lines))]
@@ -1919,7 +1949,12 @@ async def handle_review_proposed_edits(arguments: dict) -> list[TextContent]:
     proposed = manifest.get("proposed_edits", {}) if manifest else {}
 
     if not proposed:
-        return [TextContent(type="text", text=f"# Proposed Edits for {media_id}\n\nNo pending edits. Use `propose_sst_edit` to stage changes.")]
+        return [
+            TextContent(
+                type="text",
+                text=f"# Proposed Edits for {media_id}\n\nNo pending edits. Use `propose_sst_edit` to stage changes.",
+            )
+        ]
 
     lines = [f"# Proposed Edits for {media_id}\n"]
     lines.append(f"**{len(proposed)} edit{'s' if len(proposed) != 1 else ''} staged**\n")
@@ -1945,7 +1980,7 @@ async def handle_review_proposed_edits(arguments: dict) -> list[TextContent]:
         lines.append("")
 
     lines.append("---")
-    lines.append(f"Use `commit_sst_edits(\"{media_id}\")` to write these changes to Airtable.")
+    lines.append(f'Use `commit_sst_edits("{media_id}")` to write these changes to Airtable.')
     lines.append("Use `propose_sst_edit` to modify or add more changes.")
 
     return [TextContent(type="text", text="\n".join(lines))]
@@ -1961,7 +1996,11 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
     proposed = manifest.get("proposed_edits", {}) if manifest else {}
 
     if not proposed:
-        return [TextContent(type="text", text=f"No pending edits for {media_id}. Use `propose_sst_edit` to stage changes first.")]
+        return [
+            TextContent(
+                type="text", text=f"No pending edits for {media_id}. Use `propose_sst_edit` to stage changes first."
+            )
+        ]
 
     # All proposals should reference the same record
     record_id = None
@@ -1976,7 +2015,12 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
     # Optimistic concurrency check: re-fetch current values
     current_data = await fetch_sst_context(record_id)
     if not current_data:
-        return [TextContent(type="text", text="Error: Could not re-fetch Airtable record for concurrency check. Record may have been deleted.")]
+        return [
+            TextContent(
+                type="text",
+                text="Error: Could not re-fetch Airtable record for concurrency check. Record may have been deleted.",
+            )
+        ]
 
     # Check for conflicts
     conflicts = []
@@ -2011,7 +2055,12 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
     # Write to Airtable
     success, result = await patch_sst_record(record_id, patch_fields)
     if not success:
-        return [TextContent(type="text", text=f"Error writing to Airtable: {result}\n\nYour staged edits are still saved. You can retry with `commit_sst_edits(\"{media_id}\")`.")]
+        return [
+            TextContent(
+                type="text",
+                text=f'Error writing to Airtable: {result}\n\nYour staged edits are still saved. You can retry with `commit_sst_edits("{media_id}")`.',
+            )
+        ]
 
     # Post audit comment
     comment_lines = ["📝 Agent edit (Cardigan copy editor)\n\nFields updated:"]

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -19,7 +19,8 @@ Tools provided:
 Connects to the FastAPI backend on localhost:8000 for job metadata,
 and reads/writes directly to the OUTPUT folder for content.
 
-NOTE: Airtable access is READ-ONLY. No write operations are permitted.
+NOTE: Airtable writes are restricted to allowlisted fields via the
+propose/review/commit workflow. See WRITABLE_FIELDS for the allowlist.
 """
 
 import asyncio

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -666,6 +666,17 @@ async def list_tools() -> list[Tool]:
                 "required": ["media_id"],
             },
         ),
+        Tool(
+            name="commit_sst_edits",
+            description="Write all staged edits to Airtable. Checks that no fields were changed since proposal (optimistic concurrency). Posts an audit comment on the record. ALWAYS show the user the output of review_proposed_edits before calling this.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "media_id": {"type": "string", "description": "The Media ID / project name"},
+                },
+                "required": ["media_id"],
+            },
+        ),
     ]
 
 
@@ -899,6 +910,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_propose_sst_edit(arguments)
     elif name == "review_proposed_edits":
         return await handle_review_proposed_edits(arguments)
+    elif name == "commit_sst_edits":
+        return await handle_commit_sst_edits(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -1933,6 +1946,98 @@ async def handle_review_proposed_edits(arguments: dict) -> list[TextContent]:
     lines.append("---")
     lines.append(f"Use `commit_sst_edits(\"{media_id}\")` to write these changes to Airtable.")
     lines.append("Use `propose_sst_edit` to modify or add more changes.")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
+    """Write all staged edits to Airtable with concurrency checking and audit."""
+    media_id = arguments.get("media_id")
+    if not media_id:
+        return [TextContent(type="text", text="Error: media_id is required")]
+
+    manifest = load_manifest(media_id)
+    proposed = manifest.get("proposed_edits", {}) if manifest else {}
+
+    if not proposed:
+        return [TextContent(type="text", text=f"No pending edits for {media_id}. Use `propose_sst_edit` to stage changes first.")]
+
+    # All proposals should reference the same record
+    record_id = None
+    for edit in proposed.values():
+        record_id = edit.get("record_id")
+        if record_id:
+            break
+
+    if not record_id:
+        return [TextContent(type="text", text="Error: No Airtable record ID found in staged edits.")]
+
+    # Optimistic concurrency check: re-fetch current values
+    current_data = await fetch_sst_context(record_id)
+    if not current_data:
+        return [TextContent(type="text", text="Error: Could not re-fetch Airtable record for concurrency check. Record may have been deleted.")]
+
+    # Check for conflicts
+    conflicts = []
+    for field_key, edit in proposed.items():
+        expected_current = edit.get("current_value", "")
+        actual_current = current_data.get(field_key, "") or ""
+        if expected_current != actual_current:
+            airtable_column = edit.get("airtable_column", field_key)
+            conflicts.append(
+                f"**{airtable_column}:**\n"
+                f"  Expected: {expected_current or '(empty)'}\n"
+                f"  Actual now: {actual_current or '(empty)'}"
+            )
+
+    if conflicts:
+        lines = [
+            f"# ⚠️ Concurrency Conflict for {media_id}\n",
+            "The following fields were changed in Airtable since you staged your edits:\n",
+            *conflicts,
+            "\n**Your staged edits were NOT applied.**",
+            "Please review the current values, then use `propose_sst_edit` to re-stage with updated context.",
+        ]
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    # Build the PATCH payload using Airtable column names
+    patch_fields = {}
+    for field_key, edit in proposed.items():
+        airtable_column = edit.get("airtable_column")
+        if airtable_column:
+            patch_fields[airtable_column] = edit["proposed_value"]
+
+    # Write to Airtable
+    success, result = await patch_sst_record(record_id, patch_fields)
+    if not success:
+        return [TextContent(type="text", text=f"Error writing to Airtable: {result}\n\nYour staged edits are still saved. You can retry with `commit_sst_edits(\"{media_id}\")`.")]
+
+    # Post audit comment
+    comment_lines = ["📝 Agent edit (Cardigan copy editor)\n\nFields updated:"]
+    for field_key, edit in proposed.items():
+        airtable_column = edit.get("airtable_column", field_key)
+        old = edit.get("current_value", "(empty)") or "(empty)"
+        new = edit.get("proposed_value", "")
+        reason = edit.get("reason", "")
+        comment_lines.append(f'- {airtable_column}: "{old}" → "{new}" ({reason})')
+    comment_lines.append(f"\nSession: {datetime.now().isoformat()}")
+
+    await post_sst_comment(record_id, "\n".join(comment_lines))
+
+    # Clear proposed edits from manifest
+    manifest["proposed_edits"] = {}
+    save_manifest(media_id, manifest)
+
+    # Build confirmation response
+    lines = [f"# ✅ Airtable Updated for {media_id}\n"]
+    for field_key, edit in proposed.items():
+        airtable_column = edit.get("airtable_column", field_key)
+        old = edit.get("current_value", "(empty)") or "(empty)"
+        new = edit.get("proposed_value", "")
+        lines.append(f"**{airtable_column}:** {old} → {new}")
+
+    lines.append(f"\n📝 Audit comment posted on record `{record_id}`")
+    lines.append(f"✅ {len(proposed)} field{'s' if len(proposed) != 1 else ''} written successfully")
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mcp_server.server import handle_save_revision
+from mcp_server.server import handle_save_keyword_report, handle_save_revision
 
 
 @pytest.fixture
@@ -98,6 +98,43 @@ async def test_save_revision_completes_within_timeout(project_with_manifest):
             "project_name": project_name,
             "content": "Timeout test content",
         }),
+        timeout=5.0,
+    )
+    assert "✅" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_save_keyword_report_succeeds(project_with_manifest):
+    """save_keyword_report should write a file and update manifest."""
+    project_name, project_path = project_with_manifest
+    result = await handle_save_keyword_report({
+        "project_name": project_name,
+        "content": "# Keywords\nTest keyword report.",
+    })
+    assert "✅" in result[0].text
+    assert "keyword_report_v1.md" in result[0].text
+
+    assert (project_path / "keyword_report_v1.md").exists()
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert len(manifest["keyword_reports"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_keyword_report_auto_versions(project_with_manifest):
+    """save_keyword_report should auto-increment version numbers."""
+    project_name, project_path = project_with_manifest
+
+    await handle_save_keyword_report({"project_name": project_name, "content": "Report 1"})
+    result = await handle_save_keyword_report({"project_name": project_name, "content": "Report 2"})
+    assert "keyword_report_v2.md" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_save_keyword_report_completes_within_timeout(project_with_manifest):
+    """save_keyword_report should complete within a reasonable time."""
+    project_name, _ = project_with_manifest
+    result = await asyncio.wait_for(
+        handle_save_keyword_report({"project_name": project_name, "content": "Timeout test"}),
         timeout=5.0,
     )
     assert "✅" in result[0].text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -533,3 +533,101 @@ async def test_review_proposed_edits_empty(project_with_manifest):
     result = await handle_review_proposed_edits({"media_id": project_name})
     text = result[0].text
     assert "no" in text.lower() or "No" in text
+
+
+@pytest.mark.asyncio
+async def test_commit_sst_edits_writes_and_comments(project_with_manifest, monkeypatch):
+    """commit_sst_edits should PATCH Airtable and post an audit comment."""
+    from mcp_server.server import handle_commit_sst_edits, handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, project_path = project_with_manifest
+    await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "title",
+        "proposed_value": "New Title",
+        "reason": "SEO",
+    })
+
+    # Mock concurrency re-fetch (returns same value as when proposed — no conflict)
+    async def mock_fetch(record_id):
+        return {"record_id": "recTEST123", "title": "Old Title"}
+
+    monkeypatch.setattr("mcp_server.server.fetch_sst_context", mock_fetch)
+
+    # Mock the write
+    async def mock_patch(record_id, fields):
+        return True, {"id": record_id, "fields": fields}
+
+    monkeypatch.setattr("mcp_server.server.patch_sst_record", mock_patch)
+
+    # Mock the comment
+    comment_posted = []
+
+    async def mock_comment(record_id, text):
+        comment_posted.append(text)
+        return True
+
+    monkeypatch.setattr("mcp_server.server.post_sst_comment", mock_comment)
+
+    result = await handle_commit_sst_edits({"media_id": project_name})
+    text = result[0].text
+
+    assert "✅" in text
+    assert "New Title" in text
+    assert len(comment_posted) == 1
+    assert "Old Title" in comment_posted[0]
+    assert "New Title" in comment_posted[0]
+
+    # Verify proposed_edits cleared from manifest
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert manifest.get("proposed_edits", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_commit_sst_edits_concurrency_conflict(project_with_manifest, monkeypatch):
+    """commit_sst_edits should refuse if Airtable values changed since proposal."""
+    from mcp_server.server import handle_commit_sst_edits, handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, project_path = project_with_manifest
+    await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "title",
+        "proposed_value": "New Title",
+        "reason": "SEO",
+    })
+
+    # Mock concurrency re-fetch — returns DIFFERENT value (someone edited Airtable)
+    async def mock_fetch(record_id):
+        return {"record_id": "recTEST123", "title": "Manually Edited Title"}
+
+    monkeypatch.setattr("mcp_server.server.fetch_sst_context", mock_fetch)
+
+    result = await handle_commit_sst_edits({"media_id": project_name})
+    text = result[0].text
+
+    assert "conflict" in text.lower() or "changed" in text.lower()
+    assert "Manually Edited Title" in text
+
+    # Verify proposed_edits NOT cleared (user can re-propose)
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert "title" in manifest.get("proposed_edits", {})
+
+
+@pytest.mark.asyncio
+async def test_commit_sst_edits_no_pending(project_with_manifest):
+    """commit_sst_edits should report no pending edits."""
+    from mcp_server.server import handle_commit_sst_edits
+
+    project_name, _ = project_with_manifest
+    result = await handle_commit_sst_edits({"media_id": project_name})
+    assert "no" in result[0].text.lower() or "No" in result[0].text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -394,3 +394,99 @@ async def test_post_sst_comment_success(output_dir, monkeypatch):
 
     success = await post_sst_comment("recTEST123", "Test comment")
     assert success is True
+
+
+@pytest.mark.asyncio
+async def test_propose_sst_edit_stages_in_manifest(project_with_manifest, monkeypatch):
+    """propose_sst_edit should store the proposal in manifest.json."""
+    from mcp_server.server import handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title", "short_description": "Old short"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, project_path = project_with_manifest
+    result = await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "title",
+        "proposed_value": "Wisconsin Life | New Title Here",
+        "reason": "SEO improvement",
+    })
+    text = result[0].text
+    assert "Wisconsin Life | New Title Here" in text
+    assert "✅" in text  # under 80 char limit
+
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert "proposed_edits" in manifest
+    assert "title" in manifest["proposed_edits"]
+    assert manifest["proposed_edits"]["title"]["proposed_value"] == "Wisconsin Life | New Title Here"
+    assert manifest["proposed_edits"]["title"]["current_value"] == "Old Title"
+    assert manifest["proposed_edits"]["title"]["record_id"] == "recTEST123"
+
+
+@pytest.mark.asyncio
+async def test_propose_sst_edit_rejects_disallowed_field(project_with_manifest, monkeypatch):
+    """propose_sst_edit should reject fields not in the allowlist."""
+    from mcp_server.server import handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, _ = project_with_manifest
+    result = await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "status",
+        "proposed_value": "Complete",
+        "reason": "Done",
+    })
+    assert "not writable" in result[0].text.lower() or "not allowed" in result[0].text.lower() or "allowed fields" in result[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_propose_sst_edit_warns_over_limit(project_with_manifest, monkeypatch):
+    """propose_sst_edit should warn when proposed value exceeds character limit."""
+    from mcp_server.server import handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, _ = project_with_manifest
+    result = await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "title",
+        "proposed_value": "X" * 85,
+        "reason": "Testing",
+    })
+    text = result[0].text
+    assert "❌" in text or "OVER" in text
+
+
+@pytest.mark.asyncio
+async def test_propose_sst_edit_multiple_fields(project_with_manifest, monkeypatch):
+    """propose_sst_edit should allow staging multiple fields."""
+    from mcp_server.server import handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title", "short_description": "Old short"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, project_path = project_with_manifest
+
+    await handle_propose_sst_edit({
+        "media_id": project_name, "field": "title",
+        "proposed_value": "New Title", "reason": "Better",
+    })
+    await handle_propose_sst_edit({
+        "media_id": project_name, "field": "short_description",
+        "proposed_value": "New short desc", "reason": "Clearer",
+    })
+
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert "title" in manifest["proposed_edits"]
+    assert "short_description" in manifest["proposed_edits"]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -490,3 +490,46 @@ async def test_propose_sst_edit_multiple_fields(project_with_manifest, monkeypat
     manifest = json.loads((project_path / "manifest.json").read_text())
     assert "title" in manifest["proposed_edits"]
     assert "short_description" in manifest["proposed_edits"]
+
+
+@pytest.mark.asyncio
+async def test_review_proposed_edits_shows_diff(project_with_manifest, monkeypatch):
+    """review_proposed_edits should show current vs proposed for all staged edits."""
+    from mcp_server.server import handle_propose_sst_edit, handle_review_proposed_edits
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title", "short_description": "Old short"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, _ = project_with_manifest
+
+    await handle_propose_sst_edit({
+        "media_id": project_name, "field": "title",
+        "proposed_value": "New Title", "reason": "Better SEO",
+    })
+    await handle_propose_sst_edit({
+        "media_id": project_name, "field": "short_description",
+        "proposed_value": "New short", "reason": "Clearer",
+    })
+
+    result = await handle_review_proposed_edits({"media_id": project_name})
+    text = result[0].text
+
+    assert "Old Title" in text
+    assert "New Title" in text
+    assert "Old short" in text
+    assert "New short" in text
+    assert "Better SEO" in text
+    assert "2" in text  # 2 edits
+
+
+@pytest.mark.asyncio
+async def test_review_proposed_edits_empty(project_with_manifest):
+    """review_proposed_edits should report no pending edits."""
+    from mcp_server.server import handle_review_proposed_edits
+
+    project_name, _ = project_with_manifest
+    result = await handle_review_proposed_edits({"media_id": project_name})
+    text = result[0].text
+    assert "no" in text.lower() or "No" in text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -205,3 +205,52 @@ async def test_validate_copy_empty(output_dir):
     result = await handle_validate_copy({})
     text = result[0].text
     assert "Error" in text or "at least one" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_shows_all_files(project_with_manifest):
+    """list_project_files should return all files in the project folder."""
+    from mcp_server.server import handle_list_project_files
+
+    project_name, project_path = project_with_manifest
+
+    # Add some extra files to simulate a real project
+    (project_path / "copy_revision_v1.md").write_text("Revision 1")
+    (project_path / "keyword_report_v1.md").write_text("Keywords")
+    semrush_dir = project_path / "semrush"
+    semrush_dir.mkdir()
+    (semrush_dir / "export_2026-04-16.csv").write_text("keyword,volume\ncoffee,1000")
+
+    result = await handle_list_project_files({"project_name": project_name})
+    text = result[0].text
+
+    assert "analyst_output.md" in text
+    assert "copy_revision_v1.md" in text
+    assert "keyword_report_v1.md" in text
+    assert "export_2026-04-16.csv" in text
+    assert "manifest.json" in text
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_missing_project(output_dir):
+    """list_project_files should return error for nonexistent project."""
+    from mcp_server.server import handle_list_project_files
+
+    result = await handle_list_project_files({"project_name": "nonexistent"})
+    text = result[0].text
+    assert "not found" in text.lower() or "Error" in text
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_empty_project(output_dir):
+    """list_project_files should handle a project with only a manifest."""
+    from mcp_server.server import handle_list_project_files
+
+    project_name = "2WLIEmptyProject"
+    project_path = output_dir / project_name
+    project_path.mkdir()
+    (project_path / "manifest.json").write_text('{"project_name": "2WLIEmptyProject"}')
+
+    result = await handle_list_project_files({"project_name": project_name})
+    text = result[0].text
+    assert "manifest.json" in text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -254,3 +254,46 @@ async def test_list_project_files_empty_project(output_dir):
     result = await handle_list_project_files({"project_name": project_name})
     text = result[0].text
     assert "manifest.json" in text
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_with_history(project_with_manifest):
+    """list_revisions should show revision and keyword report history."""
+    from mcp_server.server import handle_list_revisions
+
+    project_name, project_path = project_with_manifest
+
+    # Create some revisions via the actual save tool
+    await handle_save_revision({"project_name": project_name, "content": "Rev 1"})
+    await handle_save_revision({"project_name": project_name, "content": "Rev 2"})
+    await handle_save_keyword_report({"project_name": project_name, "content": "KW 1"})
+
+    result = await handle_list_revisions({"project_name": project_name})
+    text = result[0].text
+
+    assert "v1" in text
+    assert "v2" in text
+    assert "copy_revision" in text
+    assert "keyword_report" in text
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_empty_project(project_with_manifest):
+    """list_revisions should report no revisions for a fresh project."""
+    from mcp_server.server import handle_list_revisions
+
+    project_name, _ = project_with_manifest
+
+    result = await handle_list_revisions({"project_name": project_name})
+    text = result[0].text
+    assert "no revisions" in text.lower() or "No revisions" in text
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_missing_project(output_dir):
+    """list_revisions should return error for nonexistent project."""
+    from mcp_server.server import handle_list_revisions
+
+    result = await handle_list_revisions({"project_name": "nonexistent"})
+    text = result[0].text
+    assert "not found" in text.lower() or "Error" in text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -138,3 +138,70 @@ async def test_save_keyword_report_completes_within_timeout(project_with_manifes
         timeout=5.0,
     )
     assert "✅" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_validate_copy_all_valid(output_dir):
+    """validate_copy should report all fields valid when under limits."""
+    from mcp_server.server import handle_validate_copy
+
+    result = await handle_validate_copy({
+        "title": "Wisconsin Life | Alice Good Café in Verona",
+        "short_description": "In Verona, Alice Good brews Colombian coffee and community.",
+        "long_description": "Alice Good Café in Verona is more than a coffee shop.",
+    })
+    text = result[0].text
+    assert "✅" in text
+    assert "Yes" in text  # "All valid: ✅ Yes"
+
+
+@pytest.mark.asyncio
+async def test_validate_copy_over_limit(output_dir):
+    """validate_copy should flag fields that exceed character limits."""
+    from mcp_server.server import handle_validate_copy
+
+    result = await handle_validate_copy({
+        "title": "X" * 85,
+        "short_description": "X" * 105,
+        "long_description": "OK",
+    })
+    text = result[0].text
+    assert "❌" in text
+    assert "OVER LIMIT" in text
+    assert "85" in text
+
+
+@pytest.mark.asyncio
+async def test_validate_copy_partial_fields(output_dir):
+    """validate_copy should work with only some fields provided."""
+    from mcp_server.server import handle_validate_copy
+
+    result = await handle_validate_copy({
+        "title": "Just a title",
+    })
+    text = result[0].text
+    assert "12" in text
+    assert "Error" not in text
+
+
+@pytest.mark.asyncio
+async def test_validate_copy_with_keywords(output_dir):
+    """validate_copy should count keywords when provided."""
+    from mcp_server.server import handle_validate_copy
+
+    result = await handle_validate_copy({
+        "title": "Test Title",
+        "keywords": "coffee, Verona, Wisconsin, fair trade, community",
+    })
+    text = result[0].text
+    assert "5" in text  # 5 keywords
+
+
+@pytest.mark.asyncio
+async def test_validate_copy_empty(output_dir):
+    """validate_copy should handle no fields gracefully."""
+    from mcp_server.server import handle_validate_copy
+
+    result = await handle_validate_copy({})
+    text = result[0].text
+    assert "Error" in text or "at least one" in text.lower()

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -631,3 +631,65 @@ async def test_commit_sst_edits_no_pending(project_with_manifest):
     project_name, _ = project_with_manifest
     result = await handle_commit_sst_edits({"media_id": project_name})
     assert "no" in result[0].text.lower() or "No" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_patch_sst_record_http_error(output_dir, monkeypatch):
+    """patch_sst_record should return failure on non-200 responses."""
+    from mcp_server.server import patch_sst_record
+
+    mock_response = MagicMock()
+    mock_response.status_code = 422
+    mock_response.text = "INVALID_VALUE"
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.patch = AsyncMock(return_value=mock_response)
+
+    monkeypatch.setattr("mcp_server.server.AIRTABLE_API_KEY", "fake-key")
+    monkeypatch.setattr("httpx.AsyncClient", lambda **kwargs: mock_client)
+
+    success, result = await patch_sst_record("recTEST123", {"Release Title": "X"})
+    assert success is False
+    assert "422" in result
+
+
+@pytest.mark.asyncio
+async def test_commit_sst_edits_patch_failure(project_with_manifest, monkeypatch):
+    """commit_sst_edits should report error when PATCH fails after concurrency check passes."""
+    from mcp_server.server import handle_commit_sst_edits, handle_propose_sst_edit
+
+    async def mock_search(media_id):
+        return {"record_id": "recTEST123", "title": "Old Title"}
+
+    monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
+
+    project_name, project_path = project_with_manifest
+    await handle_propose_sst_edit({
+        "media_id": project_name,
+        "field": "title",
+        "proposed_value": "New Title",
+        "reason": "SEO",
+    })
+
+    # Concurrency check passes
+    async def mock_fetch(record_id):
+        return {"record_id": "recTEST123", "title": "Old Title"}
+
+    monkeypatch.setattr("mcp_server.server.fetch_sst_context", mock_fetch)
+
+    # But PATCH fails
+    async def mock_patch(record_id, fields):
+        return False, "Airtable returned 500: Internal Server Error"
+
+    monkeypatch.setattr("mcp_server.server.patch_sst_record", mock_patch)
+
+    result = await handle_commit_sst_edits({"media_id": project_name})
+    text = result[0].text
+
+    assert "Error" in text
+    assert "500" in text
+    # Staged edits should still be preserved for retry
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert "title" in manifest.get("proposed_edits", {})

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -6,11 +6,16 @@ using a temporary OUTPUT directory to isolate filesystem operations.
 
 import asyncio
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mcp_server.server import handle_save_keyword_report, handle_save_revision
+from mcp_server.server import (
+    WRITABLE_FIELDS,
+    _extract_sst_fields,
+    handle_save_keyword_report,
+    handle_save_revision,
+)
 
 
 @pytest.fixture
@@ -297,3 +302,95 @@ async def test_list_revisions_missing_project(output_dir):
     result = await handle_list_revisions({"project_name": "nonexistent"})
     text = result[0].text
     assert "not found" in text.lower() or "Error" in text
+
+
+def test_writable_fields_allowlist():
+    """WRITABLE_FIELDS should contain exactly the approved fields."""
+    assert "title" in WRITABLE_FIELDS
+    assert "short_description" in WRITABLE_FIELDS
+    assert "long_description" in WRITABLE_FIELDS
+    assert "keywords" in WRITABLE_FIELDS
+    assert "social_description" in WRITABLE_FIELDS
+    assert "social_tags" in WRITABLE_FIELDS
+    assert "facebook_description" in WRITABLE_FIELDS
+    assert "hashtags" in WRITABLE_FIELDS
+    assert "status" not in WRITABLE_FIELDS
+    assert "producer" not in WRITABLE_FIELDS
+    assert "media_id" not in WRITABLE_FIELDS
+
+
+def test_extract_sst_fields_includes_social():
+    """_extract_sst_fields should extract social media fields."""
+    record = {
+        "id": "recTEST123",
+        "fields": {
+            "Media ID": "2WLITestSM",
+            "Release Title": "Test Title",
+            "Short Description": "Test short",
+            "Long Description": "Test long",
+            "General Keywords/Tags": "kw1, kw2",
+            "Social Media Description": "Social desc",
+            "Social Media Tags": "social tags",
+            "Facebook Description": "FB desc",
+            "Hashtags": "#test #hashtag",
+        },
+    }
+    result = _extract_sst_fields(record)
+    assert result["social_description"] == "Social desc"
+    assert result["social_tags"] == "social tags"
+    assert result["facebook_description"] == "FB desc"
+    assert result["hashtags"] == "#test #hashtag"
+
+
+@pytest.mark.asyncio
+async def test_patch_sst_record_success(output_dir, monkeypatch):
+    """patch_sst_record should PATCH the Airtable record and return True."""
+    from mcp_server.server import patch_sst_record
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "recTEST123", "fields": {"Release Title": "New Title"}}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.patch = AsyncMock(return_value=mock_response)
+
+    monkeypatch.setattr("mcp_server.server.AIRTABLE_API_KEY", "fake-key")
+    monkeypatch.setattr("httpx.AsyncClient", lambda **kwargs: mock_client)
+
+    success, result = await patch_sst_record("recTEST123", {"Release Title": "New Title"})
+    assert success is True
+    mock_client.patch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_sst_record_no_api_key(output_dir, monkeypatch):
+    """patch_sst_record should fail gracefully without an API key."""
+    from mcp_server.server import patch_sst_record
+
+    monkeypatch.setattr("mcp_server.server.AIRTABLE_API_KEY", None)
+
+    success, result = await patch_sst_record("recTEST123", {"Release Title": "New"})
+    assert success is False
+    assert "not configured" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_post_sst_comment_success(output_dir, monkeypatch):
+    """post_sst_comment should POST a comment to the Airtable record."""
+    from mcp_server.server import post_sst_comment
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    monkeypatch.setattr("mcp_server.server.AIRTABLE_API_KEY", "fake-key")
+    monkeypatch.setattr("httpx.AsyncClient", lambda **kwargs: mock_client)
+
+    success = await post_sst_comment("recTEST123", "Test comment")
+    assert success is True

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,103 @@
+"""Tests for MCP server tool handlers.
+
+Tests the tool handler functions directly (not via MCP protocol),
+using a temporary OUTPUT directory to isolate filesystem operations.
+"""
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from mcp_server.server import handle_save_revision
+
+
+@pytest.fixture
+def output_dir(tmp_path):
+    """Provide a temporary OUTPUT directory and patch the module global."""
+    with patch("mcp_server.server.OUTPUT_DIR", tmp_path):
+        yield tmp_path
+
+
+@pytest.fixture
+def project_with_manifest(output_dir):
+    """Create a project folder with a minimal manifest for testing."""
+    project_name = "2WLITestProjectSM"
+    project_path = output_dir / project_name
+    project_path.mkdir()
+    manifest = {
+        "project_name": project_name,
+        "phases": [
+            {"name": "analyst", "status": "completed"},
+            {"name": "formatter", "status": "completed"},
+            {"name": "seo", "status": "completed"},
+        ],
+        "outputs": {
+            "analysis": "analyst_output.md",
+            "formatted_transcript": "formatter_output.md",
+            "seo_metadata": "seo_output.md",
+        },
+        "revisions": [],
+        "keyword_reports": [],
+    }
+    (project_path / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    (project_path / "analyst_output.md").write_text("# Analysis\nTest analysis content.")
+    (project_path / "formatter_output.md").write_text("# Formatted Transcript\nTest transcript.")
+    (project_path / "seo_output.md").write_text("# SEO\nTest SEO content.")
+    return project_name, project_path
+
+
+@pytest.mark.asyncio
+async def test_save_revision_succeeds(project_with_manifest):
+    """save_revision should write a file and update manifest."""
+    project_name, project_path = project_with_manifest
+    result = await handle_save_revision({
+        "project_name": project_name,
+        "content": "# Revision\nTest revision content.",
+    })
+    assert len(result) == 1
+    assert "✅" in result[0].text
+    assert "copy_revision_v1.md" in result[0].text
+
+    assert (project_path / "copy_revision_v1.md").exists()
+    assert (project_path / "copy_revision_v1.md").read_text() == "# Revision\nTest revision content."
+
+    manifest = json.loads((project_path / "manifest.json").read_text())
+    assert len(manifest["revisions"]) == 1
+    assert manifest["revisions"][0]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_save_revision_auto_versions(project_with_manifest):
+    """save_revision should auto-increment version numbers."""
+    project_name, project_path = project_with_manifest
+
+    await handle_save_revision({"project_name": project_name, "content": "Version 1"})
+    result = await handle_save_revision({"project_name": project_name, "content": "Version 2"})
+    assert "copy_revision_v2.md" in result[0].text
+    assert (project_path / "copy_revision_v2.md").read_text() == "Version 2"
+
+
+@pytest.mark.asyncio
+async def test_save_revision_missing_args(output_dir):
+    """save_revision should return error for missing arguments."""
+    result = await handle_save_revision({"project_name": "test"})
+    assert "Error" in result[0].text
+
+    result = await handle_save_revision({"content": "test"})
+    assert "Error" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_save_revision_completes_within_timeout(project_with_manifest):
+    """save_revision should complete within a reasonable time, not hang."""
+    project_name, _ = project_with_manifest
+    result = await asyncio.wait_for(
+        handle_save_revision({
+            "project_name": project_name,
+            "content": "Timeout test content",
+        }),
+        timeout=5.0,
+    )
+    assert "✅" in result[0].text

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -57,10 +57,12 @@ def project_with_manifest(output_dir):
 async def test_save_revision_succeeds(project_with_manifest):
     """save_revision should write a file and update manifest."""
     project_name, project_path = project_with_manifest
-    result = await handle_save_revision({
-        "project_name": project_name,
-        "content": "# Revision\nTest revision content.",
-    })
+    result = await handle_save_revision(
+        {
+            "project_name": project_name,
+            "content": "# Revision\nTest revision content.",
+        }
+    )
     assert len(result) == 1
     assert "✅" in result[0].text
     assert "copy_revision_v1.md" in result[0].text
@@ -99,10 +101,12 @@ async def test_save_revision_completes_within_timeout(project_with_manifest):
     """save_revision should complete within a reasonable time, not hang."""
     project_name, _ = project_with_manifest
     result = await asyncio.wait_for(
-        handle_save_revision({
-            "project_name": project_name,
-            "content": "Timeout test content",
-        }),
+        handle_save_revision(
+            {
+                "project_name": project_name,
+                "content": "Timeout test content",
+            }
+        ),
         timeout=5.0,
     )
     assert "✅" in result[0].text
@@ -112,10 +116,12 @@ async def test_save_revision_completes_within_timeout(project_with_manifest):
 async def test_save_keyword_report_succeeds(project_with_manifest):
     """save_keyword_report should write a file and update manifest."""
     project_name, project_path = project_with_manifest
-    result = await handle_save_keyword_report({
-        "project_name": project_name,
-        "content": "# Keywords\nTest keyword report.",
-    })
+    result = await handle_save_keyword_report(
+        {
+            "project_name": project_name,
+            "content": "# Keywords\nTest keyword report.",
+        }
+    )
     assert "✅" in result[0].text
     assert "keyword_report_v1.md" in result[0].text
 
@@ -150,11 +156,13 @@ async def test_validate_copy_all_valid(output_dir):
     """validate_copy should report all fields valid when under limits."""
     from mcp_server.server import handle_validate_copy
 
-    result = await handle_validate_copy({
-        "title": "Wisconsin Life | Alice Good Café in Verona",
-        "short_description": "In Verona, Alice Good brews Colombian coffee and community.",
-        "long_description": "Alice Good Café in Verona is more than a coffee shop.",
-    })
+    result = await handle_validate_copy(
+        {
+            "title": "Wisconsin Life | Alice Good Café in Verona",
+            "short_description": "In Verona, Alice Good brews Colombian coffee and community.",
+            "long_description": "Alice Good Café in Verona is more than a coffee shop.",
+        }
+    )
     text = result[0].text
     assert "✅" in text
     assert "Yes" in text  # "All valid: ✅ Yes"
@@ -165,11 +173,13 @@ async def test_validate_copy_over_limit(output_dir):
     """validate_copy should flag fields that exceed character limits."""
     from mcp_server.server import handle_validate_copy
 
-    result = await handle_validate_copy({
-        "title": "X" * 85,
-        "short_description": "X" * 105,
-        "long_description": "OK",
-    })
+    result = await handle_validate_copy(
+        {
+            "title": "X" * 85,
+            "short_description": "X" * 105,
+            "long_description": "OK",
+        }
+    )
     text = result[0].text
     assert "❌" in text
     assert "OVER LIMIT" in text
@@ -181,9 +191,11 @@ async def test_validate_copy_partial_fields(output_dir):
     """validate_copy should work with only some fields provided."""
     from mcp_server.server import handle_validate_copy
 
-    result = await handle_validate_copy({
-        "title": "Just a title",
-    })
+    result = await handle_validate_copy(
+        {
+            "title": "Just a title",
+        }
+    )
     text = result[0].text
     assert "12" in text
     assert "Error" not in text
@@ -194,10 +206,12 @@ async def test_validate_copy_with_keywords(output_dir):
     """validate_copy should count keywords when provided."""
     from mcp_server.server import handle_validate_copy
 
-    result = await handle_validate_copy({
-        "title": "Test Title",
-        "keywords": "coffee, Verona, Wisconsin, fair trade, community",
-    })
+    result = await handle_validate_copy(
+        {
+            "title": "Test Title",
+            "keywords": "coffee, Verona, Wisconsin, fair trade, community",
+        }
+    )
     text = result[0].text
     assert "5" in text  # 5 keywords
 
@@ -407,12 +421,14 @@ async def test_propose_sst_edit_stages_in_manifest(project_with_manifest, monkey
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, project_path = project_with_manifest
-    result = await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "title",
-        "proposed_value": "Wisconsin Life | New Title Here",
-        "reason": "SEO improvement",
-    })
+    result = await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "Wisconsin Life | New Title Here",
+            "reason": "SEO improvement",
+        }
+    )
     text = result[0].text
     assert "Wisconsin Life | New Title Here" in text
     assert "✅" in text  # under 80 char limit
@@ -436,13 +452,19 @@ async def test_propose_sst_edit_rejects_disallowed_field(project_with_manifest, 
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, _ = project_with_manifest
-    result = await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "status",
-        "proposed_value": "Complete",
-        "reason": "Done",
-    })
-    assert "not writable" in result[0].text.lower() or "not allowed" in result[0].text.lower() or "allowed fields" in result[0].text.lower()
+    result = await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "status",
+            "proposed_value": "Complete",
+            "reason": "Done",
+        }
+    )
+    assert (
+        "not writable" in result[0].text.lower()
+        or "not allowed" in result[0].text.lower()
+        or "allowed fields" in result[0].text.lower()
+    )
 
 
 @pytest.mark.asyncio
@@ -456,12 +478,14 @@ async def test_propose_sst_edit_warns_over_limit(project_with_manifest, monkeypa
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, _ = project_with_manifest
-    result = await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "title",
-        "proposed_value": "X" * 85,
-        "reason": "Testing",
-    })
+    result = await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "X" * 85,
+            "reason": "Testing",
+        }
+    )
     text = result[0].text
     assert "❌" in text or "OVER" in text
 
@@ -478,14 +502,22 @@ async def test_propose_sst_edit_multiple_fields(project_with_manifest, monkeypat
 
     project_name, project_path = project_with_manifest
 
-    await handle_propose_sst_edit({
-        "media_id": project_name, "field": "title",
-        "proposed_value": "New Title", "reason": "Better",
-    })
-    await handle_propose_sst_edit({
-        "media_id": project_name, "field": "short_description",
-        "proposed_value": "New short desc", "reason": "Clearer",
-    })
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "New Title",
+            "reason": "Better",
+        }
+    )
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "short_description",
+            "proposed_value": "New short desc",
+            "reason": "Clearer",
+        }
+    )
 
     manifest = json.loads((project_path / "manifest.json").read_text())
     assert "title" in manifest["proposed_edits"]
@@ -504,14 +536,22 @@ async def test_review_proposed_edits_shows_diff(project_with_manifest, monkeypat
 
     project_name, _ = project_with_manifest
 
-    await handle_propose_sst_edit({
-        "media_id": project_name, "field": "title",
-        "proposed_value": "New Title", "reason": "Better SEO",
-    })
-    await handle_propose_sst_edit({
-        "media_id": project_name, "field": "short_description",
-        "proposed_value": "New short", "reason": "Clearer",
-    })
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "New Title",
+            "reason": "Better SEO",
+        }
+    )
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "short_description",
+            "proposed_value": "New short",
+            "reason": "Clearer",
+        }
+    )
 
     result = await handle_review_proposed_edits({"media_id": project_name})
     text = result[0].text
@@ -546,12 +586,14 @@ async def test_commit_sst_edits_writes_and_comments(project_with_manifest, monke
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, project_path = project_with_manifest
-    await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "title",
-        "proposed_value": "New Title",
-        "reason": "SEO",
-    })
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "New Title",
+            "reason": "SEO",
+        }
+    )
 
     # Mock concurrency re-fetch (returns same value as when proposed — no conflict)
     async def mock_fetch(record_id):
@@ -599,12 +641,14 @@ async def test_commit_sst_edits_concurrency_conflict(project_with_manifest, monk
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, project_path = project_with_manifest
-    await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "title",
-        "proposed_value": "New Title",
-        "reason": "SEO",
-    })
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "New Title",
+            "reason": "SEO",
+        }
+    )
 
     # Mock concurrency re-fetch — returns DIFFERENT value (someone edited Airtable)
     async def mock_fetch(record_id):
@@ -666,12 +710,14 @@ async def test_commit_sst_edits_patch_failure(project_with_manifest, monkeypatch
     monkeypatch.setattr("mcp_server.server.search_sst_by_media_id", mock_search)
 
     project_name, project_path = project_with_manifest
-    await handle_propose_sst_edit({
-        "media_id": project_name,
-        "field": "title",
-        "proposed_value": "New Title",
-        "reason": "SEO",
-    })
+    await handle_propose_sst_edit(
+        {
+            "media_id": project_name,
+            "field": "title",
+            "proposed_value": "New Title",
+            "reason": "SEO",
+        }
+    )
 
     # Concurrency check passes
     async def mock_fetch(record_id):


### PR DESCRIPTION
## Summary

Overhauls the Cardigan MCP server based on [detailed usability feedback from a chat agent editing session](https://github.com/mriechers/cardigan/issues). The editorial assistant's write tools were hanging, agents had no way to discover files or validate copy, and the deliverable workflow required manual Airtable transcription. This PR fixes all three categories.

### WP1: Write Tool Reliability
- `save_revision` and `save_keyword_report` refactored to use `asyncio.to_thread` with 15-second timeout
- Returns clear error on timeout instead of hanging indefinitely
- Root cause: synchronous file I/O blocking the async event loop under HTTP transport

### WP2: Controlled Airtable Writes
- **`propose_sst_edit`** — stages field edits in manifest.json with allowlist enforcement and char validation
- **`review_proposed_edits`** — shows diff of all staged changes for user review
- **`commit_sst_edits`** — writes to Airtable with optimistic concurrency check + audit comment
- Hard-coded allowlist: 8 fields (title, descriptions, keywords, social media)
- CLAUDE.md policy updated from "NEVER write" to "controlled writes via staging workflow"

### WP3: Validation & Discovery Tools
- **`validate_copy`** — server-side character count validation (title: 80, SD: 100, LD: 350)
- **`list_project_files`** — directory listing grouped by type (finds SEMRush uploads, etc.)
- **`list_revisions`** — version history from manifest with timestamps and sizes

### WP4: Instructions Cleanup
- Replaced aggressive "produce immediately, don't ask" default with collaborative approach
- Documented all 16 tools and the propose/review/commit workflow
- Removed duplicate sections (QC checklist x2, Ethical AI x2)
- Added "When Tools Fail" guidance
- Net reduction: -48 lines despite adding new workflow docs

**Tool count: 10 → 16** | **New tests: 32** | **Files: mcp_server/server.py, tests/test_mcp_tools.py, CLAUDE.md, EDITOR_AGENT_INSTRUCTIONS.md**

## Test plan

- [x] All 32 new MCP tool tests pass (`tests/test_mcp_tools.py`)
- [x] Full suite (398 passed, 3 skipped, 6 xfailed)
- [x] Server loads with 16 tools verified
- [x] Lint clean (ruff)
- [ ] Manual test: run an editing session with the chat agent using propose/review/commit flow
- [ ] Manual test: verify audit comment appears on Airtable record after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)