### PR TITLE
feat: Migrate secrets to Docker file-based management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,32 +1,27 @@
-# Cardigan API Keys
-# =================
-# API keys are loaded from macOS Keychain (service: developer.workspace.*)
-# Falls back to environment variables for CI/Docker.
+# Cardigan Configuration
+# ======================
 #
-# Add secrets to Keychain:
+# SECRETS: Stored as Docker secrets in ./secrets/ (one value per file).
+# In local dev, secrets fall back to macOS Keychain or environment variables.
+# See ./secrets/ directory — each file contains one secret value.
+#
+# Required secrets (create files in ./secrets/):
+#   secrets/openrouter_api_key
+#   secrets/airtable_api_key
+#   secrets/langfuse_public_key
+#   secrets/langfuse_secret_key
+#   secrets/cardigan_api_key
+#   secrets/cloudflare_tunnel_token  (optional — only for tunnel profile)
+#
+# Local dev (macOS Keychain — no Docker):
 #   security add-generic-password -a "$USER" -s "developer.workspace.OPENROUTER_API_KEY" -w "sk-or-..." -U
 #   security add-generic-password -a "$USER" -s "developer.workspace.AIRTABLE_API_KEY" -w "pat..." -U
-#
-# For CI/Docker, set these environment variables:
-# OPENROUTER_API_KEY=sk-or-...
-# AIRTABLE_API_KEY=pat...
 
-# Optional: Additional LLM providers (only needed if using multiple providers)
-# GEMINI_API_KEY=
-# OPENAI_API_KEY=
-# ANTHROPIC_API_KEY=
-
-# Docker / deployment paths
-# DATABASE_PATH=./dashboard.db
-# OUTPUT_DIR=./OUTPUT
+# NON-SECRET configuration only below this line.
+# Secrets should NOT be placed in this file.
 
 # CORS origins (comma-separated). Defaults to localhost:3000,localhost:5173 for dev.
 # CORS_ORIGINS=http://localhost:3000,https://cardigan.bymarkriechers.com
 
-# API authentication key. When empty or absent, auth is disabled (dev mode).
-# Set to a strong random value in production.
-CARDIGAN_API_KEY=
-
-# Cloudflare Tunnel (optional — only needed for remote/shared access)
-# Enable with: docker compose --profile tunnel up
-# CLOUDFLARE_TUNNEL_TOKEN=your-tunnel-token-here
+# Docker config path (for watchtower in prod)
+# DOCKER_CONFIG=/home/ubuntu/.docker

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 .Python
 venv/
 .env
