### PR TITLE
feat: Port remapping refs, tier-aware escalation, and ingest improvements

### DIFF
--- a/.claude/agents/copy_editor.md
+++ b/.claude/agents/copy_editor.md
@@ -146,7 +146,7 @@ In CLI context (no MCP tools), all revisions are delivered as inline chat respon
 Handle missing resources gracefully, with the same warmth you'd show a neighbor who stopped by while you were still setting up.
 
 ### If pipeline output isn't in the local OUTPUT directory:
-The pipeline may be running in Docker — output lives in a Docker volume, not the local filesystem. Before giving up, check the REST API at `localhost:8000`:
+The pipeline may be running in Docker — output lives in a Docker volume, not the local filesystem. Before giving up, check the REST API at `localhost:8100`:
 - `GET /api/jobs` to find the project
 - `GET /api/jobs/{id}/outputs/{filename}` to read individual files
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
       "args": ["-m", "mcp_server.server"],
       "cwd": "/Users/mriechers/Developer/cardigan-v4",
       "env": {
-        "EDITORIAL_API_URL": "http://localhost:8000"
+        "EDITORIAL_API_URL": "http://localhost:8100"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ cd web && npm run dev
 
 | URL | Description |
 |-----|-------------|
-| http://localhost:8000 | API server |
-| http://localhost:8000/docs | Interactive API docs (Swagger) |
-| http://localhost:3000 | Web dashboard |
+| http://localhost:8100 | API server |
+| http://localhost:8100/docs | Interactive API docs (Swagger) |
+| http://localhost:3100 | Web dashboard |
 
 See [docs/QUICK_START.md](docs/QUICK_START.md) for detailed setup instructions.
 
@@ -188,10 +188,10 @@ docker compose up -d
 
 ```bash
 # API health check
-curl http://localhost:8000/api/system/health
+curl http://localhost:8100/api/system/health
 
 # Open the web dashboard
-open http://localhost:3000
+open http://localhost:3100
 ```
 
 ### Stop

--- a/api/models/job.py
+++ b/api/models/job.py
@@ -107,6 +107,9 @@ class JobUpdate(BaseModel):
 
     status: Optional[JobStatus] = None
     priority: Optional[int] = None
+    transcript_file: Optional[str] = None
+    project_name: Optional[str] = None
+    project_path: Optional[str] = None
     current_phase: Optional[str] = None
     error_message: Optional[str] = None
     estimated_cost: Optional[float] = None

--- a/api/routers/chat_prototype.py
+++ b/api/routers/chat_prototype.py
@@ -74,10 +74,13 @@ async def send_chat_message(request: ChatRequest) -> ChatResponse:
         llm = get_llm_client()
         chat_config = llm.config.get("chat", {})
 
+        # Route through the tier system (respects phase_base_tiers setting)
+        backend = llm.get_backend_for_phase("chat")
+
         # Make the LLM call
         response = await llm.chat(
             messages=messages,
-            backend=chat_config.get("backend", "openrouter"),
+            backend=backend,
             phase="chat",  # For Langfuse tracing
             max_tokens=chat_config.get("max_tokens", 4096),
             temperature=chat_config.get("temperature", 0.7),

--- a/api/routers/langfuse.py
+++ b/api/routers/langfuse.py
@@ -307,12 +307,10 @@ async def get_phase_stats(
 
         # Calculate escalation rate relative to configured base tier
         configured_tier = phase_base_tiers.get(phase_name, 0)
-        at_or_below = sum(
-            m.completions for m in ps.models if m.tier is not None and m.tier <= configured_tier
-        ) + sum(m.completions for m in ps.models if m.tier is None)
-        escalated_completions = sum(
-            m.completions for m in ps.models if m.tier is not None and m.tier > configured_tier
+        at_or_below = sum(m.completions for m in ps.models if m.tier is not None and m.tier <= configured_tier) + sum(
+            m.completions for m in ps.models if m.tier is None
         )
+        escalated_completions = sum(m.completions for m in ps.models if m.tier is not None and m.tier > configured_tier)
         if ps.total_completions > 0:
             ps.escalation_rate = round(escalated_completions / ps.total_completions * 100, 1)
 

--- a/api/routers/langfuse.py
+++ b/api/routers/langfuse.py
@@ -168,6 +168,8 @@ class PhaseStatsResponse(BaseModel):
     total_completions: int = Field(0)
     total_failures: int = Field(0)
     escalation_summary: Dict[str, Any] = Field(default_factory=dict)
+    phase_base_tiers: Dict[str, int] = Field(default_factory=dict, description="Current configured tier per phase")
+    tier_labels: List[str] = Field(default_factory=list, description="Human-readable tier names")
 
 
 @router.get("/phase-stats", response_model=PhaseStatsResponse)
@@ -282,6 +284,12 @@ async def get_phase_stats(
         ps = phase_data[phase_name]
         ps.total_failures = sum(tier_failures.values())
 
+    # Load current routing config for tier-relative escalation calculation
+    from api.services.llm import get_llm_client
+
+    llm_config = get_llm_client().config
+    phase_base_tiers = llm_config.get("routing", {}).get("phase_base_tiers", {})
+
     # Calculate overall stats and escalation rates
     total_cost = 0.0
     total_completions = 0
@@ -297,20 +305,28 @@ async def get_phase_stats(
         total_attempts = ps.total_completions + ps.total_failures
         ps.success_rate = round((ps.total_completions / total_attempts * 100) if total_attempts > 0 else 0, 1)
 
-        # Calculate escalation rate (how many finished at tier > 0)
-        base_tier_completions = sum(m.completions for m in ps.models if m.tier == 0 or m.tier is None)
-        escalated_completions = sum(m.completions for m in ps.models if m.tier is not None and m.tier > 0)
+        # Calculate escalation rate relative to configured base tier
+        configured_tier = phase_base_tiers.get(phase_name, 0)
+        at_or_below = sum(
+            m.completions for m in ps.models if m.tier is not None and m.tier <= configured_tier
+        ) + sum(m.completions for m in ps.models if m.tier is None)
+        escalated_completions = sum(
+            m.completions for m in ps.models if m.tier is not None and m.tier > configured_tier
+        )
         if ps.total_completions > 0:
             ps.escalation_rate = round(escalated_completions / ps.total_completions * 100, 1)
 
         escalation_summary["by_phase"][phase_name] = {
-            "base_tier": base_tier_completions,
+            "configured_tier": configured_tier,
+            "at_configured": at_or_below,
             "escalated": escalated_completions,
             "rate": ps.escalation_rate,
         }
 
     # Sort phases by name
     phases = sorted(phase_data.values(), key=lambda p: p.phase)
+
+    tier_labels = llm_config.get("routing", {}).get("tier_labels", [])
 
     return PhaseStatsResponse(
         phases=phases,
@@ -321,4 +337,6 @@ async def get_phase_stats(
         total_completions=total_completions,
         total_failures=total_failures,
         escalation_summary=escalation_summary,
+        phase_base_tiers=phase_base_tiers,
+        tier_labels=tier_labels,
     )

--- a/api/services/database.py
+++ b/api/services/database.py
@@ -568,6 +568,15 @@ async def update_job(job_id: int, job_update: JobUpdate) -> Optional[Job]:
         if job_update.priority is not None:
             update_values["priority"] = job_update.priority
 
+        if job_update.transcript_file is not None:
+            update_values["transcript_file"] = job_update.transcript_file
+
+        if job_update.project_name is not None:
+            update_values["project_name"] = job_update.project_name
+
+        if job_update.project_path is not None:
+            update_values["project_path"] = job_update.project_path
+
         if job_update.current_phase is not None:
             update_values["current_phase"] = job_update.current_phase
 

--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -22,7 +22,7 @@ from bs4 import BeautifulSoup
 from sqlalchemy import text
 
 from api.services.database import get_session
-from api.services.utils import extract_media_id, sanitize_duplicate_filename
+from api.services.utils import extract_media_id
 
 logger = logging.getLogger(__name__)
 

--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -22,7 +22,7 @@ from bs4 import BeautifulSoup
 from sqlalchemy import text
 
 from api.services.database import get_session
-from api.services.utils import sanitize_duplicate_filename
+from api.services.utils import extract_media_id, sanitize_duplicate_filename
 
 logger = logging.getLogger(__name__)
 
@@ -501,13 +501,17 @@ class IngestScanner:
         """
         Extract Media ID from filename using PBS Wisconsin conventions.
 
+        Delegates to the shared extract_media_id() utility after URL-decoding
+        and stripping duplicate extensions (remote server artifacts).
+
         Examples:
             "2WLI1209HD_transcript.srt" -> "2WLI1209HD"
             "9UNP2005_screengrab.jpg" -> "9UNP2005"
-            "WPT_2401_final.srt" -> None (doesn't match pattern)
+            "WPT_2401_final.srt" -> "WPT_2401_final"
             "2WLI1209HD%20(2).srt" -> "2WLI1209HD" (URL-encoded, duplicate stripped)
             "2WLI1209HD.srt.srt" -> "2WLI1209HD" (duplicate extension)
             "2WLIComicArtistSM (1).srt" -> "2WLIComicArtistSM" (OS duplicate stripped)
+            "2WLIAliceGoodSM_REV20251106.srt" -> "2WLIAliceGoodSM_REV20251106"
         """
         # URL-decode the filename first (handles %20, etc.)
         decoded = unquote(filename)
@@ -518,19 +522,8 @@ class IngestScanner:
         while decoded.endswith(".txt.txt"):
             decoded = decoded[:-4]
 
-        # Remove extension for sanitization
-        if "." in decoded:
-            name_part = decoded.rsplit(".", 1)[0]
-        else:
-            name_part = decoded
-
-        # Sanitize OS duplicate patterns like (1), - Copy, copy 2
-        sanitized, was_duplicate = sanitize_duplicate_filename(name_part)
-
-        match = self.MEDIA_ID_PATTERN.search(sanitized)
-        if match:
-            return match.group(1).upper()
-        return None
+        # Delegate to shared utility for consistent media ID extraction
+        return extract_media_id(decoded)
 
     def _parse_file_metadata(self, link_element) -> tuple[Optional[int], Optional[datetime]]:
         """

--- a/api/services/screengrab_attacher.py
+++ b/api/services/screengrab_attacher.py
@@ -21,8 +21,8 @@ from typing import List, Optional
 import httpx
 
 from api.services.airtable import AirtableClient
-from api.services.secrets import get_secret
 from api.services.database import get_session
+from api.services.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 

--- a/api/services/utils.py
+++ b/api/services/utils.py
@@ -280,8 +280,10 @@ def extract_media_id(filename: str) -> Optional[str]:
 
     # Step 3: Match PBS Media ID pattern
     # e.g., 2WLI1209HD, 6GWQ2503, 2BUC0000HDWEB02
+    # Reject matches starting with "REV" — those are revision date suffixes
+    # (e.g., _REV20251106 falsely matching REV20251 as a show code)
     match = re.search(r"([A-Z0-9]{4}\d{4}(?:[A-Z]+\d{0,2})?)", sanitized, re.IGNORECASE)
-    if match:
+    if match and not match.group(1).upper().startswith("REV"):
         base_id = match.group(1).upper()
         # Check if a _REV[date] suffix follows the matched base ID in the sanitized stem
         rev_match = re.search(
@@ -289,7 +291,7 @@ def extract_media_id(filename: str) -> Optional[str]:
             sanitized,
             re.IGNORECASE,
         )
-        if rev_match:
+        if rev_match and not rev_match.group(1).upper().startswith("REV"):
             return (rev_match.group(1) + rev_match.group(2)).upper()
         return base_id
 

--- a/docs/AGENT_INTERFACE_GUIDE.md
+++ b/docs/AGENT_INTERFACE_GUIDE.md
@@ -4,26 +4,26 @@ This guide is a single, high-signal entry point for agents that need to interfac
 
 ## Quick Start (Minimal Integration)
 1) Check health
-- `GET http://localhost:8000/`
-- `GET http://localhost:8000/api/system/health`
+- `GET http://localhost:8100/`
+- `GET http://localhost:8100/api/system/health`
 
 2) List queue
-- `GET http://localhost:8000/api/queue/?status=pending&page=1&page_size=50`
+- `GET http://localhost:8100/api/queue/?status=pending&page=1&page_size=50`
 
 3) Fetch job details and outputs
-- `GET http://localhost:8000/api/jobs/{job_id}`
-- `GET http://localhost:8000/api/jobs/{job_id}/outputs/manifest.json`
-- `GET http://localhost:8000/api/jobs/{job_id}/outputs/analyst_output.md`
+- `GET http://localhost:8100/api/jobs/{job_id}`
+- `GET http://localhost:8100/api/jobs/{job_id}/outputs/manifest.json`
+- `GET http://localhost:8100/api/jobs/{job_id}/outputs/analyst_output.md`
 
 4) WebSocket for live updates
-- Connect: `ws://localhost:8000/api/ws/jobs`
+- Connect: `ws://localhost:8100/api/ws/jobs`
 - Listen for `job_*` and `stats_updated` events
 
 5) MCP (Cardigan) for copy editing
 - Use MCP tools to list, load, and save project artifacts without touching the API directly.
 
 ## API Interface (HTTP)
-Base URL: `http://localhost:8000`
+Base URL: `http://localhost:8100`
 
 ### Health
 - `GET /` -> `{ "status": "ok", "version": "3.0.0-dev" }`

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # Editorial Assistant API Reference
 
 ## Overview
-- Base URL: `http://localhost:8000`
+- Base URL: `http://localhost:8100`
 - API prefix: `/api`
 - WebSocket: `/api/ws/jobs`
 - Auth: none (local dev by default)

--- a/docs/CLAUDE_DESKTOP_SETUP.md
+++ b/docs/CLAUDE_DESKTOP_SETUP.md
@@ -182,7 +182,7 @@ The MCP server supports these environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EDITORIAL_API_URL` | `http://localhost:8000` | The Metadata Neighborhood API URL |
+| `EDITORIAL_API_URL` | `http://localhost:8100` | The Metadata Neighborhood API URL |
 | `EDITORIAL_OUTPUT_DIR` | `./OUTPUT` | Project output directory |
 | `EDITORIAL_TRANSCRIPTS_DIR` | `./transcripts` | Transcript source directory |
 | `AIRTABLE_API_KEY` | (none) | For SST metadata lookup (READ-ONLY) |

--- a/docs/MCP_REFERENCE.md
+++ b/docs/MCP_REFERENCE.md
@@ -11,7 +11,7 @@
 - Airtable: READ-ONLY SST lookups (requires `AIRTABLE_API_KEY`)
 
 ## Environment
-- `EDITORIAL_API_URL` (default `http://localhost:8000`)
+- `EDITORIAL_API_URL` (default `http://localhost:8100`)
 - `EDITORIAL_OUTPUT_DIR` (default `OUTPUT`)
 - `EDITORIAL_TRANSCRIPTS_DIR` (default `transcripts`)
 - `AIRTABLE_API_KEY` (optional; required for SST lookups)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -53,9 +53,9 @@ This runs database migrations, starts the API server, and launches the worker.
 
 | URL | Description |
 |-----|-------------|
-| http://metadata.neighborhood:8000 | API (after domain setup) |
-| http://localhost:8000 | API (always works) |
-| http://localhost:3000 | Web dashboard (run `cd web && npm run dev`) |
+| http://metadata.neighborhood:8100 | API (after domain setup) |
+| http://localhost:8100 | API (always works) |
+| http://localhost:3100 | Web dashboard (run `cd web && npm run dev`) |
 
 ### Shell Aliases (add to ~/.zshrc)
 
@@ -67,7 +67,7 @@ alias neighborhood-start="$NEIGHBORHOOD/scripts/start.sh"
 alias neighborhood-stop="$NEIGHBORHOOD/scripts/stop.sh"
 alias neighborhood-status="$NEIGHBORHOOD/scripts/status.sh"
 alias neighborhood-logs="tail -f $NEIGHBORHOOD/logs/api.log $NEIGHBORHOOD/logs/worker.log"
-alias neighborhood-queue="curl -s http://metadata.neighborhood:8000/api/queue/stats | python3 -m json.tool"
+alias neighborhood-queue="curl -s http://metadata.neighborhood:8100/api/queue/stats | python3 -m json.tool"
 ```
 
 ## Meet Cardigan
@@ -86,7 +86,7 @@ Cardigan speaks like Mister Rogers — warm, patient, and genuinely delighted to
 ### Add a transcript to the queue
 
 ```bash
-curl -X POST http://metadata.neighborhood:8000/api/queue \
+curl -X POST http://metadata.neighborhood:8100/api/queue \
   -H "Content-Type: application/json" \
   -d '{"transcript_file": "MY_TRANSCRIPT.txt"}'
 ```
@@ -104,7 +104,7 @@ curl -X POST http://metadata.neighborhood:8000/api/queue \
 ### Check queue status
 
 ```bash
-curl http://metadata.neighborhood:8000/api/queue/stats
+curl http://metadata.neighborhood:8100/api/queue/stats
 ```
 
 ## Troubleshooting

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -14,11 +14,11 @@ Cloudflare Edge (TLS termination + Access auth)
   |
   | cloudflared tunnel (encrypted QUIC, outbound from your Mac)
   v
-localhost:3000 (Vite dev server)
+localhost:3100 (Vite dev server)
   |
   | proxy /api/* and /api/ws/*
   v
-localhost:8000 (FastAPI / uvicorn)
+localhost:8100 (FastAPI / uvicorn)
 ```
 
 No ports are opened on your machine. The tunnel is outbound-only.

--- a/docs/WEBSOCKET_IMPLEMENTATION.md
+++ b/docs/WEBSOCKET_IMPLEMENTATION.md
@@ -62,7 +62,7 @@ WebSocket messages are JSON objects:
 
 ## Connection Flow
 
-1. Client connects to `ws://localhost:8000/api/ws/jobs`
+1. Client connects to `ws://localhost:8100/api/ws/jobs`
 2. Server accepts connection and adds to active connections
 3. Server broadcasts updates when jobs change
 4. Client sends "ping" every 30s, server responds with "pong"

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -16,7 +16,7 @@ Tools provided:
 - Load project context (transcript, brainstorming, revisions, SST metadata)
 - Save revisions and keyword reports with auto-versioning
 
-Connects to the FastAPI backend on localhost:8000 for job metadata,
+Connects to the FastAPI backend on localhost:8100 for job metadata,
 and reads/writes directly to the OUTPUT folder for content.
 
 NOTE: Airtable writes are restricted to allowlisted fields via the
@@ -66,7 +66,7 @@ if _keychain_path.exists():
         pass  # Keychain module not available (e.g., CI/Docker)
 
 # Configuration
-API_BASE_URL = os.getenv("EDITORIAL_API_URL", "http://localhost:8000")
+API_BASE_URL = os.getenv("EDITORIAL_API_URL", "http://localhost:8100")
 OUTPUT_DIR = Path(os.getenv("EDITORIAL_OUTPUT_DIR", Path(__file__).parent.parent / "OUTPUT"))
 TRANSCRIPTS_DIR = Path(os.getenv("EDITORIAL_TRANSCRIPTS_DIR", Path(__file__).parent.parent / "transcripts"))
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -79,32 +79,32 @@ echo ""
 echo "Connectivity:"
 
 # Test localhost API
-echo -n "  localhost:8000:           "
-if curl -s --connect-timeout 2 http://localhost:8000/api/system/health > /dev/null 2>&1; then
+echo -n "  localhost:8100:           "
+if curl -s --connect-timeout 2 http://localhost:8100/api/system/health > /dev/null 2>&1; then
     echo "✅ Responding"
 else
     echo "❌ Not responding"
 fi
 
 # Test metadata.neighborhood API
-echo -n "  metadata.neighborhood:8000: "
-if curl -s --connect-timeout 2 http://metadata.neighborhood:8000/api/system/health > /dev/null 2>&1; then
+echo -n "  metadata.neighborhood:8100: "
+if curl -s --connect-timeout 2 http://metadata.neighborhood:8100/api/system/health > /dev/null 2>&1; then
     echo "✅ Responding"
 else
     echo "❌ Not responding"
 fi
 
 # Test localhost frontend
-echo -n "  localhost:3000:           "
-if curl -s --connect-timeout 2 http://localhost:3000 > /dev/null 2>&1; then
+echo -n "  localhost:3100:           "
+if curl -s --connect-timeout 2 http://localhost:3100 > /dev/null 2>&1; then
     echo "✅ Responding"
 else
     echo "❌ Not responding"
 fi
 
 # Test metadata.neighborhood frontend
-echo -n "  metadata.neighborhood:3000: "
-if curl -s --connect-timeout 2 http://metadata.neighborhood:3000 > /dev/null 2>&1; then
+echo -n "  metadata.neighborhood:3100: "
+if curl -s --connect-timeout 2 http://metadata.neighborhood:3100 > /dev/null 2>&1; then
     echo "✅ Responding"
 else
     echo "❌ Not responding"
@@ -113,8 +113,8 @@ fi
 # Queue stats
 echo ""
 echo "Queue Status:"
-if curl -s http://localhost:8000/api/queue/stats > /dev/null 2>&1; then
-    QUEUE=$(curl -s http://localhost:8000/api/queue/stats 2>/dev/null)
+if curl -s http://localhost:8100/api/queue/stats > /dev/null 2>&1; then
+    QUEUE=$(curl -s http://localhost:8100/api/queue/stats 2>/dev/null)
     PENDING=$(echo "$QUEUE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('pending',0))" 2>/dev/null || echo "?")
     IN_PROGRESS=$(echo "$QUEUE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('in_progress',0))" 2>/dev/null || echo "?")
     COMPLETED=$(echo "$QUEUE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('completed',0))" 2>/dev/null || echo "?")

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -189,9 +189,8 @@ class TestMediaIdExtraction:
         scanner = IngestScanner()
 
         # macOS adds " (1)" when downloading duplicates
-        # Note: Scanner pattern requires 4 chars + 4 digits format
-        # "2WLIComicArtistSM" doesn't match that pattern, so returns None
-        assert scanner._extract_media_id("2WLIComicArtistSM (1).srt") is None  # No 4+4 pattern
+        # SM-style names without 4+4 pattern fall back to full sanitized stem
+        assert scanner._extract_media_id("2WLIComicArtistSM (1).srt") == "2WLIComicArtistSM"
         assert scanner._extract_media_id("2WLI1209HD (2).srt") == "2WLI1209HD"
         assert scanner._extract_media_id("9UNP2005HD (3).txt") == "9UNP2005HD"
 
@@ -204,13 +203,12 @@ class TestMediaIdExtraction:
         assert scanner._extract_media_id("2WLI1209HD copy 2.srt") == "2WLI1209HD"
 
     def test_extract_media_id_preserves_revision_dates(self):
-        """Test that _REV[date] patterns are NOT stripped (legitimate IDs)."""
+        """Test that _REV[date] patterns are preserved as part of the full media ID."""
         scanner = IngestScanner()
 
-        # _REV patterns should be preserved - they're legitimate Media IDs
-        # Note: Pattern only extracts base 8-char ID, so _REV part isn't in result
+        # _REV patterns are preserved — they distinguish revisions from originals
         result = scanner._extract_media_id("2BUC0000HDWEB02_REV20251202.srt")
-        assert result == "2BUC0000HD"  # Pattern extracts base ID
+        assert result == "2BUC0000HDWEB02_REV20251202"
 
     def test_extract_media_id_without_suffix(self):
         """Test extracting Media ID without HD suffix."""
@@ -220,12 +218,11 @@ class TestMediaIdExtraction:
         assert scanner._extract_media_id("9UNP2005.srt") == "9UNP2005"
 
     def test_extract_media_id_with_web_suffix(self):
-        """Test extracting Media ID with WEB suffix (extracts base ID only)."""
+        """Test extracting Media ID with WEB suffix preserves full ID."""
         scanner = IngestScanner()
 
-        # Pattern only matches 4 chars + 4 digits + up to 2 letters
-        # "2BUC0000HDWEB02" has more than 2 letters at end, so extracts "2BUC0000HD"
-        assert scanner._extract_media_id("2BUC0000HDWEB02_REV20251202.srt") == "2BUC0000HD"
+        # Full media ID including WEB suffix and revision date
+        assert scanner._extract_media_id("2BUC0000HDWEB02_REV20251202.srt") == "2BUC0000HDWEB02_REV20251202"
 
     def test_extract_media_id_case_insensitive(self):
         """Test Media ID extraction is case insensitive but returns uppercase."""
@@ -235,12 +232,20 @@ class TestMediaIdExtraction:
         assert scanner._extract_media_id("9unp2005HD.srt") == "9UNP2005HD"
 
     def test_no_match_returns_none(self):
-        """Test that non-matching filenames return None."""
+        """Test that filenames with spaces return None (freeform text, not IDs)."""
         scanner = IngestScanner()
 
-        assert scanner._extract_media_id("README.txt") is None
-        assert scanner._extract_media_id("notes.srt") is None
-        assert scanner._extract_media_id("WPT_2401_final.srt") is None
+        # Filenames with spaces are treated as freeform text, not valid IDs
+        assert scanner._extract_media_id("TLB CC IN WI.srt") is None
+
+    def test_fallback_to_stem_for_non_standard_names(self):
+        """Test that non-standard filenames without spaces fall back to full stem."""
+        scanner = IngestScanner()
+
+        # These don't match 4+4 pattern but are valid underscore-separated IDs
+        assert scanner._extract_media_id("README.txt") == "README"
+        assert scanner._extract_media_id("notes.srt") == "notes"
+        assert scanner._extract_media_id("WPT_2401_final.srt") == "WPT_2401_final"
 
     def test_empty_string_returns_none(self):
         """Test that empty string returns None."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,3 +144,17 @@ class TestExtractMediaId:
         # These don't match the 4+4 pattern but should still work
         assert extract_media_id("Some_Project_Name.txt") == "Some_Project_Name"
         assert extract_media_id("WC_S01_trailer.srt") == "WC_S01_trailer"
+
+    def test_sm_style_filenames_no_rev_false_positive(self):
+        """Test that SM-style filenames don't false-match REV dates as media IDs."""
+        # SM-style: show code + title slug, no standard 4+4 episode number.
+        # The _REV suffix is a revision date, NOT a show code.
+        assert extract_media_id("2WLIAliceGoodSM_REV20251106.srt") == "2WLIAliceGoodSM_REV20251106"
+        assert extract_media_id("2WLIExchangeStudentSM.srt") == "2WLIExchangeStudentSM"
+        assert extract_media_id("6WLIBigfootConvention_ForClaude.txt") == "6WLIBigfootConvention"
+
+    def test_rev_suffix_not_extracted_as_media_id(self):
+        """Test that _REV date suffixes are never mistaken for show codes."""
+        # Previously, REV20251 would match [A-Z0-9]{4}\\d{4} as a false positive
+        result = extract_media_id("2WLIAliceGoodSM_REV20251106.srt")
+        assert result != "REV20251", "REV date suffix should not be extracted as media ID"

--- a/watch_transcripts.py
+++ b/watch_transcripts.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import httpx
 
 TRANSCRIPTS_DIR = Path("transcripts")
-API_BASE = "http://localhost:8000"
+API_BASE = "http://localhost:8100"
 POLL_INTERVAL = 5  # seconds
 
 

--- a/web/src/components/PhaseStatsWidget.tsx
+++ b/web/src/components/PhaseStatsWidget.tsx
@@ -31,8 +31,10 @@ interface PhaseStatsResponse {
   total_completions: number
   total_failures: number
   escalation_summary: {
-    by_phase: Record<string, { base_tier: number; escalated: number; rate: number }>
+    by_phase: Record<string, { configured_tier: number; at_configured: number; escalated: number; rate: number }>
   }
+  phase_base_tiers: Record<string, number>
+  tier_labels: string[]
 }
 
 interface PhaseStatsWidgetProps {
@@ -46,12 +48,20 @@ const PHASE_INFO: Record<string, { name: string; icon: string }> = {
   seo: { name: 'SEO', icon: '🎯' },
   manager: { name: 'QA Manager', icon: '✅' },
   copy_editor: { name: 'Copy Editor', icon: '✏️' },
+  chat: { name: 'Chat Editor', icon: '💬' },
   timestamp: { name: 'Timestamps', icon: '⏱️' },
 }
 
+// Tier color styling
+const TIER_STYLES = [
+  { badge: 'bg-green-900/30 text-green-400 border-green-500/30', text: 'text-green-400' },
+  { badge: 'bg-cyan-900/30 text-cyan-400 border-cyan-500/30', text: 'text-cyan-400' },
+  { badge: 'bg-purple-900/30 text-purple-400 border-purple-500/30', text: 'text-purple-400' },
+]
+
 /**
- * Widget displaying phase-level performance analytics.
- * Shows success rates, escalation patterns, and cost attribution by agent role.
+ * Unified agent performance widget.
+ * Shows each agent's configured tier, success rate, escalation rate, and model breakdown.
  */
 export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetProps) {
   const [stats, setStats] = useState<PhaseStatsResponse | null>(null)
@@ -83,7 +93,6 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [days])
 
-  // Get color based on success rate
   const getSuccessColor = (rate: number) => {
     if (rate >= 99) return 'text-green-400'
     if (rate >= 95) return 'text-yellow-400'
@@ -91,7 +100,6 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
     return 'text-red-400'
   }
 
-  // Get bar color based on success rate
   const getBarColor = (rate: number) => {
     if (rate >= 99) return 'bg-green-500'
     if (rate >= 95) return 'bg-yellow-500'
@@ -99,7 +107,6 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
     return 'bg-red-500'
   }
 
-  // Get escalation indicator color
   const getEscalationColor = (rate: number) => {
     if (rate <= 5) return 'text-green-400'
     if (rate <= 20) return 'text-cyan-400'
@@ -107,16 +114,25 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
     return 'text-orange-400'
   }
 
-  // Format cost
   const formatCost = (cost: number) => {
     if (cost < 0.01) return `$${cost.toFixed(4)}`
     if (cost < 1) return `$${cost.toFixed(3)}`
     return `$${cost.toFixed(2)}`
   }
 
-  // Get phase display info
   const getPhaseInfo = (phase: string) => {
     return PHASE_INFO[phase] || { name: phase, icon: '🤖' }
+  }
+
+  const getTierBadge = (tierIdx: number) => {
+    const style = TIER_STYLES[tierIdx] || TIER_STYLES[0]
+    const label = stats?.tier_labels?.[tierIdx] || `Tier ${tierIdx}`
+    return { style, label }
+  }
+
+  const getModelTierStyle = (tier: number | null) => {
+    if (tier === null || tier === undefined) return TIER_STYLES[0]
+    return TIER_STYLES[tier] || TIER_STYLES[0]
   }
 
   return (
@@ -127,7 +143,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
             Agent Performance
           </h3>
           <p className="text-xs text-gray-500 mt-0.5">
-            Success rates & escalation patterns
+            Model usage & escalation rates relative to configured tier
           </p>
         </div>
         <div className="flex items-center space-x-2">
@@ -207,6 +223,8 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
               {stats.phases.map((phase) => {
                 const info = getPhaseInfo(phase.phase)
                 const isExpanded = expandedPhase === phase.phase
+                const configuredTier = stats.phase_base_tiers?.[phase.phase] ?? 0
+                const tierBadge = getTierBadge(configuredTier)
 
                 return (
                   <div key={phase.phase} className="bg-gray-900 rounded-lg overflow-hidden">
@@ -220,6 +238,9 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                         <div className="text-left">
                           <div className="flex items-center space-x-2">
                             <span className="text-white font-medium">{info.name}</span>
+                            <span className={`text-[10px] px-1.5 py-0.5 rounded border ${tierBadge.style.badge}`}>
+                              {tierBadge.label}
+                            </span>
                             <span className="text-xs text-gray-500">
                               {phase.total_completions} runs
                             </span>
@@ -268,40 +289,39 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                           <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">
                             Model Breakdown
                           </div>
-                          {phase.models.map((model, idx) => (
-                            <div
-                              key={idx}
-                              className="flex items-center justify-between text-xs py-1.5 px-2 bg-gray-800 rounded"
-                            >
-                              <div className="flex items-center space-x-2">
-                                {model.tier_label && (
-                                  <span className={`px-1.5 py-0.5 rounded text-[10px] ${
-                                    model.tier_label === 'big-brain'
-                                      ? 'bg-purple-500/20 text-purple-400'
-                                      : model.tier_label === 'cheapskate'
-                                      ? 'bg-green-500/20 text-green-400'
-                                      : 'bg-cyan-500/20 text-cyan-400'
-                                  }`}>
-                                    {model.tier_label}
+                          {phase.models.map((model, idx) => {
+                            const modelTierStyle = getModelTierStyle(model.tier)
+                            const isEscalated = model.tier !== null && model.tier > configuredTier
+                            return (
+                              <div
+                                key={idx}
+                                className="flex items-center justify-between text-xs py-1.5 px-2 bg-gray-800 rounded"
+                              >
+                                <div className="flex items-center space-x-2">
+                                  {model.tier !== null && (
+                                    <span className={`px-1.5 py-0.5 rounded text-[10px] ${modelTierStyle.badge}`}>
+                                      {stats.tier_labels?.[model.tier] || `T${model.tier}`}
+                                      {isEscalated && ' ↑'}
+                                    </span>
+                                  )}
+                                  <span className="text-gray-300 font-mono truncate max-w-[200px]" title={model.model}>
+                                    {model.model}
                                   </span>
-                                )}
-                                <span className="text-gray-300 font-mono truncate max-w-[200px]" title={model.model}>
-                                  {model.model}
-                                </span>
+                                </div>
+                                <div className="flex items-center space-x-4">
+                                  <span className="text-gray-500">
+                                    {model.completions} runs
+                                  </span>
+                                  <span className={getSuccessColor(model.success_rate)}>
+                                    {model.success_rate}%
+                                  </span>
+                                  <span className="text-gray-400 font-mono">
+                                    {formatCost(model.total_cost)}
+                                  </span>
+                                </div>
                               </div>
-                              <div className="flex items-center space-x-4">
-                                <span className="text-gray-500">
-                                  {model.completions} runs
-                                </span>
-                                <span className={getSuccessColor(model.success_rate)}>
-                                  {model.success_rate}%
-                                </span>
-                                <span className="text-gray-400 font-mono">
-                                  {formatCost(model.total_cost)}
-                                </span>
-                              </div>
-                            </div>
-                          ))}
+                            )
+                          })}
                         </div>
 
                         {/* Insights for problematic phases */}
@@ -309,12 +329,12 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                           <div className="mt-3 p-2 bg-yellow-900/20 border border-yellow-500/30 rounded text-xs">
                             {phase.success_rate < 95 && (
                               <p className="text-yellow-400">
-                                ⚠️ Low success rate - consider using a more capable base model
+                                Low success rate — consider using a more capable base model
                               </p>
                             )}
                             {phase.escalation_rate > 30 && phase.escalation_rate < 100 && (
                               <p className="text-yellow-400">
-                                ⚠️ High escalation rate - base tier may be underpowered for this task
+                                High escalation rate — base tier may be underpowered for this task
                               </p>
                             )}
                           </div>
@@ -327,17 +347,22 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
             </div>
           )}
 
-          {/* Footer */}
-          <div className="mt-4 pt-3 border-t border-gray-700 flex justify-between items-center text-xs text-gray-600">
-            <span>
-              {stats.period_start ? new Date(stats.period_start).toLocaleDateString() : 'N/A'}
-              {' - '}
-              {stats.period_end ? new Date(stats.period_end).toLocaleDateString() : 'now'}
-            </span>
-            <span>
-              Data from local session_stats
-            </span>
-          </div>
+          {/* Tier legend */}
+          {stats.tier_labels && stats.tier_labels.length > 0 && (
+            <div className="mt-4 pt-3 border-t border-gray-700 flex items-center justify-between">
+              <div className="flex items-center space-x-4 text-xs text-gray-500">
+                {stats.tier_labels.map((label, idx) => {
+                  const style = TIER_STYLES[idx] || TIER_STYLES[0]
+                  return (
+                    <span key={idx} className={style.text}>{label}</span>
+                  )
+                })}
+              </div>
+              <span className="text-xs text-gray-600">
+                Escalation = ran above configured tier
+              </span>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useState } from 'react'
-import ModelStatsWidget from '../components/ModelStatsWidget'
 import PhaseStatsWidget from '../components/PhaseStatsWidget'
-import { AGENT_INFO } from '../constants/agents'
 
-interface PresetInfo {
-  description: string
-  models: string[]
-  models_verified?: string
+interface DurationThreshold {
+  max_minutes: number | null
+  tier: number
 }
 
 interface HealthStatus {
@@ -16,14 +13,10 @@ interface HealthStatus {
     in_progress: number
   }
   llm?: {
-    active_model: string | null
-    active_backend: string | null
-    active_preset: string | null
-    primary_backend: string | null
-    configured_preset: string | null
-    fallback_model: string | null
-    phase_backends?: Record<string, string>
-    openrouter_presets?: Record<string, PresetInfo>
+    routing?: {
+      tier_labels: string[]
+      duration_thresholds: DurationThreshold[]
+    }
   }
   last_run?: {
     total_cost: number
@@ -134,10 +127,10 @@ export default function System() {
               <div>
                 <p className="text-white font-medium">Check if the API server is running</p>
                 <p className="text-sm text-gray-400 mt-1">
-                  The API should be running on port 8000. Open a terminal and run:
+                  The API should be running on port 8100. Open a terminal and run:
                 </p>
                 <pre className="mt-2 bg-gray-900 rounded p-3 text-sm text-green-400 font-mono overflow-x-auto">
-                  lsof -i :8000
+                  lsof -i :8100
                 </pre>
               </div>
             </div>
@@ -151,7 +144,7 @@ export default function System() {
                 </p>
                 <pre className="mt-2 bg-gray-900 rounded p-3 text-sm text-green-400 font-mono overflow-x-auto">
 {`cd /Users/mriechers/Developer/ai-editorial-assistant-v3
-./venv/bin/uvicorn api.main:app --reload --port 8000`}
+./venv/bin/uvicorn api.main:app --reload --port 8100`}
                 </pre>
               </div>
             </div>
@@ -188,43 +181,6 @@ export default function System() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
             <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">
-              LLM Configuration
-            </h3>
-            <div className="space-y-2">
-              <InfoRow
-                label="Primary Backend"
-                value={health.llm?.primary_backend || 'Not configured'}
-              />
-              {health.llm?.configured_preset ? (
-                <>
-                  <InfoRow
-                    label="Model Preset"
-                    value={health.llm.configured_preset}
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    OpenRouter selects from preset's model pool
-                  </p>
-                </>
-              ) : (
-                <InfoRow
-                  label="Fallback Model"
-                  value={health.llm?.fallback_model || 'Not configured'}
-                />
-              )}
-              {health.llm?.active_model && (
-                <div className="pt-2 border-t border-gray-700 mt-2">
-                  <div className="text-xs text-gray-500 mb-1">Currently processing with:</div>
-                  <InfoRow
-                    label="Active Model"
-                    value={health.llm.active_model}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-
-          <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-            <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">
               Queue Status
             </h3>
             <div className="space-y-2">
@@ -238,120 +194,43 @@ export default function System() {
               )}
             </div>
           </div>
-        </div>
-      )}
 
-      {/* OpenRouter Presets - Show when connected */}
-      {isConnected && health?.llm?.openrouter_presets && Object.keys(health.llm.openrouter_presets).length > 0 && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
-              OpenRouter Presets
-            </h3>
-            <a
-              href="https://openrouter.ai/settings/presets"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-blue-400 hover:text-blue-300 flex items-center space-x-1"
-            >
-              <span>Manage Presets</span>
-              <span>↗</span>
-            </a>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {Object.entries(health.llm.openrouter_presets).map(([presetName, preset]) => {
-              const isBigBrain = presetName.includes('big-brain')
-              const isCheapskate = presetName.includes('cheapskate')
-              const colorClass = isBigBrain
-                ? 'bg-purple-900/10 border-purple-500/30'
-                : isCheapskate
-                ? 'bg-green-900/10 border-green-500/30'
-                : 'bg-cyan-900/10 border-cyan-500/30'
-              const textClass = isBigBrain
-                ? 'text-purple-400'
-                : isCheapskate
-                ? 'text-green-400'
-                : 'text-cyan-400'
-              return (
-                <div key={presetName} className={`rounded-lg p-3 border ${colorClass}`}>
-                  <div className="flex items-center space-x-2 mb-2">
-                    <span className={`text-sm font-medium ${textClass}`}>
-                      {presetName.replace('ai-editorial-assistant-', '').replace('ai-editorial-assistant', 'default')}
-                    </span>
-                  </div>
-                  <p className="text-xs text-gray-500 mb-2">{preset.description}</p>
-                  <div className="space-y-1">
-                    {preset.models.map((model, idx) => (
-                      <div key={idx} className="text-xs font-mono text-gray-400 flex items-center space-x-2">
-                        <span className="text-gray-600">{idx + 1}.</span>
-                        <span>{model}</span>
-                      </div>
-                    ))}
-                  </div>
-                  {preset.models_verified && (
-                    <p className="text-[10px] text-gray-600 mt-2">
-                      Verified {new Date(preset.models_verified + 'T00:00:00').toLocaleDateString()}
-                    </p>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-          <p className="text-xs text-gray-600 mt-3 italic">
-            Model lists are maintained locally. Update config/llm-config.json when presets change on OpenRouter.
-          </p>
-        </div>
-      )}
-
-      {/* Actual Model Usage from Langfuse - Show when connected */}
-      {isConnected && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <ModelStatsWidget />
-          <PhaseStatsWidget />
-        </div>
-      )}
-
-      {/* Agent Roster - Show when connected */}
-      {isConnected && health?.llm?.phase_backends && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">
-            Agent Roster
-          </h3>
-          <div className="space-y-3">
-            {AGENT_INFO.map((agent) => {
-              const backend = health.llm?.phase_backends?.[agent.id] || 'openrouter'
-              const isBigBrain = backend.includes('big-brain')
-              const isCheapskate = backend.includes('cheapskate')
-              const badgeClass = isBigBrain
-                ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                : isCheapskate
-                ? 'bg-green-500/20 text-green-400 border border-green-500/30'
-                : 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
-              const tierLabel = isBigBrain ? 'big-brain' : isCheapskate ? 'cheapskate' : 'default'
-              return (
-                <div key={agent.id} className="flex items-start space-x-4 p-3 bg-gray-900 rounded-lg">
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center text-lg">
-                    {agent.icon}
-                  </div>
-                  <div className="flex-grow min-w-0">
-                    <div className="flex items-center space-x-2">
-                      <span className="font-medium text-white">{agent.name}</span>
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${badgeClass}`}>
-                        {tierLabel}
+          {health.llm?.routing && (
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+              <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">
+                Duration Escalation
+              </h3>
+              <p className="text-xs text-gray-500 mb-3">
+                Base tier is escalated automatically for longer transcripts
+              </p>
+              <div className="space-y-1.5">
+                {health.llm.routing.duration_thresholds.map((threshold, idx) => {
+                  const label = health.llm?.routing?.tier_labels?.[threshold.tier] || `Tier ${threshold.tier}`
+                  const tierColors = ['text-green-400', 'text-cyan-400', 'text-purple-400']
+                  return (
+                    <div key={idx} className="flex items-center justify-between text-sm">
+                      <span className={tierColors[threshold.tier] || 'text-gray-400'}>
+                        {label}
+                      </span>
+                      <span className="text-gray-500 text-xs">
+                        {threshold.max_minutes === null
+                          ? '45+ min'
+                          : idx === 0
+                          ? `≤ ${threshold.max_minutes} min`
+                          : `≤ ${threshold.max_minutes} min`}
                       </span>
                     </div>
-                    <p className="text-sm text-gray-400 mt-1">{agent.description}</p>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-          <p className="text-xs text-gray-500 mt-3">
-            <span className="text-purple-400">big-brain</span> = complex reasoning |{' '}
-            <span className="text-cyan-400">default</span> = balanced |{' '}
-            <span className="text-green-400">cheapskate</span> = free tier
-          </p>
+                  )
+                })}
+              </div>
+            </div>
+          )}
         </div>
+      )}
+
+      {/* Agent Performance - Show when connected */}
+      {isConnected && (
+        <PhaseStatsWidget />
       )}
 
       {/* Connection Log */}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     allowedHosts: ['metadata.neighborhood', 'localhost', 'cardigan.bymarkriechers.com'],
     proxy: {
       '/api': {
-        target: 'http://metadata.neighborhood:8000',
+        target: 'http://metadata.neighborhood:8100',
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
## Summary
Bundle of local working directory changes for review against open PRs:

- **Port remapping**: Update all hardcoded port references (8000→8100, 3001→3100) across docs, scripts, configs, and vite proxy to match docker-compose changes from #88
- **Tier-aware escalation**: Phase stats escalation rate calculated relative to configured base tier (not always tier 0). Chat prototype routes through tier system. Overlaps with #81
- **JobUpdate expansion**: `transcript_file`, `project_name`, `project_path` now patchable via PATCH /jobs/{id}
- **Ingest scanner**: Media ID extraction falls back to full sanitized stem instead of returning None. Overlaps with #85/#86
- **Frontend**: PhaseStatsWidget and System page updated for tier-aware display

## Why this PR exists
These changes were uncommitted locally and may conflict with PRs #81, #85, and #88. Created as a separate PR to compare and resolve overlaps before merging.

## Test plan
- [ ] Compare diffs against #81, #85, #88 for conflicts
- [ ] Verify port references are consistent across all files
- [ ] Run `pytest` (excluding test_ingest_scanner.py hang)
- [ ] Check PhaseStatsWidget renders with tier-aware data

🤖 Generated with [Claude Code](https://claude.com/claude-code)