### PR TITLE
feat: Dynamic model roster + fix preset routing

### DIFF
--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -563,7 +563,6 @@ class LLMClient:
         messages: List[Dict[str, str]],
         backend: Optional[str] = None,
         model: Optional[str] = None,
-        preset: Optional[str] = None,
         job_id: Optional[int] = None,
         phase: Optional[str] = None,
         tier: Optional[int] = None,
@@ -575,8 +574,7 @@ class LLMClient:
         Args:
             messages: List of message dicts with 'role' and 'content'
             backend: Backend to use (default: primary)
-            model: Model override (default: backend's configured model)
-            preset: OpenRouter preset override (default: backend's configured preset)
+            model: Model override (default: phase_models config, then backend model)
             job_id: Job ID for event logging
             phase: Agent phase name for observability (analyst, formatter, etc.)
             tier: Tier index for observability (0=cheapskate, 1=default, 2=big-brain)
@@ -589,14 +587,22 @@ class LLMClient:
         backend_name = backend or self.config.get("primary_backend", "openrouter")
         backend_config = self.get_backend_config(backend_name)
 
-        # Determine model - for OpenRouter with preset, use @preset/name syntax
-        preset_name = preset or backend_config.get("preset")
-        if preset_name and backend_config.get("type") == "openrouter":
-            model_id = f"@preset/{preset_name}"
-            self.active_preset = preset_name
+        # Determine model — priority order:
+        # 1. Explicit model param
+        # 2. phase_models config (per-phase model assignment from Settings UI)
+        # 3. Backend's configured model / fallback_model
+        if model:
+            model_id = model
+        elif phase:
+            phase_models = self.config.get("phase_models", {})
+            model_id = phase_models.get(phase)
         else:
-            model_id = model or backend_config.get("model") or backend_config.get("fallback_model")
-            self.active_preset = None
+            model_id = None
+
+        if not model_id:
+            model_id = backend_config.get("model") or backend_config.get("fallback_model")
+
+        self.active_preset = None
 
         self.active_backend = backend_name
         self.active_model = model_id


### PR DESCRIPTION
## Summary

- **Dynamic model roster**: New `model_roster.py` service fetches available models from OpenRouter API, filtered by `model_families` patterns in config. Cached for 1 hour with async-safe locking. Falls back to static `available_models` list when OpenRouter is unreachable.
- **Settings UI now controls model routing**: `phase_models` config (written by Settings dropdowns) is now actually used at runtime. Previously the `chat()` method always routed through OpenRouter `@preset/` syntax, ignoring phase_models entirely — causing 404s when presets were removed from the account.
- **Model ID normalization**: Updated defaults and pricing to use OpenRouter's canonical short-form IDs (`anthropic/claude-haiku-4.5` instead of `anthropic/claude-haiku-4-5-20251001`).
- **UI polish**: Right padding on model select dropdowns, consistent Settings page layout and accessibility.

## Changes

| File | What |
|------|------|
| `api/services/model_roster.py` | New — fetches, filters, classifies, caches models from OpenRouter |
| `api/routers/config.py` | Wire up dynamic roster for GET/PATCH `/config/models`, add `/config/models/refresh` |
| `api/services/llm.py` | Fix model resolution: `phase_models[phase]` > backend fallback; remove dead preset routing |
| `config/llm-config.json` | Add `model_families` patterns, update model IDs to canonical form, add Claude 4.6 pricing |
| `web/src/pages/Settings.tsx` | Layout/padding polish, wire up dynamic model list |

## Test plan

- [x] `pytest tests/api/test_llm.py` — 41 passed, 1 xfailed
- [ ] Verify analyst phase no longer 404s on job queue processing
- [ ] Confirm Settings UI model dropdowns populate from OpenRouter
- [ ] Confirm `/api/config/models/refresh` clears cache and returns fresh roster
- [ ] Docker rebuild + smoke test full pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)