### PR TITLE
feat: Direct model selection and tier label cleanup

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -326,6 +326,11 @@ async def update_phase_models(update: PhaseModelsUpdate):
     config["phase_models"] = phase_models
     _save_config(config)
 
+    # Reload the live LLM client so changes take effect immediately
+    from api.services.llm import get_llm_client
+
+    get_llm_client().reload_config()
+
     return await get_phase_models()
 
 

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -116,7 +116,7 @@ async def get_phase_backends():
 
     phase_backends = config.get("phase_backends", {})
     available_backends = list(config.get("backends", {}).keys())
-    available_phases = ["analyst", "formatter", "seo", "manager", "copy_editor", "chat"]
+    available_phases = ["analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"]
 
     return PhaseBackendsResponse(
         phase_backends=phase_backends,
@@ -134,7 +134,7 @@ async def update_phase_backends(update: PhaseBackendsUpdate):
     """
     config = _load_config()
     available_backends = list(config.get("backends", {}).keys())
-    valid_phases = {"analyst", "formatter", "seo", "manager", "copy_editor", "chat"}
+    valid_phases = {"analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"}
 
     # Validate the update
     for phase, backend in update.phase_backends.items():
@@ -150,6 +150,11 @@ async def update_phase_backends(update: PhaseBackendsUpdate):
     # Update config
     config["phase_backends"] = update.phase_backends
     _save_config(config)
+
+    # Reload the live LLM client so changes take effect immediately
+    from api.services.llm import get_llm_client
+
+    get_llm_client().reload_config()
 
     return PhaseBackendsResponse(
         phase_backends=config["phase_backends"],
@@ -169,13 +174,13 @@ async def get_routing_config():
 
     # Default values
     default_tiers = ["openrouter-cheapskate", "openrouter", "openrouter-big-brain"]
-    default_labels = ["cheapskate", "default", "big-brain"]
+    default_labels = ["economy", "standard", "premium"]
     default_thresholds = [
-        {"max_minutes": 15, "tier": 0},
-        {"max_minutes": 30, "tier": 1},
+        {"max_minutes": 30, "tier": 0},
+        {"max_minutes": 45, "tier": 1},
         {"max_minutes": None, "tier": 2},
     ]
-    default_phase_tiers = {"analyst": 1, "formatter": 0, "seo": 0, "manager": 2, "copy_editor": 1, "chat": 1}
+    default_phase_tiers = {"analyst": 0, "formatter": 1, "seo": 0, "manager": 2, "timestamp": 1, "copy_editor": 2, "chat": 1}
     default_escalation = {
         "enabled": True,
         "on_failure": True,
@@ -202,7 +207,7 @@ async def update_routing_config(update: RoutingConfigUpdate):
     """
     config = _load_config()
     routing = config.get("routing", {})
-    valid_phases = {"analyst", "formatter", "seo", "manager", "copy_editor", "chat"}
+    valid_phases = {"analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"}
 
     # Apply updates (only non-None values)
     if update.duration_thresholds is not None:
@@ -228,8 +233,100 @@ async def update_routing_config(update: RoutingConfigUpdate):
     config["routing"] = routing
     _save_config(config)
 
+    # Reload the live LLM client so changes take effect immediately
+    from api.services.llm import get_llm_client
+
+    get_llm_client().reload_config()
+
     # Return updated config
     return await get_routing_config()
+
+
+class AvailableModel(BaseModel):
+    """A model available for phase assignment."""
+
+    id: str = Field(..., description="OpenRouter model ID (e.g., 'anthropic/claude-sonnet-4-5-20250514')")
+    name: str = Field(..., description="Human-readable model name")
+    provider: str = Field(..., description="Model provider (e.g., 'Anthropic', 'Google')")
+    tier: int = Field(..., ge=0, le=2, description="Cost tier (0=economy, 1=standard, 2=premium)")
+
+
+class PhaseModelsResponse(BaseModel):
+    """Response with current phase-to-model assignments and available models."""
+
+    phase_models: Dict[str, str] = Field(..., description="Current model ID assigned to each phase")
+    available_models: List[AvailableModel] = Field(..., description="All models available for selection")
+    available_phases: List[str] = Field(..., description="All configurable phases")
+
+
+class PhaseModelsUpdate(BaseModel):
+    """Request body for updating phase-to-model assignments."""
+
+    phase_models: Dict[str, str] = Field(
+        ...,
+        description="Mapping of phase names to model IDs",
+        examples=[{"analyst": "anthropic/claude-haiku-4-5-20251001", "formatter": "anthropic/claude-sonnet-4-5-20250514"}],
+    )
+
+
+DEFAULT_PHASE_MODELS = {
+    "analyst": "anthropic/claude-haiku-4-5-20251001",
+    "formatter": "anthropic/claude-sonnet-4-5-20250514",
+    "seo": "anthropic/claude-haiku-4-5-20251001",
+    "manager": "anthropic/claude-opus-4-5-20250514",
+    "timestamp": "anthropic/claude-sonnet-4-5-20250514",
+    "copy_editor": "anthropic/claude-opus-4-5-20250514",
+    "chat": "anthropic/claude-sonnet-4-5-20250514",
+}
+
+
+@router.get("/models", response_model=PhaseModelsResponse)
+async def get_phase_models():
+    """Get current phase-to-model assignments and available models.
+
+    Returns which specific model is assigned to each agent phase,
+    plus the full list of available models for the Settings UI.
+    """
+    config = _load_config()
+    available_models = [AvailableModel(**m) for m in config.get("available_models", [])]
+    phase_models = config.get("phase_models", DEFAULT_PHASE_MODELS)
+    available_phases = ["analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"]
+
+    return PhaseModelsResponse(
+        phase_models=phase_models,
+        available_models=available_models,
+        available_phases=available_phases,
+    )
+
+
+@router.patch("/models", response_model=PhaseModelsResponse)
+async def update_phase_models(update: PhaseModelsUpdate):
+    """Update phase-to-model assignments.
+
+    Allows reconfiguring which specific model handles each agent phase.
+    Changes are persisted to the config file and take effect immediately.
+    """
+    config = _load_config()
+    valid_phases = {"analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"}
+    available_model_ids = {m["id"] for m in config.get("available_models", [])}
+
+    for phase, model_id in update.phase_models.items():
+        if phase not in valid_phases:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid phase: {phase}. Valid phases: {', '.join(sorted(valid_phases))}"
+            )
+        if available_model_ids and model_id not in available_model_ids:
+            raise HTTPException(
+                status_code=400, detail=f"Unknown model: {model_id}. Check available_models in config."
+            )
+
+    # Merge with existing (partial update)
+    phase_models = config.get("phase_models", DEFAULT_PHASE_MODELS)
+    phase_models.update(update.phase_models)
+    config["phase_models"] = phase_models
+    _save_config(config)
+
+    return await get_phase_models()
 
 
 class WorkerConfigResponse(BaseModel):

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -180,7 +180,15 @@ async def get_routing_config():
         {"max_minutes": 45, "tier": 1},
         {"max_minutes": None, "tier": 2},
     ]
