### PR TITLE
fix: Handle datetime serialization in manifest JSON

### DIFF
--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -2641,7 +2641,7 @@ The editor reviewed the previous timestamp output and provided the following fee
         }
 
         manifest_file = project_path / "manifest.json"
-        manifest_file.write_text(json.dumps(manifest, indent=2))
+        manifest_file.write_text(json.dumps(manifest, indent=2, default=str))
 
 
 # CLI entry point


### PR DESCRIPTION
## Summary

- Fix `Object of type datetime is not JSON serializable` error that caused jobs to show as failed even after all phases completed successfully
- The `phases` list passed to `_create_manifest` contains datetime objects from phase completion timestamps; `json.dumps` fails without a serializer
- One-line fix: add `default=str` to the `json.dumps` call

## Test plan

- [x] Job 12 completed successfully with this fix applied locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)