+secrets/*
+!secrets/README.md
+!secrets/*.example
 
 # Database
 *.db

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -19,4 +19,4 @@ COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 3000
 
-CMD ["/bin/sh", "-c", "envsubst '${CARDIGAN_API_KEY}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "export CARDIGAN_API_KEY=$(cat /run/secrets/cardigan_api_key 2>/dev/null || echo \"${CARDIGAN_API_KEY}\") && envsubst '${CARDIGAN_API_KEY}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]

--- a/api/main.py
+++ b/api/main.py
@@ -4,33 +4,15 @@ Cardigan v4.0 - FastAPI Application
 Main entry point for the API server.
 """
 
-import importlib.util
 import os
-from pathlib import Path
 
-# Load .env file FIRST — it contains the current, correct credentials
 from dotenv import load_dotenv
 
 load_dotenv()
 
-# Then backfill from Keychain for any keys still missing.
-# keychain_secrets isn't on sys.path, so use spec_from_file_location.
-_keychain_path = Path.home() / "Developer/the-lodge/scripts/keychain_secrets.py"
-if _keychain_path.exists():
-    try:
-        spec = importlib.util.spec_from_file_location("keychain_secrets", _keychain_path)
-        if spec and spec.loader:
-            _keychain_mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(_keychain_mod)
-            _get_secret = getattr(_keychain_mod, "get_secret", None)
-            if _get_secret:
-                for key in ["OPENROUTER_API_KEY", "AIRTABLE_API_KEY", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"]:
-                    if key not in os.environ:
-                        value = _get_secret(key)
-                        if value:
-                            os.environ[key] = value
-    except Exception:
-        pass  # Keychain module not available (e.g., CI/Docker)
+from api.services.secrets import bootstrap_secrets
+
+bootstrap_secrets()
 
 from contextlib import asynccontextmanager
 
@@ -155,6 +137,9 @@ async def health():
     llm_client = get_llm_client()
     llm_status = llm_client.get_status()
 
+    # Get routing config for tier display
+    routing_config = llm_client.config.get("routing", {})
+
     return {
         "status": "ok",
         "queue": queue_stats,
@@ -167,6 +152,12 @@ async def health():
             "fallback_model": llm_status.get("fallback_model"),
             "phase_backends": llm_status.get("phase_backends"),
             "openrouter_presets": llm_status.get("openrouter_presets"),
+            "routing": {
+                "tiers": routing_config.get("tiers", []),
+                "tier_labels": routing_config.get("tier_labels", []),
+                "phase_base_tiers": routing_config.get("phase_base_tiers", {}),
+                "duration_thresholds": routing_config.get("duration_thresholds", []),
+            },
         },
         "last_run": llm_status.get("last_run_totals"),
     }

--- a/api/services/airtable.py
+++ b/api/services/airtable.py
@@ -6,37 +6,11 @@ Provides read-only access to the PBS Wisconsin SST (Single Source of Truth) tabl
 CRITICAL: This service is intentionally READ-ONLY. No write operations are permitted.
 """
 
-import importlib.util
-import os
-from pathlib import Path
 from typing import Optional
 
 import httpx
 
-# keychain_secrets isn't on sys.path, so use spec_from_file_location.
-_keychain_path = Path.home() / "Developer/the-lodge/scripts/keychain_secrets.py"
-get_secret = None
-if _keychain_path.exists():
-    try:
-        spec = importlib.util.spec_from_file_location("keychain_secrets", _keychain_path)
-        if spec and spec.loader:
-            _keychain_mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(_keychain_mod)
-            get_secret = getattr(_keychain_mod, "get_secret", None)
-    except Exception:
-        pass  # Keychain not available (CI/Docker)
-
-
-def _get_airtable_credential(key: str) -> Optional[str]:
-    """Get Airtable credential from environment first, Keychain as fallback."""
-    value = os.environ.get(key)
-    if value:
-        return value
-    if get_secret:
-        value = get_secret(key)
-        if value:
-            return value
-    return None
+from api.services.secrets import get_secret
 
 
 class AirtableClient:
@@ -66,7 +40,7 @@ class AirtableClient:
         Raises:
             ValueError: If no API key is provided or found.
         """
-        self.api_key = api_key or _get_airtable_credential("AIRTABLE_API_KEY")
+        self.api_key = api_key or get_secret("AIRTABLE_API_KEY")
         if not self.api_key:
             raise ValueError("Airtable API key required. Add to Keychain or set AIRTABLE_API_KEY env var.")
 

--- a/api/services/langfuse_client.py
+++ b/api/services/langfuse_client.py
@@ -13,55 +13,19 @@ Langfuse credentials are loaded from:
 2. macOS Keychain via keychain_secrets (fallback)
 """
 
-import importlib.util
 import json
 import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import httpx
-from dotenv import load_dotenv
 
 from api.services.logging import get_logger
+from api.services.secrets import get_secret as _get_langfuse_credential
 
 logger = get_logger(__name__)
-
-# Optionally load keychain_secrets without sys.path manipulation.
-# The module lives in ~/Developer/the-lodge/scripts/ and may not be
-# on sys.path, so we probe the known location with importlib.util.
-_keychain_get_secret = None
-_keychain_path = Path.home() / "Developer/the-lodge/scripts/keychain_secrets.py"
-if _keychain_path.exists():
-    try:
-        spec = importlib.util.spec_from_file_location("keychain_secrets", _keychain_path)
-        if spec and spec.loader:
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-            _keychain_get_secret = getattr(mod, "get_secret", None)
-    except Exception:
-        pass
-
-
-def _get_langfuse_credential(key: str) -> Optional[str]:
-    """Get Langfuse credential from environment first, Keychain as fallback."""
-    # Ensure .env is loaded (idempotent — safe to call multiple times)
-    load_dotenv()
-
-    # Prefer environment / .env (contains current, correct keys)
-    value = os.environ.get(key)
-    if value:
-        return value
-
-    # Fall back to Keychain
-    if _keychain_get_secret:
-        value = _keychain_get_secret(key)
-        if value:
-            return value
-
-    return None
 
 
 @dataclass

--- a/api/services/langfuse_client.py
+++ b/api/services/langfuse_client.py
@@ -14,7 +14,6 @@ Langfuse credentials are loaded from:
 """
 
 import json
-import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone

--- a/api/services/screengrab_attacher.py
+++ b/api/services/screengrab_attacher.py
@@ -20,7 +20,8 @@ from typing import List, Optional
 
 import httpx
 
-from api.services.airtable import AirtableClient, get_secret
+from api.services.airtable import AirtableClient
+from api.services.secrets import get_secret
 from api.services.database import get_session
 
 logger = logging.getLogger(__name__)

--- a/api/services/screengrab_attacher.py
+++ b/api/services/screengrab_attacher.py
@@ -21,8 +21,8 @@ from typing import List, Optional
 import httpx
 
 from api.services.airtable import AirtableClient
-from api.services.secrets import get_secret
 from api.services.database import get_session
+from api.services.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 

--- a/api/services/secrets.py
+++ b/api/services/secrets.py
@@ -1,0 +1,98 @@
+"""
+Centralized secret management for Cardigan.
+
+Resolution order:
+1. Docker secret file (/run/secrets/<name_lowercase>)
+2. Environment variable
+3. macOS Keychain via keychain_secrets (local dev only)
+
+This module replaces the duplicated keychain-loading boilerplate that was
+previously copy-pasted across main.py, run_worker.py, airtable.py, and
+langfuse_client.py.
+"""
+
+import importlib.util
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+DOCKER_SECRETS_DIR = Path("/run/secrets")
+
+# ---------------------------------------------------------------------------
+# macOS Keychain loader (local dev only — not available in Docker/CI)
+# ---------------------------------------------------------------------------
+_keychain_get_secret = None
+_keychain_path = Path.home() / "Developer/the-lodge/scripts/keychain_secrets.py"
+if _keychain_path.exists():
+    try:
+        spec = importlib.util.spec_from_file_location("keychain_secrets", _keychain_path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            _keychain_get_secret = getattr(mod, "get_secret", None)
+    except Exception:
+        pass
+
+
+def get_secret(key: str) -> Optional[str]:
+    """Get a secret value by name.
+
+    Checks in order:
+    1. Docker secret file at /run/secrets/<key_lowercase>
+    2. Environment variable with the exact key name
+    3. macOS Keychain (local dev fallback)
+
+    Returns None if the secret is not found in any source.
+    """
+    # 1. Docker secret file
+    secret_file = DOCKER_SECRETS_DIR / key.lower()
+    if secret_file.is_file():
+        try:
+            return secret_file.read_text().strip()
+        except OSError:
+            pass
+
+    # 2. Environment variable
+    value = os.environ.get(key)
+    if value:
+        return value
+
+    # 3. macOS Keychain
+    if _keychain_get_secret:
+        value = _keychain_get_secret(key)
+        if value:
+            return value
+
+    return None
+
+
+@lru_cache(maxsize=1)
+def _bootstrap_complete() -> bool:
+    """One-time bootstrap: populate os.environ from Docker secrets / Keychain.
+
+    Called from main.py and run_worker.py at startup so that downstream code
+    using os.environ.get() (e.g., middleware, LLM client) picks up secrets
+    without needing to call get_secret() directly.
+    """
+    keys = [
+        "OPENROUTER_API_KEY",
+        "AIRTABLE_API_KEY",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "CARDIGAN_API_KEY",
+    ]
+    for key in keys:
+        if key not in os.environ:
+            value = get_secret(key)
+            if value:
+                os.environ[key] = value
+    return True
+
+
+def bootstrap_secrets() -> None:
+    """Populate os.environ with secrets from Docker files / Keychain.
+
+    Safe to call multiple times — only runs once.
+    """
+    _bootstrap_complete()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,21 +2,26 @@
 # Usage: docker compose -f docker-compose.prod.yml up -d
 #
 # Requires:
-#   - .env file with API keys and CARDIGAN_API_KEY
+#   - Secret files in ./secrets/ (one value per file, no trailing newline)
 #   - docker login to ghcr.io (see Task 7 in the plan)
+#   - Optional: CORS_ORIGINS and DOCKER_CONFIG in .env for non-secret config
 
 services:
   api:
     image: ghcr.io/mriechers/cardigan-api:latest
     ports:
-      - "8000:8000"
-    env_file: .env
+      - "8100:8000"
     environment:
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
       - TRANSCRIPTS_DIR=/data/transcripts
+      - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -33,12 +38,16 @@ services:
 
   worker:
     image: ghcr.io/mriechers/cardigan-worker:latest
-    env_file: .env
     environment:
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
       - TRANSCRIPTS_DIR=/data/transcripts
+      - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -53,9 +62,9 @@ services:
   web:
     image: ghcr.io/mriechers/cardigan-web:latest
     ports:
-      - "3000:3000"
+      - "3100:3000"
     environment:
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
+      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY:-}
     depends_on:
       - api
     labels:
@@ -66,14 +75,18 @@ services:
     image: ghcr.io/mriechers/cardigan-api:latest
     command: ["python", "-m", "mcp_server.server"]
     ports:
-      - "8080:8080"
-    env_file: .env
+      - "8180:8080"
     environment:
       - MCP_TRANSPORT=http
       - EDITORIAL_API_URL=http://api:8000
       - DATABASE_PATH=/data/db/dashboard.db
-      - OUTPUT_DIR=/data/output
-      - TRANSCRIPTS_DIR=/data/transcripts
+      - EDITORIAL_OUTPUT_DIR=/data/output
+      - EDITORIAL_TRANSCRIPTS_DIR=/data/transcripts
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -114,6 +127,16 @@ services:
       # Only update containers with the watchtower.enable=true label
       - WATCHTOWER_LABEL_ENABLE=true
     restart: unless-stopped
+
+secrets:
+  openrouter_api_key:
+    file: ./secrets/openrouter_api_key
+  airtable_api_key:
+    file: ./secrets/airtable_api_key
+  langfuse_public_key:
+    file: ./secrets/langfuse_public_key
+  langfuse_secret_key:
+    file: ./secrets/langfuse_secret_key
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,23 @@ services:
       context: .
       dockerfile: Dockerfile.api
     ports:
-      - "8000:8000"
-    env_file: .env
+      - "8100:8000"
     environment:
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output
-      - CORS_ORIGINS=http://localhost:3001
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
+      - CORS_ORIGINS=http://localhost:3100
       - TRANSCRIPTS_DIR=/data/transcripts
+      - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
-      - transcript-data:/data/transcripts
+      - ./transcripts:/data/transcripts
+      - ./config:/app/config
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')"]
       interval: 30s
@@ -27,19 +32,24 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.worker
-    env_file: .env
     environment:
       - DATABASE_PATH=/data/db/dashboard.db
       - OUTPUT_DIR=/data/output
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
       - TRANSCRIPTS_DIR=/data/transcripts
+      - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       # NOTE: SQLite shared via volume between api + worker. WAL mode handles
       # concurrent access adequately for low-throughput workloads. Consider
       # PostgreSQL if write contention becomes an issue.
       - db-data:/data/db
       - output-data:/data/output
-      - transcript-data:/data/transcripts
+      - ./transcripts:/data/transcripts
+      - ./config:/app/config
     depends_on:
       api:
         condition: service_healthy
@@ -49,9 +59,9 @@ services:
       context: .
       dockerfile: Dockerfile.web
     ports:
-      - "3001:3000"
+      - "3100:3000"
     environment:
-      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY}
+      - CARDIGAN_API_KEY=${CARDIGAN_API_KEY:-}
     depends_on:
       - api
 
@@ -61,18 +71,22 @@ services:
       dockerfile: Dockerfile.api
     command: ["python", "-m", "mcp_server.server"]
     ports:
-      - "8080:8080"
-    env_file: .env
+      - "8180:8080"
     environment:
       - MCP_TRANSPORT=http
       - EDITORIAL_API_URL=http://api:8000
       - DATABASE_PATH=/data/db/dashboard.db
-      - OUTPUT_DIR=/data/output
-      - TRANSCRIPTS_DIR=/data/transcripts
+      - EDITORIAL_OUTPUT_DIR=/data/output
+      - EDITORIAL_TRANSCRIPTS_DIR=/data/transcripts
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
-      - transcript-data:/data/transcripts
+      - ./transcripts:/data/transcripts
     depends_on:
       api:
         condition: service_healthy
@@ -94,7 +108,16 @@ services:
       - tunnel
     restart: unless-stopped
 
+secrets:
+  openrouter_api_key:
+    file: ./secrets/openrouter_api_key
+  airtable_api_key:
+    file: ./secrets/airtable_api_key
+  langfuse_public_key:
+    file: ./secrets/langfuse_public_key
+  langfuse_secret_key:
+    file: ./secrets/langfuse_secret_key
+
 volumes:
   db-data:
   output-data:
-  transcript-data:

--- a/run_worker.py
+++ b/run_worker.py
@@ -18,7 +18,6 @@ Secrets:
 
 import argparse
 import asyncio
-import os
 import signal
 
 from dotenv import load_dotenv

--- a/run_worker.py
+++ b/run_worker.py
@@ -12,40 +12,22 @@ Run multiple workers for parallel processing:
     ./venv/bin/python run_worker.py --worker-id worker-2 --concurrent 2 &
 
 Secrets:
-    API keys are loaded from macOS Keychain (service: developer.workspace.*)
-    Falls back to .env file or environment variables for CI/Docker.
+    API keys are loaded from Docker secret files (/run/secrets/),
+    environment variables, or macOS Keychain (local dev fallback).
 """
 
 import argparse
 import asyncio
-import importlib.util
 import os
 import signal
-from pathlib import Path
 
-# Load .env file FIRST — it contains the current, correct credentials
 from dotenv import load_dotenv
 
 load_dotenv()
 
-# Then backfill from Keychain for any keys still missing.
-# keychain_secrets isn't on sys.path, so use spec_from_file_location.
-_keychain_path = Path.home() / "Developer/the-lodge/scripts/keychain_secrets.py"
-if _keychain_path.exists():
-    try:
-        spec = importlib.util.spec_from_file_location("keychain_secrets", _keychain_path)
-        if spec and spec.loader:
-            _keychain_mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(_keychain_mod)
-            _get_secret = getattr(_keychain_mod, "get_secret", None)
-            if _get_secret:
-                for key in ["OPENROUTER_API_KEY", "AIRTABLE_API_KEY"]:
-                    if key not in os.environ:
-                        value = _get_secret(key)
-                        if value:
-                            os.environ[key] = value
-    except Exception:
-        pass  # Keychain module not available (e.g., CI/Docker)
+from api.services.secrets import bootstrap_secrets
+
+bootstrap_secrets()
 
 import json
 from pathlib import Path

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,40 @@
+# Docker Secrets
+
+Each file in this directory contains a single secret value (no quotes, no
+trailing newline). Docker Compose mounts them into containers at
+`/run/secrets/<filename>`.
+
+This directory is gitignored. To set up a new deployment, create each file
+below and paste in the raw key value.
+
+## Required secrets
+
+### openrouter_api_key
+LLM API access for the 4-phase pipeline (Analyst, Formatter, SEO, Manager).
+Get a key at https://openrouter.ai/settings/keys — starts with `sk-or-v1-`.
+
+### airtable_api_key
+Read-only access to the PBS Wisconsin Single Source of Truth table.
+Create a Personal Access Token at https://airtable.com/create/tokens with
+read-only scopes on the `appZ2HGwhiifQToB6` base. Starts with `pat`.
+
+### langfuse_public_key
+Observability — traces LLM calls, token usage, and costs.
+Create an API key pair in your Langfuse project settings
+(Settings > API Keys). Starts with `pk-lf-`.
+
+### langfuse_secret_key
+The secret half of the Langfuse API key pair (created at the same time
+as the public key above). Starts with `sk-lf-`.
+
+## Optional secrets (passed as env vars, not files)
+
+### CARDIGAN_API_KEY
+API authentication for the Cardigan dashboard. Set as an environment
+variable in `.env` or your shell. When empty or absent, auth is disabled
+(dev mode). Generate with: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`
+
+### CLOUDFLARE_TUNNEL_TOKEN
+Only needed when running with `--profile tunnel` for remote access.
+Set as an environment variable. Get from Cloudflare Zero Trust >
+Tunnels > configure your tunnel. Starts with `eyJ`.

--- a/secrets/airtable_api_key.example
+++ b/secrets/airtable_api_key.example
@@ -1,0 +1,1 @@
+patXXXXXXXXXXXXXX.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/secrets/langfuse_public_key.example
+++ b/secrets/langfuse_public_key.example
@@ -1,0 +1,1 @@
+pk-lf-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/secrets/langfuse_secret_key.example
+++ b/secrets/langfuse_secret_key.example
@@ -1,0 +1,1 @@
+sk-lf-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/secrets/openrouter_api_key.example
+++ b/secrets/openrouter_api_key.example
@@ -1,0 +1,1 @@
+sk-or-v1-your-key-here

--- a/tests/api/test_langfuse_client.py
+++ b/tests/api/test_langfuse_client.py
@@ -13,7 +13,6 @@ import pytest
 from api.services.langfuse_client import (
     LangfuseClient,
     ModelStatsResponse,
-    _get_langfuse_credential,
     get_langfuse_client,
 )
 from api.services.secrets import get_secret

--- a/tests/api/test_langfuse_client.py
+++ b/tests/api/test_langfuse_client.py
@@ -16,51 +16,49 @@ from api.services.langfuse_client import (
     _get_langfuse_credential,
     get_langfuse_client,
 )
+from api.services.secrets import get_secret
 
 # ---------------------------------------------------------------------------
-# Credential loading
+# Credential loading (now tests api.services.secrets.get_secret)
 # ---------------------------------------------------------------------------
 
 
 class TestCredentialLoading:
-    """Tests for _get_langfuse_credential() priority order."""
+    """Tests for get_secret() priority order (Docker file → env → Keychain)."""
 
     @patch.dict("os.environ", {"LANGFUSE_PUBLIC_KEY": "pk-from-env"}, clear=False)
     def test_env_takes_priority_over_keychain(self):
         """Environment variable should be returned even if Keychain has a value."""
-        with patch("api.services.langfuse_client._keychain_get_secret", lambda k: "pk-from-keychain"):
-            result = _get_langfuse_credential("LANGFUSE_PUBLIC_KEY")
+        with patch("api.services.secrets._keychain_get_secret", lambda k: "pk-from-keychain"):
+            result = get_secret("LANGFUSE_PUBLIC_KEY")
         assert result == "pk-from-env"
 
-    @patch("api.services.langfuse_client.load_dotenv")
     @patch.dict("os.environ", {}, clear=True)
-    def test_falls_back_to_keychain(self, _mock_dotenv):
+    def test_falls_back_to_keychain(self):
         """When env var is missing, should fall back to Keychain."""
-        with patch("api.services.langfuse_client._keychain_get_secret", lambda k: "pk-from-keychain"):
-            result = _get_langfuse_credential("LANGFUSE_PUBLIC_KEY")
+        with patch("api.services.secrets._keychain_get_secret", lambda k: "pk-from-keychain"):
+            result = get_secret("LANGFUSE_PUBLIC_KEY")
         assert result == "pk-from-keychain"
 
-    @patch("api.services.langfuse_client.load_dotenv")
     @patch.dict("os.environ", {}, clear=True)
-    def test_returns_none_when_nothing_available(self, _mock_dotenv):
+    def test_returns_none_when_nothing_available(self):
         """When neither env nor Keychain has the key, return None."""
-        with patch("api.services.langfuse_client._keychain_get_secret", lambda k: None):
-            result = _get_langfuse_credential("LANGFUSE_PUBLIC_KEY")
+        with patch("api.services.secrets._keychain_get_secret", lambda k: None):
+            result = get_secret("LANGFUSE_PUBLIC_KEY")
         assert result is None
 
-    @patch("api.services.langfuse_client.load_dotenv")
     @patch.dict("os.environ", {}, clear=True)
-    def test_returns_none_when_keychain_unavailable(self, _mock_dotenv):
+    def test_returns_none_when_keychain_unavailable(self):
         """When Keychain module isn't loaded, return None for missing env var."""
-        with patch("api.services.langfuse_client._keychain_get_secret", None):
-            result = _get_langfuse_credential("LANGFUSE_PUBLIC_KEY")
+        with patch("api.services.secrets._keychain_get_secret", None):
+            result = get_secret("LANGFUSE_PUBLIC_KEY")
         assert result is None
 
     @patch.dict("os.environ", {"MY_KEY": "env-val"}, clear=False)
     def test_env_value_returned_when_keychain_unavailable(self):
         """Env var returned even when Keychain module isn't loaded."""
-        with patch("api.services.langfuse_client._keychain_get_secret", None):
-            result = _get_langfuse_credential("MY_KEY")
+        with patch("api.services.secrets._keychain_get_secret", None):
+            result = get_secret("MY_KEY")
         assert result == "env-val"
 
 


### PR DESCRIPTION
## Summary
- Centralized secret management in `api/services/secrets.py` with three-tier resolution: Docker file → env var → macOS Keychain
- Replaced duplicated keychain boilerplate across `main.py`, `run_worker.py`, `airtable.py`, and `langfuse_client.py`
- Docker Compose now uses file-based secrets for 4 required keys (OpenRouter, Airtable, Langfuse public/secret)
- CARDIGAN_API_KEY and CLOUDFLARE_TUNNEL_TOKEN remain optional env vars
- Added `secrets/` directory with README and `.example` placeholder files
- Ports remapped to 81xx/31xx range, transcripts/config use bind mounts

## Test plan
- [ ] Verify `api/services/secrets.py` correctly reads from `/run/secrets/` in Docker
- [ ] Verify `.env` fallback still works for local development
- [ ] Verify Keychain fallback works on macOS without Docker
- [ ] Run `pytest tests/api/test_langfuse_client.py` — credential loading tests updated
- [ ] Docker build + deploy with `secrets/` files populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)