-    default_phase_tiers = {"analyst": 0, "formatter": 1, "seo": 0, "manager": 2, "timestamp": 1, "copy_editor": 2, "chat": 1}
+    default_phase_tiers = {
+        "analyst": 0,
+        "formatter": 1,
+        "seo": 0,
+        "manager": 2,
+        "timestamp": 1,
+        "copy_editor": 2,
+        "chat": 1,
+    }
     default_escalation = {
         "enabled": True,
         "on_failure": True,
@@ -265,7 +273,9 @@ class PhaseModelsUpdate(BaseModel):
     phase_models: Dict[str, str] = Field(
         ...,
         description="Mapping of phase names to model IDs",
-        examples=[{"analyst": "anthropic/claude-haiku-4-5-20251001", "formatter": "anthropic/claude-sonnet-4-5-20250514"}],
+        examples=[
+            {"analyst": "anthropic/claude-haiku-4-5-20251001", "formatter": "anthropic/claude-sonnet-4-5-20250514"}
+        ],
     )
 
 
@@ -316,9 +326,7 @@ async def update_phase_models(update: PhaseModelsUpdate):
                 status_code=400, detail=f"Invalid phase: {phase}. Valid phases: {', '.join(sorted(valid_phases))}"
             )
         if available_model_ids and model_id not in available_model_ids:
-            raise HTTPException(
-                status_code=400, detail=f"Unknown model: {model_id}. Check available_models in config."
-            )
+            raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}. Check available_models in config.")
 
     # Merge with existing (partial update)
     phase_models = config.get("phase_models", DEFAULT_PHASE_MODELS)

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -807,7 +807,7 @@ class PhaseRetryRequest(BaseModel):
     tier: Optional[int] = Field(
         None,
         ge=0,
-        description="Force specific tier index (0=Claude Haiku, 1=Claude Sonnet, 2=Claude Opus). "
+        description="Force specific tier index (0=economy, 1=standard, 2=premium). "
         "If not specified, auto-escalates from the tier previously used.",
     )
     feedback: Optional[str] = Field(

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -199,9 +199,9 @@ async def retry_job(job_id: int):
     for phase in phases:
         if phase.tier is not None and phase.tier > max_previous_tier:
             max_previous_tier = phase.tier
-    escalated_tier = min(max_previous_tier + 1, 3)  # Cap at tier 3 (Claude pinned)
+    escalated_tier = min(max_previous_tier + 1, 2)  # Cap at tier 2 (Claude Opus)
 
-    tier_labels = {0: "Claude Haiku", 1: "Claude Sonnet", 2: "Claude Opus", 3: "Claude (pinned)"}
+    tier_labels = {0: "economy", 1: "standard", 2: "premium"}
     logger.info(
         "Retry with escalation",
         extra={
@@ -325,6 +325,179 @@ async def cancel_job(job_id: int):
     job_update = JobUpdate(status=JobStatus.cancelled)
     updated_job = await update_job(job_id, job_update)
 
+    return updated_job
+
+
+TRANSCRIPT_REPLACEABLE_STATES = {
+    JobStatus.failed,
+    JobStatus.paused,
+    JobStatus.pending,
+    JobStatus.completed,
+    JobStatus.cancelled,
+}
+
+TRANSCRIPTS_DIR = Path(os.getenv("TRANSCRIPTS_DIR", "transcripts"))
+ALLOWED_EXTENSIONS = {".txt", ".srt"}
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
+@router.post("/{job_id}/replace-transcript", response_model=Job)
+async def replace_transcript(
+    job_id: int,
+    file: UploadFile = File(..., description="Replacement transcript file (.txt or .srt)"),
+):
+    """Replace a job's transcript file and reset for reprocessing.
+
+    Accepts a new transcript upload for an existing job. The old transcript
+    is kept (not deleted). The job is reset to pending with all phases cleared.
+
+    Useful when a corrected transcript is available and you want to reprocess
+    without creating a new job.
+
+    Args:
+        job_id: Job ID to update
+        file: New transcript file
+
+    Returns:
+        Updated job record reset to pending
+
+    Raises:
+        HTTPException: 404 if job not found, 400 if invalid file or state
+    """
+    job = await get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    if job.status not in TRANSCRIPT_REPLACEABLE_STATES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot replace transcript for job in status '{job.status}'. "
+            f"Only {', '.join(s.value for s in TRANSCRIPT_REPLACEABLE_STATES)} jobs are eligible.",
+        )
+
+    # Validate file
+    file_ext = Path(file.filename or "").suffix.lower()
+    if file_ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid file type. Allowed: {', '.join(ALLOWED_EXTENSIONS)}",
+        )
+
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File too large. Maximum size: {MAX_FILE_SIZE / 1024 / 1024:.0f} MB",
+        )
+
+    # Save new transcript
+    TRANSCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
+    file_path = TRANSCRIPTS_DIR / (file.filename or "")
+    file_path.write_bytes(content)
+    logger.info(f"Job {job_id}: Saved replacement transcript: {file_path}")
+
+    # Recalculate metadata
+    from api.routers.queue import calculate_transcript_metrics_from_file
+    from api.services.utils import extract_media_id
+
+    new_media_id = extract_media_id(file.filename or "")
+    duration_minutes, word_count = calculate_transcript_metrics_from_file(file.filename or "")
+
+    old_transcript = job.transcript_file
+    old_media_id = job.media_id
+
+    # Reset all phases to pending
+    from api.models.job import JobPhase
+
+    reset_phases = []
+    for phase in job.phases or []:
+        phase_dict = phase.model_dump()
+        # Archive previous run if it had results
+        if phase_dict.get("model") or phase_dict.get("tier") is not None:
+            prev_run = {
+                "tier": phase_dict.get("tier"),
+                "tier_label": phase_dict.get("tier_label"),
+                "model": phase_dict.get("model"),
+                "cost": phase_dict.get("cost", 0),
+                "tokens": phase_dict.get("tokens", 0),
+                "completed_at": phase_dict.get("completed_at"),
+            }
+            previous_runs = phase_dict.get("previous_runs") or []
+            previous_runs.append(prev_run)
+            phase_dict["previous_runs"] = previous_runs
+
+        phase_dict["status"] = "pending"
+        phase_dict["completed_at"] = None
+        phase_dict["error_message"] = None
+        phase_dict["cost"] = 0
+        phase_dict["tokens"] = 0
+        phase_dict["model"] = None
+        phase_dict["tier"] = None
+        phase_dict["tier_label"] = None
+        phase_dict["tier_reason"] = None
+        phase_dict["attempts"] = None
+        phase_dict["metadata"] = None
+        reset_phases.append(phase_dict)
+
+    # Build update
+    project_name = Path(file.filename or "").stem
+    for suffix in ["_ForClaude", "_forclaude", "_transcript"]:
+        if project_name.endswith(suffix):
+            project_name = project_name[: -len(suffix)]
+
+    job_update = JobUpdate(
+        status=JobStatus.pending,
+        transcript_file=file.filename or "",
+        project_name=project_name,
+        project_path=f"/data/output/{project_name}",
+        media_id=new_media_id,
+        duration_minutes=duration_minutes,
+        word_count=word_count,
+        error_message="",
+        current_phase=None,
+        actual_cost=0.0,
+        phases=[JobPhase(**p) for p in reset_phases],
+    )
+    updated_job = await update_job(job_id, job_update)
+
+    # Re-link Airtable if media_id changed
+    if new_media_id and new_media_id != old_media_id:
+        try:
+            airtable_client = AirtableClient()
+            record = await airtable_client.search_sst_by_media_id(new_media_id)
+            if record:
+                record_id = record["id"]
+                airtable_url = airtable_client.get_sst_url(record_id)
+                link_update = JobUpdate(
+                    airtable_record_id=record_id,
+                    airtable_url=airtable_url,
+                )
+                updated_job = await update_job(job_id, link_update)
+                logger.info(f"Job {job_id}: Re-linked to SST record {record_id}")
+        except Exception as e:
+            logger.warning(f"Job {job_id}: Airtable re-link failed - {e}")
+
+    # Log the replacement event
+    await log_event(
+        EventCreate(
+            job_id=job_id,
+            event_type=EventType.user_action,
+            data=EventData(
+                extra={
+                    "action": "transcript_replaced",
+                    "old_transcript": old_transcript,
+                    "new_transcript": file.filename,
+                    "old_media_id": old_media_id,
+                    "new_media_id": new_media_id,
+                }
+            ),
+        )
+    )
+
+    logger.info(
+        f"Job {job_id}: Transcript replaced {old_transcript} -> {file.filename}, "
+        f"media_id {old_media_id} -> {new_media_id}"
+    )
     return updated_job
 
 
