### PR TITLE
Dynamic model roster + Settings polish

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -281,9 +281,9 @@ class PhaseModelsUpdate(BaseModel):
 
 
 DEFAULT_PHASE_MODELS = {
-    "analyst": "anthropic/claude-haiku-4-5-20251001",
+    "analyst": "anthropic/claude-haiku-4.5",
     "formatter": "anthropic/claude-sonnet-4.6",
-    "seo": "anthropic/claude-haiku-4-5-20251001",
+    "seo": "anthropic/claude-haiku-4.5",
     "manager": "anthropic/claude-opus-4.6",
     "timestamp": "anthropic/claude-sonnet-4.6",
     "copy_editor": "anthropic/claude-opus-4.6",

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from api.services.llm import get_llm_client
+from api.services.model_roster import get_available_models, invalidate_cache
 
 router = APIRouter(prefix="/config", tags=["config"])
 
@@ -281,12 +282,12 @@ class PhaseModelsUpdate(BaseModel):
 
 DEFAULT_PHASE_MODELS = {
     "analyst": "anthropic/claude-haiku-4-5-20251001",
-    "formatter": "anthropic/claude-sonnet-4-5-20250514",
+    "formatter": "anthropic/claude-sonnet-4.6",
     "seo": "anthropic/claude-haiku-4-5-20251001",
-    "manager": "anthropic/claude-opus-4-5-20250514",
-    "timestamp": "anthropic/claude-sonnet-4-5-20250514",
-    "copy_editor": "anthropic/claude-opus-4-5-20250514",
-    "chat": "anthropic/claude-sonnet-4-5-20250514",
+    "manager": "anthropic/claude-opus-4.6",
+    "timestamp": "anthropic/claude-sonnet-4.6",
+    "copy_editor": "anthropic/claude-opus-4.6",
+    "chat": "anthropic/claude-sonnet-4.6",
 }
 
 
@@ -296,9 +297,12 @@ async def get_phase_models():
 
     Returns which specific model is assigned to each agent phase,
     plus the full list of available models for the Settings UI.
+    Models are fetched dynamically from OpenRouter when model_families
+    is configured, falling back to the static available_models list.
     """
     config = _load_config()
-    available_models = [AvailableModel(**m) for m in config.get("available_models", [])]
+    models_data = await get_available_models()
+    available_models = [AvailableModel(**m) for m in models_data]
     phase_models = config.get("phase_models", DEFAULT_PHASE_MODELS)
     available_phases = ["analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"]
 
@@ -318,7 +322,8 @@ async def update_phase_models(update: PhaseModelsUpdate):
     """
     config = _load_config()
     valid_phases = {"analyst", "formatter", "seo", "manager", "timestamp", "copy_editor", "chat"}
-    available_model_ids = {m["id"] for m in config.get("available_models", [])}
+    models_data = await get_available_models()
+    available_model_ids = {m["id"] for m in models_data}
 
     for phase, model_id in update.phase_models.items():
         if phase not in valid_phases:
@@ -339,6 +344,17 @@ async def update_phase_models(update: PhaseModelsUpdate):
 
     get_llm_client().reload_config()
 
+    return await get_phase_models()
+
+
+@router.post("/models/refresh", response_model=PhaseModelsResponse)
+async def refresh_model_roster():
+    """Force-refresh the dynamic model roster from OpenRouter.
+
+    Clears the cache and fetches a fresh model list. Useful when new
+    models have been released and you want them immediately.
+    """
+    invalidate_cache()
     return await get_phase_models()
 
 

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -72,6 +72,8 @@ MODEL_PRICING: Dict[str, Dict[str, float]] = {
     "anthropic/claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
     "anthropic/claude-sonnet-4-5-20250514": {"input": 3.00, "output": 15.00},
     "anthropic/claude-opus-4-5-20250514": {"input": 15.00, "output": 75.00},
+    "anthropic/claude-sonnet-4.6": {"input": 3.00, "output": 15.00},
+    "anthropic/claude-opus-4.6": {"input": 5.00, "output": 25.00},
     "gemini-1.5-flash": {"input": 0.075, "output": 0.30},
     "gemini-1.5-flash-8b": {"input": 0.0375, "output": 0.15},
     "gemini-1.5-pro": {"input": 1.25, "output": 5.00},

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -70,6 +70,7 @@ MODEL_PRICING: Dict[str, Dict[str, float]] = {
     "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00},
     # Claude via OpenRouter — tier 0/1/2 (pricing per 1M tokens)
     "anthropic/claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
+    "anthropic/claude-haiku-4.5": {"input": 0.80, "output": 4.00},
     "anthropic/claude-sonnet-4-5-20250514": {"input": 3.00, "output": 15.00},
     "anthropic/claude-opus-4-5-20250514": {"input": 15.00, "output": 75.00},
     "anthropic/claude-sonnet-4.6": {"input": 3.00, "output": 15.00},

--- a/api/services/model_roster.py
+++ b/api/services/model_roster.py
@@ -70,9 +70,7 @@ async def fetch_openrouter_models() -> Optional[List[dict]]:
         return None
 
 
-def _classify_models(
-    raw_models: List[dict], families: List[dict]
-) -> List[dict]:
+def _classify_models(raw_models: List[dict], families: List[dict]) -> List[dict]:
     """Filter and classify raw OpenRouter models using family patterns.
 
     Returns a list of dicts matching the AvailableModel schema:
@@ -91,12 +89,14 @@ def _classify_models(
             continue
 
         seen_ids.add(model_id)
-        results.append({
-            "id": model_id,
-            "name": model.get("name", model_id),
-            "provider": family["provider"],
-            "tier": family["tier"],
-        })
+        results.append(
+            {
+                "id": model_id,
+                "name": model.get("name", model_id),
+                "provider": family["provider"],
+                "tier": family["tier"],
+            }
+        )
 
     # Sort by tier, then name
     results.sort(key=lambda m: (m["tier"], m["name"]))

--- a/api/services/model_roster.py
+++ b/api/services/model_roster.py
@@ -5,6 +5,7 @@ patterns, and classifies each into a cost tier. Falls back to the static
 `available_models` list in llm-config.json when OpenRouter is unreachable.
 """
 
+import asyncio
 import json
 import logging
 import time
@@ -22,6 +23,7 @@ CONFIG_PATH = Path("config/llm-config.json")
 
 # Cache: list of model dicts + expiry timestamp
 _cache: Dict[str, Any] = {"models": None, "expires": 0.0}
+_cache_lock = asyncio.Lock()
 CACHE_TTL_SECONDS = 3600  # 1 hour
 
 
@@ -106,7 +108,7 @@ def _static_fallback(config: dict) -> List[dict]:
     return config.get("available_models", [])
 
 
-async def get_available_models(force_refresh: bool = False) -> List[dict]:
+async def get_available_models() -> List[dict]:
     """Get the current model roster, using cache when fresh.
 
     Priority:
@@ -116,34 +118,40 @@ async def get_available_models(force_refresh: bool = False) -> List[dict]:
     """
     now = time.time()
 
-    # Return cache if fresh and not forcing
-    if not force_refresh and _cache["models"] is not None and now < _cache["expires"]:
+    # Fast path: return cache if fresh
+    if _cache["models"] is not None and now < _cache["expires"]:
         return _cache["models"]
 
-    config = _load_config()
-    families = _get_family_patterns(config)
+    async with _cache_lock:
+        # Re-check after acquiring lock (another coroutine may have refreshed)
+        now = time.time()
+        if _cache["models"] is not None and now < _cache["expires"]:
+            return _cache["models"]
 
-    # If no families configured, use static list
-    if not families:
-        logger.info("No model_families configured, using static available_models")
-        return _static_fallback(config)
+        config = _load_config()
+        families = _get_family_patterns(config)
 
-    # Try dynamic fetch
-    raw_models = await fetch_openrouter_models()
-    if raw_models is None:
-        logger.info("OpenRouter fetch failed, using static fallback")
-        return _static_fallback(config)
+        # If no families configured, use static list
+        if not families:
+            logger.info("No model_families configured, using static available_models")
+            return _static_fallback(config)
 
-    classified = _classify_models(raw_models, families)
-    if not classified:
-        logger.warning("No models matched family patterns, using static fallback")
-        return _static_fallback(config)
+        # Try dynamic fetch
+        raw_models = await fetch_openrouter_models()
+        if raw_models is None:
+            logger.info("OpenRouter fetch failed, using static fallback")
+            return _static_fallback(config)
 
-    # Update cache
-    _cache["models"] = classified
-    _cache["expires"] = now + CACHE_TTL_SECONDS
-    logger.info("Refreshed model roster: %d models from OpenRouter", len(classified))
-    return classified
+        classified = _classify_models(raw_models, families)
+        if not classified:
+            logger.warning("No models matched family patterns, using static fallback")
+            return _static_fallback(config)
+
+        # Update cache
+        _cache["models"] = classified
+        _cache["expires"] = now + CACHE_TTL_SECONDS
+        logger.info("Refreshed model roster: %d models from OpenRouter", len(classified))
+        return classified
 
 
 def invalidate_cache() -> None:

--- a/api/services/model_roster.py
+++ b/api/services/model_roster.py
@@ -1,0 +1,152 @@
+"""Dynamic model roster via OpenRouter API.
+
+Fetches available models from OpenRouter, filters by configured family
+patterns, and classifies each into a cost tier. Falls back to the static
+`available_models` list in llm-config.json when OpenRouter is unreachable.
+"""
+
+import json
+import logging
+import time
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from api.services.secrets import get_secret
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = Path("config/llm-config.json")
+
+# Cache: list of model dicts + expiry timestamp
+_cache: Dict[str, Any] = {"models": None, "expires": 0.0}
+CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+def _load_config() -> dict:
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def _get_family_patterns(config: dict) -> List[dict]:
+    """Return model_families from config, or empty list if not configured."""
+    return config.get("model_families", [])
+
+
+def _match_model(model_id: str, families: List[dict]) -> Optional[dict]:
+    """Match a model ID against family patterns, return first match or None."""
+    for family in families:
+        for pattern in family["patterns"]:
+            if fnmatch(model_id, pattern):
+                return family
+    return None
+
+
+async def fetch_openrouter_models() -> Optional[List[dict]]:
+    """Fetch model list from OpenRouter API.
+
+    Returns the raw model list on success, None on failure.
+    """
+    api_key = get_secret("OPENROUTER_API_KEY")
+    if not api_key:
+        logger.warning("OPENROUTER_API_KEY not available, cannot fetch models")
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                "https://openrouter.ai/api/v1/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("data", [])
+    except (httpx.HTTPError, KeyError, json.JSONDecodeError) as e:
+        logger.warning("Failed to fetch OpenRouter models: %s", e)
+        return None
+
+
+def _classify_models(
+    raw_models: List[dict], families: List[dict]
+) -> List[dict]:
+    """Filter and classify raw OpenRouter models using family patterns.
+
+    Returns a list of dicts matching the AvailableModel schema:
+    {id, name, provider, tier}
+    """
+    results = []
+    seen_ids = set()
+
+    for model in raw_models:
+        model_id = model.get("id", "")
+        if model_id in seen_ids:
+            continue
+
+        family = _match_model(model_id, families)
+        if family is None:
+            continue
+
+        seen_ids.add(model_id)
+        results.append({
+            "id": model_id,
+            "name": model.get("name", model_id),
+            "provider": family["provider"],
+            "tier": family["tier"],
+        })
+
+    # Sort by tier, then name
+    results.sort(key=lambda m: (m["tier"], m["name"]))
+    return results
+
+
+def _static_fallback(config: dict) -> List[dict]:
+    """Return the static available_models from config as fallback."""
+    return config.get("available_models", [])
+
+
+async def get_available_models(force_refresh: bool = False) -> List[dict]:
+    """Get the current model roster, using cache when fresh.
+
+    Priority:
+    1. Cached dynamic roster (if within TTL)
+    2. Fresh fetch from OpenRouter → classify → cache
+    3. Static fallback from config
+    """
+    now = time.time()
+
+    # Return cache if fresh and not forcing
+    if not force_refresh and _cache["models"] is not None and now < _cache["expires"]:
+        return _cache["models"]
+
+    config = _load_config()
+    families = _get_family_patterns(config)
+
+    # If no families configured, use static list
+    if not families:
+        logger.info("No model_families configured, using static available_models")
+        return _static_fallback(config)
+
+    # Try dynamic fetch
+    raw_models = await fetch_openrouter_models()
+    if raw_models is None:
+        logger.info("OpenRouter fetch failed, using static fallback")
+        return _static_fallback(config)
+
+    classified = _classify_models(raw_models, families)
+    if not classified:
+        logger.warning("No models matched family patterns, using static fallback")
+        return _static_fallback(config)
+
+    # Update cache
+    _cache["models"] = classified
+    _cache["expires"] = now + CACHE_TTL_SECONDS
+    logger.info("Refreshed model roster: %d models from OpenRouter", len(classified))
+    return classified
+
+
+def invalidate_cache() -> None:
+    """Clear the model roster cache, forcing a refresh on next call."""
+    _cache["models"] = None
+    _cache["expires"] = 0.0

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -190,6 +190,38 @@
       "min_tier": 1
     }
   },
+  "model_families": [
+    {
+      "name": "Claude Haiku",
+      "provider": "Anthropic",
+      "tier": 0,
+      "patterns": ["anthropic/claude-haiku-*"]
+    },
+    {
+      "name": "Claude Sonnet",
+      "provider": "Anthropic",
+      "tier": 1,
+      "patterns": ["anthropic/claude-sonnet-*"]
+    },
+    {
+      "name": "Claude Opus",
+      "provider": "Anthropic",
+      "tier": 2,
+      "patterns": ["anthropic/claude-opus-*"]
+    },
+    {
+      "name": "Gemini Flash",
+      "provider": "Google",
+      "tier": 0,
+      "patterns": ["google/gemini-*-flash*"]
+    },
+    {
+      "name": "Gemini Pro",
+      "provider": "Google",
+      "tier": 1,
+      "patterns": ["google/gemini-*-pro*"]
+    }
+  ],
   "available_models": [
     {
       "id": "anthropic/claude-haiku-4-5-20251001",

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -95,7 +95,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant-cheapskate",
-      "fallback_model": "anthropic/claude-haiku-4-5-20251001",
+      "fallback_model": "anthropic/claude-haiku-4.5",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 300,
       "cost_per_project": 0.0,
@@ -224,7 +224,7 @@
   ],
   "available_models": [
     {
-      "id": "anthropic/claude-haiku-4-5-20251001",
+      "id": "anthropic/claude-haiku-4.5",
       "name": "Claude Haiku 4.5",
       "provider": "Anthropic",
       "tier": 0
@@ -255,9 +255,9 @@
     }
   ],
   "phase_models": {
-    "analyst": "anthropic/claude-haiku-4-5-20251001",
+    "analyst": "anthropic/claude-haiku-4.5",
     "formatter": "anthropic/claude-sonnet-4.6",
-    "seo": "anthropic/claude-haiku-4-5-20251001",
+    "seo": "anthropic/claude-haiku-4.5",
     "manager": "anthropic/claude-opus-4.6",
     "timestamp": "anthropic/claude-sonnet-4.6",
     "copy_editor": "anthropic/claude-opus-4.6",
@@ -285,7 +285,7 @@
     "ai-editorial-assistant-cheapskate": {
       "description": "Cheapskate tier — Claude Haiku via OpenRouter",
       "models": [
-        "anthropic/claude-haiku-4-5-20251001",
+        "anthropic/claude-haiku-4.5",
         "openai/gpt-oss-120b",
         "moonshotai/kimi-k2-0711"
       ],

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -77,7 +77,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant",
-      "fallback_model": "anthropic/claude-sonnet-4-5-20250514",
+      "fallback_model": "anthropic/claude-sonnet-4.6",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 180,
       "cost_per_project": 0.02
@@ -86,7 +86,7 @@
       "type": "openrouter",
       "endpoint": "https://openrouter.ai/api/v1/chat/completions",
       "preset": "ai-editorial-assistant-big-brain",
-      "fallback_model": "anthropic/claude-opus-4-5-20250514",
+      "fallback_model": "anthropic/claude-opus-4.6",
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 300,
       "cost_per_project": 0.1
@@ -198,44 +198,44 @@
       "tier": 0
     },
     {
-      "id": "google/gemini-2.0-flash-001",
-      "name": "Gemini 2.0 Flash",
+      "id": "google/gemini-3-flash-preview",
+      "name": "Gemini 3 Flash",
       "provider": "Google",
       "tier": 0
     },
     {
-      "id": "anthropic/claude-sonnet-4-5-20250514",
-      "name": "Claude Sonnet 4.5",
+      "id": "anthropic/claude-sonnet-4.6",
+      "name": "Claude Sonnet 4.6",
       "provider": "Anthropic",
       "tier": 1
     },
     {
-      "id": "google/gemini-2.5-pro-preview",
-      "name": "Gemini 2.5 Pro",
+      "id": "google/gemini-3-pro-preview",
+      "name": "Gemini 3 Pro",
       "provider": "Google",
       "tier": 1
     },
     {
-      "id": "anthropic/claude-opus-4-5-20250514",
-      "name": "Claude Opus 4.5",
+      "id": "anthropic/claude-opus-4.6",
+      "name": "Claude Opus 4.6",
       "provider": "Anthropic",
       "tier": 2
     }
   ],
   "phase_models": {
     "analyst": "anthropic/claude-haiku-4-5-20251001",
-    "formatter": "anthropic/claude-sonnet-4-5-20250514",
+    "formatter": "anthropic/claude-sonnet-4.6",
     "seo": "anthropic/claude-haiku-4-5-20251001",
-    "manager": "anthropic/claude-opus-4-5-20250514",
-    "timestamp": "anthropic/claude-sonnet-4-5-20250514",
-    "copy_editor": "anthropic/claude-opus-4-5-20250514",
-    "chat": "anthropic/claude-sonnet-4-5-20250514"
+    "manager": "anthropic/claude-opus-4.6",
+    "timestamp": "anthropic/claude-sonnet-4.6",
+    "copy_editor": "anthropic/claude-opus-4.6",
+    "chat": "anthropic/claude-sonnet-4.6"
   },
   "openrouter_presets": {
     "ai-editorial-assistant": {
       "description": "Default tier — Claude Sonnet via OpenRouter",
       "models": [
-        "anthropic/claude-sonnet-4-5-20250514",
+        "anthropic/claude-sonnet-4.6",
         "google/gemini-3-flash-preview",
         "openai/gpt-5.1-codex-mini"
       ],
@@ -244,7 +244,7 @@
     "ai-editorial-assistant-big-brain": {
       "description": "Big Brain tier — Claude Opus via OpenRouter",
       "models": [
-        "anthropic/claude-opus-4-5-20250514",
+        "anthropic/claude-opus-4.6",
         "google/gemini-3-pro-preview",
         "openai/gpt-5.1-codex"
       ],

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -527,7 +527,7 @@ export default function Settings() {
                           id={`model-${agent.id}`}
                           value={currentModel}
                           onChange={(e) => handlePhaseModelChange(agent.id, e.target.value)}
-                          className={`px-3 py-2 rounded-md border text-sm font-medium ${styles.bg} ${styles.border} ${styles.text}`}
+                          className={`pl-3 pr-8 py-2 rounded-md border text-sm font-medium ${styles.bg} ${styles.border} ${styles.text}`}
                           aria-label={`Select model for ${agent.name} agent`}
                         >
                           {[0, 1, 2].map(tier => {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -111,6 +111,7 @@ export default function Settings() {
   const [pendingPhaseModels, setPendingPhaseModels] = useState<Record<string, string> | null>(null)
   const [pendingWorker, setPendingWorker] = useState<Partial<WorkerConfig> | null>(null)
   const [pendingIngest, setPendingIngest] = useState<Partial<IngestConfigUpdate> | null>(null)
+  const [refreshingModels, setRefreshingModels] = useState(false)
 
   const fetchConfig = useCallback(async () => {
     try {
@@ -183,6 +184,23 @@ export default function Settings() {
     const interval = setInterval(fetchSystemStatus, 5000)
     return () => clearInterval(interval)
   }, [activeTab, fetchSystemStatus])
+
+  const handleRefreshModels = async () => {
+    try {
+      setRefreshingModels(true)
+      const res = await fetch('/api/config/models/refresh', { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to refresh')
+      const data = await res.json()
+      setPhaseModels(data)
+      setSuccess('Model roster refreshed from OpenRouter')
+      setTimeout(() => setSuccess(null), 3000)
+    } catch {
+      setError('Could not refresh models from OpenRouter')
+      setTimeout(() => setError(null), 5000)
+    } finally {
+      setRefreshingModels(false)
+    }
+  }
 
   const handlePhaseModelChange = (phase: string, modelId: string) => {
     const current = pendingPhaseModels || phaseModels?.phase_models || {}
@@ -463,7 +481,17 @@ export default function Settings() {
           <div className="space-y-6">
             {/* Agent Model Assignment */}
             <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-              <h2 className="text-lg font-semibold text-white mb-4">Agent Models</h2>
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold text-white">Agent Models</h2>
+                <button
+                  onClick={handleRefreshModels}
+                  disabled={refreshingModels}
+                  className="text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+                  title="Refresh available models from OpenRouter"
+                >
+                  {refreshingModels ? 'Refreshing…' : 'Refresh models'}
+                </button>
+              </div>
               <p className="text-sm text-gray-400 mb-6">
                 Choose which model runs each agent. On failure, the system escalates
                 to the next tier automatically.

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -482,42 +482,40 @@ export default function Settings() {
                   const styles = TIER_STYLES[tierColor]
 
                   return (
-                    <div key={agent.id} className="flex items-center justify-between p-4 bg-gray-900 rounded-lg">
-                      <div className="flex items-center space-x-4">
-                        <div className="w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center text-lg">
-                          {agent.icon}
+                    <div key={agent.id} className="p-4 bg-gray-900 rounded-lg space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-3">
+                          <span className="text-lg">{agent.icon}</span>
+                          <span className="font-medium text-white">{agent.name}</span>
                         </div>
-                        <div>
-                          <div className="font-medium text-white">{agent.name}</div>
-                          <div className="text-sm text-gray-400">{agent.description}</div>
-                        </div>
-                      </div>
 
-                      <label htmlFor={`model-${agent.id}`} className="sr-only">
-                        Model for {agent.name}
-                      </label>
-                      <select
-                        id={`model-${agent.id}`}
-                        value={currentModel}
-                        onChange={(e) => handlePhaseModelChange(agent.id, e.target.value)}
-                        className={`px-3 py-2 rounded-md border text-sm font-medium min-w-[220px] ${styles.bg} ${styles.border} ${styles.text}`}
-                        aria-label={`Select model for ${agent.name} agent`}
-                      >
-                        {[0, 1, 2].map(tier => {
-                          const tierModels = models.filter(m => m.tier === tier)
-                          if (tierModels.length === 0) return null
-                          const tierLabel = routing?.tier_labels?.[tier] || `tier ${tier}`
-                          return (
-                            <optgroup key={tier} label={tierLabel}>
-                              {tierModels.map(m => (
-                                <option key={m.id} value={m.id} className="bg-gray-800 text-white">
-                                  {m.name} ({m.provider})
-                                </option>
-                              ))}
-                            </optgroup>
-                          )
-                        })}
-                      </select>
+                        <label htmlFor={`model-${agent.id}`} className="sr-only">
+                          Model for {agent.name}
+                        </label>
+                        <select
+                          id={`model-${agent.id}`}
+                          value={currentModel}
+                          onChange={(e) => handlePhaseModelChange(agent.id, e.target.value)}
+                          className={`px-3 py-2 rounded-md border text-sm font-medium ${styles.bg} ${styles.border} ${styles.text}`}
+                          aria-label={`Select model for ${agent.name} agent`}
+                        >
+                          {[0, 1, 2].map(tier => {
+                            const tierModels = models.filter(m => m.tier === tier)
+                            if (tierModels.length === 0) return null
+                            const tierLabel = routing?.tier_labels?.[tier] || `tier ${tier}`
+                            return (
+                              <optgroup key={tier} label={tierLabel}>
+                                {tierModels.map(m => (
+                                  <option key={m.id} value={m.id} className="bg-gray-800 text-white">
+                                    {m.name}
+                                  </option>
+                                ))}
+                              </optgroup>
+                            )
+                          })}
+                        </select>
+                      </div>
+                      <p className="text-sm text-gray-500 pl-8 max-w-prose">{agent.description}</p>
                     </div>
                   )
                 })}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -153,8 +153,8 @@ export default function Settings() {
       if (response.ok) {
         setIngestConfig(await response.json())
       }
-    } catch (err) {
-      console.error('Failed to fetch ingest config:', err)
+    } catch {
+      // Ingest config may not be available — non-critical
     }
   }, [])
 
@@ -165,8 +165,8 @@ export default function Settings() {
         const data = await res.json()
         setSystemStatus(data)
       }
-    } catch (err) {
-      console.error('Failed to fetch system status:', err)
+    } catch {
+      // System status may not be available — non-critical
     }
   }, [])
 
@@ -325,6 +325,7 @@ export default function Settings() {
 
   const handleReset = () => {
     setPendingRouting(null)
+    setPendingPhaseModels(null)
     setPendingWorker(null)
     setPendingIngest(null)
   }
@@ -457,6 +458,7 @@ export default function Settings() {
           {TABS.map((tab) => (
             <button
               key={tab.id}
+              id={`tab-${tab.id}`}
               role="tab"
               aria-selected={activeTab === tab.id}
               aria-controls={`panel-${tab.id}`}
@@ -475,7 +477,7 @@ export default function Settings() {
       </div>
 
       {/* Tab Panels */}
-      <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={activeTab}>
+      <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
         {/* AGENTS TAB */}
         {activeTab === 'agents' && (
           <div className="space-y-6">
@@ -487,9 +489,10 @@ export default function Settings() {
                   onClick={handleRefreshModels}
                   disabled={refreshingModels}
                   className="text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50"
-                  title="Refresh available models from OpenRouter"
+                  title="Fetch latest models from OpenRouter"
+                  aria-label="Refresh available models from OpenRouter"
                 >
-                  {refreshingModels ? 'Refreshing…' : 'Refresh models'}
+                  {refreshingModels ? 'Refreshing…' : '↻ Refresh models'}
                 </button>
               </div>
               <p className="text-sm text-gray-400 mb-6">
@@ -543,7 +546,7 @@ export default function Settings() {
                           })}
                         </select>
                       </div>
-                      <p className="text-sm text-gray-500 pl-8 max-w-prose">{agent.description}</p>
+                      <p className="text-sm text-gray-400 pl-8 max-w-prose">{agent.description}</p>
                     </div>
                   )
                 })}
@@ -551,15 +554,21 @@ export default function Settings() {
 
               <div className="mt-4 flex items-center space-x-6 text-xs text-gray-400">
                 {routing?.tier_labels?.map((label, idx) => {
-                  const color = getTierColor(idx)
+                  const dotColor = ['bg-green-500', 'bg-cyan-500', 'bg-purple-500'][idx] || 'bg-gray-500'
                   return (
                     <div key={idx} className="flex items-center space-x-2">
-                      <span className="w-2 h-2 rounded-full" style={{backgroundColor: color === 'green' ? '#22c55e' : color === 'cyan' ? '#06b6d4' : '#a855f7'}} />
+                      <span className={`w-2 h-2 rounded-full ${dotColor}`} />
                       <span>{label}</span>
                     </div>
                   )
                 })}
               </div>
+            </div>
+
+            {/* Model Usage Stats (from Langfuse) */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <ModelStatsWidget />
+              <PhaseStatsWidget />
             </div>
           </div>
         )}
@@ -900,35 +909,32 @@ export default function Settings() {
             </div>
 
             {/* Link to Ready for Work page */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-medium text-white">Ready for Work</h3>
-                  <p className="text-sm text-gray-400 mt-1">
-                    View and queue transcripts from the ingest server with search and filtering.
+                  <h3 className="text-sm font-medium text-white">Ready for Work</h3>
+                  <p className="text-xs text-gray-400 mt-1">
+                    View and queue transcripts from the ingest server.
                   </p>
                 </div>
                 <Link
                   to="/ready"
-                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors font-medium"
+                  className="text-sm text-blue-400 hover:text-blue-300 transition-colors"
                 >
-                  Open Ready for Work
+                  Open →
                 </Link>
               </div>
             </div>
 
             {/* Screengrab Info */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
               <div className="flex items-start space-x-3">
-                <div className="flex-shrink-0 w-10 h-10 bg-purple-500/20 rounded-full flex items-center justify-center">
-                  <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                </div>
+                <span className="text-purple-400 text-xl">🖼️</span>
                 <div>
-                  <h3 className="text-lg font-medium text-white">Screengrab Attachments</h3>
-                  <p className="text-sm text-gray-400 mt-1">
-                    Screengrabs are now attached contextually from the job detail page. When a completed job has matching screengrabs available, you'll see an "Attach Screengrabs" button in the job header.
+                  <h3 className="text-sm font-medium text-white">Screengrab Attachments</h3>
+                  <p className="text-xs text-gray-400 mt-1">
+                    Screengrabs are attached from the job detail page. Completed jobs with matching
+                    screengrabs show an "Attach Screengrabs" button in the job header.
                   </p>
                 </div>
               </div>
@@ -1179,12 +1185,6 @@ export default function Settings() {
             </div>
           </div>
         )}
-      </div>
-
-      {/* Model Usage Stats (from Langfuse) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <ModelStatsWidget />
-        <PhaseStatsWidget />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **Dynamic model roster**: Models are now discovered from OpenRouter's API using pattern-based family matching (`model_families` in config). Each family maps to a provider and cost tier via fnmatch globs. Results are cached 1 hour with static fallback when OpenRouter is unreachable. Refresh button in Settings UI.
- **Settings layout fix**: Agent descriptions no longer collide with model dropdowns. Stacked layout, removed provider suffix from options, WCAG line-length compliance.
- **Model updates**: Claude 4.5 → 4.6, Gemini 2.x → 3.x across config, presets, pricing, and defaults. Normalized Haiku ID to OpenRouter canonical format.
- **Polish pass**: Fixed Reset button bug (wasn't clearing model changes), moved Langfuse widgets into Agents tab, improved contrast/ARIA/spacing consistency.

## New files

- `api/services/model_roster.py` — OpenRouter fetch, fnmatch classify, TTL cache, static fallback

## Modified files

- `api/routers/config.py` — GET/PATCH `/models` use dynamic roster, new POST `/models/refresh`
- `api/services/llm.py` — Added pricing for Claude 4.6 and canonical Haiku ID
- `config/llm-config.json` — Added `model_families`, updated all model references
- `web/src/pages/Settings.tsx` — Layout fix, refresh button, polish pass

## Related issues

- See #92 for follow-up on tightening model family patterns

## Test plan

- [ ] Settings page loads with dynamically fetched models in dropdowns
- [ ] Model selects show tier-grouped options with proper colors
- [ ] Changing a model assignment and clicking Save persists correctly
- [ ] Clicking Reset clears all pending changes including model assignments
- [ ] "Refresh models" button fetches fresh roster from OpenRouter
- [ ] Langfuse widgets only appear on Agents tab
- [ ] Dropdown chevrons have adequate right padding
- [ ] API still works when OpenRouter is unreachable (static fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)