@@ -634,7 +807,7 @@ class PhaseRetryRequest(BaseModel):
     tier: Optional[int] = Field(
         None,
         ge=0,
-        description="Force specific tier index (0=Claude Haiku, 1=Claude Sonnet, 2=Claude Opus, 3=Claude pinned). "
+        description="Force specific tier index (0=Claude Haiku, 1=Claude Sonnet, 2=Claude Opus). "
         "If not specified, auto-escalates from the tier previously used.",
     )
     feedback: Optional[str] = Field(
@@ -778,7 +951,7 @@ async def retry_phase(
 
     background_tasks.add_task(run_retry)
 
-    tier_labels = {0: "Claude Haiku", 1: "Claude Sonnet", 2: "Claude Opus", 3: "Claude (pinned)"}
+    tier_labels = {0: "economy", 1: "standard", 2: "premium"}
     escalation_note = " (auto-escalated)" if tier is None else ""
     tier_msg = f" at tier {effective_tier} ({tier_labels.get(effective_tier, '?')}){escalation_note}"
     return PhaseRetryResponse(

--- a/api/services/ingest_config.py
+++ b/api/services/ingest_config.py
@@ -46,7 +46,26 @@ DEFAULT_CONFIG = IngestConfig(
     server_url="https://mmingest.pbswi.wisc.edu/",
     # Scan from root to auto-discover all directories (IWP, SCC2SRT, misc, etc.)
     directories=["/"],
-    ignore_directories=["/promos/"],
+    # Directories that don't contain transcripts/screengrabs — skip to avoid timeouts
+    ignore_directories=[
+        "SkyCloud",
+        "promos",
+        "Promotions",
+        "_old_projects",
+        "AddDisclaimer",
+        "SCC_Add1Hour",
+        "SRT2SCC",
+        "VideoDownloader",
+        "GIFLINK",
+        "AppsNCTR",
+        "CCRecord",
+        "pledge",
+        "test_jd",
+        "preservation",
+        "candidatestatements",
+        "fmdub",
+        "MP4_Misc_Output",
+    ],
 )
 
 

--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -309,11 +309,17 @@ class IngestScanner:
 
             logger.info(f"Found {len(existing_urls)} existing files, {len(files) - len(existing_urls)} new")
 
-            # Step 2: Insert new files
-            new_files = [f for f in files if f.url not in existing_urls]
+            # Step 2: Insert new files (dedup by URL within the batch)
+            seen_urls: set = set()
+            new_files = []
+            for f in files:
+                if f.url not in existing_urls and f.url not in seen_urls:
+                    new_files.append(f)
+                    seen_urls.add(f.url)
+
             for f in new_files:
                 insert_query = text("""
-                    INSERT INTO available_files
+                    INSERT OR IGNORE INTO available_files
                     (remote_url, filename, directory_path, file_type, media_id,
                      file_size_bytes, remote_modified_at, first_seen_at, last_seen_at, status)
                     VALUES

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -1686,7 +1686,7 @@ Please format this transcript section:
                     },
                 )
 
-                return response.content
+                return {"content": response.content, "cost": response.cost, "tokens": response.total_tokens}
 
         # Log phase start
         await log_event(
@@ -1735,14 +1735,12 @@ Please format this transcript section:
                         "cost": 0,
                     }
 
-            # Merge outputs
-            merged = merge_formatter_chunks(chunk_results)
+            # Aggregate cost/tokens from all chunks
+            total_cost = sum(r["cost"] for r in chunk_results)
+            total_tokens = sum(r["tokens"] for r in chunk_results)
 
-            # Calculate aggregate cost/tokens from run tracker
-            # (RunCostTracker accumulates automatically via llm.chat)
-            # We report 0 here since the tracker handles it
-            total_cost = 0.0
-            total_tokens = 0
+            # Merge text outputs
+            merged = merge_formatter_chunks([r["content"] for r in chunk_results])
 
             # Save merged output
             output_file = project_path / "formatter_output.md"
@@ -1753,7 +1751,9 @@ Please format this transcript section:
                 prev_file.write_text(prev_content)
 
             provenance_header = (
-                f"<!-- model: chunked ({total_chunks} chunks) | " f"tier: {tier_label} | backend: {backend} -->\n"
+                f"<!-- model: chunked ({total_chunks} chunks) | "
+                f"tier: {tier_label} | backend: {backend} | "
+                f"cost: ${total_cost:.4f} | tokens: {total_tokens} -->\n"
             )
             output_file.write_text(provenance_header + merged)
 

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -100,6 +100,12 @@
       "timeout": 300,
       "cost_per_project": 0.0,
       "enabled": true
+    },
+    "openrouter-direct": {
+      "type": "openrouter",
+      "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "timeout": 300
     }
   },
   "auto_select": {
@@ -120,25 +126,24 @@
     "heartbeat_interval_seconds": 60
   },
   "phase_backends": {
-    "analyst": "openrouter",
-    "formatter": "openrouter-claude",
+    "analyst": "openrouter-cheapskate",
+    "formatter": "openrouter",
     "seo": "openrouter-cheapskate",
     "manager": "openrouter-big-brain",
-    "copy_editor": "openrouter",
+    "timestamp": "openrouter",
+    "copy_editor": "openrouter-big-brain",
     "chat": "openrouter"
   },
   "routing": {
     "tiers": [
       "openrouter-cheapskate",
       "openrouter",
-      "openrouter-big-brain",
-      "openrouter-claude"
+      "openrouter-big-brain"
     ],
     "tier_labels": [
-      "Claude Haiku",
-      "Claude Sonnet",
-      "Claude Opus",
-      "Claude (pinned)"
+      "economy",
+      "standard",
+      "premium"
     ],
     "duration_thresholds": [
       {
@@ -156,9 +161,10 @@
     ],
     "phase_base_tiers": {
       "analyst": 0,
-      "formatter": 3,
+      "formatter": 1,
       "seo": 0,
       "manager": 2,
+      "timestamp": 1,
       "copy_editor": 2,
       "chat": 1
     },
@@ -183,6 +189,53 @@
       "max_parallel": 3,
       "min_tier": 1
     }
+  },
+  "available_models": [
+    {
+      "id": "anthropic/claude-haiku-4-5-20251001",
+      "name": "Claude Haiku 4.5",
+      "provider": "Anthropic",
+      "tier": 0
+    },
+    {
+      "id": "google/gemini-2.0-flash-001",
+      "name": "Gemini 2.0 Flash",
+      "provider": "Google",
+      "tier": 0
+    },
+    {
+      "id": "anthropic/claude-sonnet-4-5-20250514",
+      "name": "Claude Sonnet 4.5",
+      "provider": "Anthropic",
+      "tier": 1
+    },
+    {
+      "id": "google/gemini-2.5-pro-preview",
+      "name": "Gemini 2.5 Pro",
+      "provider": "Google",
+      "tier": 1
+    },
+    {
+      "id": "anthropic/claude-opus-4-5-20250514",
+      "name": "Claude Opus 4.5",
+      "provider": "Anthropic",
+      "tier": 2
+    },
+    {
+      "id": "google/gemini-2.5-pro-preview",
+      "name": "Gemini 2.5 Pro (premium)",
+      "provider": "Google",
+      "tier": 2
+    }
+  ],
+  "phase_models": {
+    "analyst": "anthropic/claude-haiku-4-5-20251001",
+    "formatter": "anthropic/claude-sonnet-4-5-20250514",
+    "seo": "anthropic/claude-haiku-4-5-20251001",
+    "manager": "anthropic/claude-opus-4-5-20250514",
+    "timestamp": "anthropic/claude-sonnet-4-5-20250514",
+    "copy_editor": "anthropic/claude-opus-4-5-20250514",
+    "chat": "anthropic/claude-sonnet-4-5-20250514"
   },
   "openrouter_presets": {
     "ai-editorial-assistant": {

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -220,12 +220,6 @@
       "name": "Claude Opus 4.5",
       "provider": "Anthropic",
       "tier": 2
-    },
-    {
-      "id": "google/gemini-2.5-pro-preview",
-      "name": "Gemini 2.5 Pro (premium)",
-      "provider": "Google",
-      "tier": 2
     }
   ],
   "phase_models": {

--- a/tests/api/test_langfuse_client.py
+++ b/tests/api/test_langfuse_client.py
@@ -197,7 +197,7 @@ class TestTraceGeneration:
             job_id=42,
             phase="analyst",
             tier=0,
-            tier_label="cheapskate",
+            tier_label="economy",
             backend="openrouter",
         )
 

--- a/tests/api/test_llm.py
+++ b/tests/api/test_llm.py
@@ -53,7 +53,7 @@ def mock_config(tmp_path):
         },
         "routing": {
             "tiers": ["openrouter-cheapskate", "openrouter", "openrouter-big-brain"],
-            "tier_labels": ["cheapskate", "default", "big-brain"],
+            "tier_labels": ["economy", "standard", "premium"],
             "phase_base_tiers": {"analyst": 0, "formatter": 0, "seo": 0, "manager": 2},
             "duration_thresholds": [
                 {"max_minutes": 15, "tier": 0},

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -19,7 +19,7 @@ def mock_llm_client():
     client = MagicMock()
     client.config = {
         "routing": {
-            "tier_labels": ["cheapskate", "default", "big-brain"],
+            "tier_labels": ["economy", "standard", "premium"],
             "tiers": ["openrouter-cheapskate", "openrouter", "openrouter-big-brain"],
             "long_form_threshold_minutes": 15,
         }
@@ -510,7 +510,7 @@ class TestAnalyzeAndRecover:
         result = await worker._analyze_and_recover(
             job={"id": 1, "project_name": "Test"},
             project_path=tmp_path,
-            phases=[{"name": "analyst", "status": "failed", "tier": 0, "tier_label": "cheapskate"}],
+            phases=[{"name": "analyst", "status": "failed", "tier": 0, "tier_label": "economy"}],
             context={"transcript": "test"},
             error="Test error",
             current_cost=0.001,

--- a/web/src/constants/agents.ts
+++ b/web/src/constants/agents.ts
@@ -46,6 +46,13 @@ export const AGENT_INFO: AgentInfo[] = [
       'Reviews all automated outputs for quality before completion. Audits cheaper model work and flags issues. Always runs on big-brain tier for oversight.',
   },
   {
+    id: 'timestamp',
+    name: 'Timestamp',
+    icon: '⏱️',
+    description:
+      'Generates chapter timestamps with descriptive labels for long-form content. Uses SRT captions to identify topic transitions and segment boundaries.',
+  },
+  {
     id: 'copy_editor',
     name: 'Copy Editor',
     icon: '✏️',

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -685,11 +685,16 @@ export default function JobDetail() {
                   <div className="flex items-center space-x-3">
                     {phaseStatusIcon(phase.status)}
                     <span className="text-white">{phase.name}</span>
+                    {phase.model && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-gray-700 text-gray-300 font-mono">
+                        {phase.model}
+                      </span>
+                    )}
                     {phase.tier_label && (
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${
-                        phase.tier === 2 ? 'bg-purple-900/50 text-purple-300' :
-                        phase.tier === 1 ? 'bg-blue-900/50 text-blue-300' :
-                        'bg-green-900/50 text-green-300'
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+                        phase.tier === 2 ? 'bg-purple-900/30 text-purple-400' :
+                        phase.tier === 1 ? 'bg-blue-900/30 text-blue-400' :
+                        'bg-green-900/30 text-green-400'
                       }`}>
                         {phase.tier_label}
                       </span>
@@ -717,18 +722,9 @@ export default function JobDetail() {
                     )}
                   </div>
                 </div>
-                {(phase.model || phase.tier_reason) && (
-                  <div className="mt-1 ml-8 text-xs text-gray-500 space-y-0.5">
-                    {phase.model && (
-                      <div>
-                        Model: <span className="text-gray-400 font-mono">{phase.model}</span>
-                      </div>
-                    )}
-                    {phase.tier_reason && (
-                      <div>
-                        Reason: <span className="text-gray-400">{phase.tier_reason}</span>
-                      </div>
-                    )}
+                {phase.tier_reason && (
+                  <div className="mt-1 ml-8 text-xs text-gray-500">
+                    <span className="text-gray-400">{phase.tier_reason}</span>
                   </div>
                 )}
                 {phase.previous_runs && phase.previous_runs.length > 0 && (
@@ -737,12 +733,7 @@ export default function JobDetail() {
                     {phase.previous_runs.map((run, i) => (
                       <div key={i} className="flex items-center gap-2 text-gray-500 ml-2">
                         <span className="text-gray-600">#{i + 1}</span>
-                        <span className={`px-1.5 py-0 rounded text-[10px] ${
-                          run.tier === 2 ? 'bg-purple-900/30 text-purple-400' :
-                          run.tier === 1 ? 'bg-blue-900/30 text-blue-400' :
-                          'bg-green-900/30 text-green-400'
-                        }`}>{run.tier_label || 'unknown'}</span>
-                        {run.model && <span className="font-mono">{run.model}</span>}
+                        {run.model && <span className="font-mono text-gray-400">{run.model}</span>}
                         <span>${(run.cost || 0).toFixed(4)}</span>
                       </div>
                     ))}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -24,6 +24,19 @@ interface RoutingConfig {
   escalation: EscalationConfig
 }
 
+interface AvailableModel {
+  id: string
+  name: string
+  provider: string
+  tier: number
+}
+
+interface PhaseModelsConfig {
+  phase_models: Record<string, string>
+  available_models: AvailableModel[]
+  available_phases: string[]
+}
+
 interface WorkerConfig {
   max_concurrent_jobs: number
   poll_interval_seconds: number
@@ -81,6 +94,7 @@ interface SystemStatus {
 export default function Settings() {
   const { preferences, updatePreferences } = usePreferences()
   const [routing, setRouting] = useState<RoutingConfig | null>(null)
+  const [phaseModels, setPhaseModels] = useState<PhaseModelsConfig | null>(null)
   const [worker, setWorker] = useState<WorkerConfig | null>(null)
   const [ingestConfig, setIngestConfig] = useState<IngestConfig | null>(null)
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
@@ -92,14 +106,16 @@ export default function Settings() {
 
   // Track unsaved changes
   const [pendingRouting, setPendingRouting] = useState<Partial<RoutingConfig> | null>(null)
+  const [pendingPhaseModels, setPendingPhaseModels] = useState<Record<string, string> | null>(null)
   const [pendingWorker, setPendingWorker] = useState<Partial<WorkerConfig> | null>(null)
   const [pendingIngest, setPendingIngest] = useState<Partial<IngestConfigUpdate> | null>(null)
 
   const fetchConfig = useCallback(async () => {
     try {
       setLoading(true)
-      const [routingRes, workerRes] = await Promise.all([
+      const [routingRes, modelsRes, workerRes] = await Promise.all([
         fetch('/api/config/routing'),
+        fetch('/api/config/models'),
         fetch('/api/config/worker')
       ])
 
@@ -113,8 +129,12 @@ export default function Settings() {
       const routingData = await routingRes.json()
       const workerData = await workerRes.json()
       setRouting(routingData)
+      if (modelsRes.ok) {
+        setPhaseModels(await modelsRes.json())
+      }
       setWorker(workerData)
       setPendingRouting(null)
+      setPendingPhaseModels(null)
       setPendingWorker(null)
       setError(null)
     } catch (err) {
@@ -162,12 +182,9 @@ export default function Settings() {
     return () => clearInterval(interval)
   }, [activeTab, fetchSystemStatus])
 
-  const handlePhaseBaseTierChange = (phase: string, tier: number) => {
-    const current = pendingRouting?.phase_base_tiers || routing?.phase_base_tiers || {}
-    setPendingRouting({
-      ...pendingRouting,
-      phase_base_tiers: { ...current, [phase]: tier }
-    })
+  const handlePhaseModelChange = (phase: string, modelId: string) => {
+    const current = pendingPhaseModels || phaseModels?.phase_models || {}
+    setPendingPhaseModels({ ...current, [phase]: modelId })
   }
 
   const handleThresholdChange = (index: number, value: number | null) => {
@@ -226,6 +243,25 @@ export default function Settings() {
         }
       }
 
+      // Save phase model assignments if changed
+      if (pendingPhaseModels) {
+        const res = await fetch('/api/config/models', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phase_models: pendingPhaseModels })
+        })
+        if (!res.ok) {
+          let detail = 'Failed to save model assignments'
+          try {
+            const data = await res.json()
+            detail = data.detail || detail
+          } catch {
+            // Response wasn't JSON
+          }
+          throw new Error(detail)
+        }
+      }
+
       // Save worker config if changed
       if (pendingWorker) {
         const res = await fetch('/api/config/worker', {
@@ -273,7 +309,7 @@ export default function Settings() {
     setPendingIngest(null)
   }
 
-  const hasChanges = pendingRouting !== null || pendingWorker !== null || pendingIngest !== null
+  const hasChanges = pendingRouting !== null || pendingPhaseModels !== null || pendingWorker !== null || pendingIngest !== null
 
   const getCurrentWorker = (): WorkerConfig => {
     return {
@@ -295,10 +331,6 @@ export default function Settings() {
       ignore_directories: ingestConfig?.ignore_directories ?? [],
       next_scan_at: ingestConfig?.next_scan_at ?? null
     }
-  }
-
-  const getCurrentPhaseBaseTier = (phase: string): number => {
-    return pendingRouting?.phase_base_tiers?.[phase] ?? routing?.phase_base_tiers?.[phase] ?? 0
   }
 
   const getCurrentThresholds = (): DurationThreshold[] => {
@@ -427,19 +459,25 @@ export default function Settings() {
         {/* AGENTS TAB */}
         {activeTab === 'agents' && (
           <div className="space-y-6">
-            {/* Agent Base Tier Assignment */}
+            {/* Agent Model Assignment */}
             <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-              <h2 className="text-lg font-semibold text-white mb-4">Agent Base Tiers</h2>
+              <h2 className="text-lg font-semibold text-white mb-4">Agent Models</h2>
               <p className="text-sm text-gray-400 mb-6">
-                Set the starting tier for each agent. Short transcripts will use this tier.
-                Longer transcripts may automatically escalate based on duration thresholds.
+                Choose which model runs each agent. On failure, the system escalates
+                to the next tier automatically.
               </p>
 
               <div className="space-y-4">
                 {AGENT_INFO.map((agent) => {
-                  const currentTier = getCurrentPhaseBaseTier(agent.id)
-                  const color = getTierColor(currentTier)
-                  const styles = TIER_STYLES[color]
+                  const currentModel = pendingPhaseModels?.[agent.id]
+                    || phaseModels?.phase_models?.[agent.id]
+                    || ''
+                  const models = phaseModels?.available_models || []
+                  const selectedModel = models.find(m => m.id === currentModel)
+                  const tierColor = selectedModel
+                    ? TIER_COLORS[selectedModel.tier] || 'cyan'
+                    : 'cyan'
+                  const styles = TIER_STYLES[tierColor]
 
                   return (
                     <div key={agent.id} className="flex items-center justify-between p-4 bg-gray-900 rounded-lg">
@@ -453,21 +491,30 @@ export default function Settings() {
                         </div>
                       </div>
 
-                      <label htmlFor={`tier-${agent.id}`} className="sr-only">
-                        Base tier for {agent.name}
+                      <label htmlFor={`model-${agent.id}`} className="sr-only">
+                        Model for {agent.name}
                       </label>
                       <select
-                        id={`tier-${agent.id}`}
-                        value={currentTier}
-                        onChange={(e) => handlePhaseBaseTierChange(agent.id, parseInt(e.target.value))}
-                        className={`px-3 py-2 rounded-md border text-sm font-medium ${styles.bg} ${styles.border} ${styles.text}`}
-                        aria-label={`Select base tier for ${agent.name} agent`}
+                        id={`model-${agent.id}`}
+                        value={currentModel}
+                        onChange={(e) => handlePhaseModelChange(agent.id, e.target.value)}
+                        className={`px-3 py-2 rounded-md border text-sm font-medium min-w-[220px] ${styles.bg} ${styles.border} ${styles.text}`}
+                        aria-label={`Select model for ${agent.name} agent`}
                       >
-                        {routing?.tier_labels?.map((label, idx) => (
-                          <option key={idx} value={idx} className="bg-gray-800 text-white">
-                            {label}
-                          </option>
-                        ))}
+                        {[0, 1, 2].map(tier => {
+                          const tierModels = models.filter(m => m.tier === tier)
+                          if (tierModels.length === 0) return null
+                          const tierLabel = routing?.tier_labels?.[tier] || `tier ${tier}`
+                          return (
+                            <optgroup key={tier} label={tierLabel}>
+                              {tierModels.map(m => (
+                                <option key={m.id} value={m.id} className="bg-gray-800 text-white">
+                                  {m.name} ({m.provider})
+                                </option>
+                              ))}
+                            </optgroup>
+                          )
+                        })}
                       </select>
                     </div>
                   )


### PR DESCRIPTION
## Summary
- **Direct model selection**: Each agent phase can now be assigned a specific model (e.g., `anthropic/claude-sonnet-4-5`) via Settings UI, replacing the opaque tier→preset→model rotation system
- **Tier label cleanup**: Renamed from "Claude Haiku/Sonnet/Opus" to generic "economy/standard/premium" since OpenRouter presets route to multiple providers (Gemini, GPT, Claude)
- **Chunked formatter cost fix**: Formatter phases using chunked processing now report actual aggregated costs instead of $0.00
- **Chunk consistency**: All chunks now hit the same model via `openrouter-direct` backend, fixing style inconsistencies across chunks
- **Timestamp phase**: Added to config, Settings UI, and valid phases list (was previously invisible to settings)

## Changes
- `config/llm-config.json`: Added `available_models` list, `phase_models` map, `openrouter-direct` backend; updated defaults
- `api/routers/config.py`: New `GET/PATCH /api/config/models` endpoints; synced fallback defaults
- `api/services/worker.py`: `phase_models` routing in `_run_phase` and chunked formatter; chunk cost aggregation fix
- `web/src/pages/Settings.tsx`: Model dropdown per phase (grouped by tier) replaces tier selector
- `web/src/pages/JobDetail.tsx`: Model name as primary badge, tier label demoted
- `web/src/constants/agents.ts`: Added timestamp agent info

## Test plan
- [ ] Verify Settings page loads and shows model dropdowns grouped by economy/standard/premium
- [ ] Change a phase model via Settings, confirm it persists and is used on next job
- [ ] Run a chunked formatter job, verify cost > $0 on job detail screen
- [ ] Verify job detail shows actual model name (e.g., `anthropic/claude-sonnet-4-5`) not tier label as primary badge
- [ ] Confirm escalation still works: if configured model fails, system falls back to tier-based routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)