### PR TITLE
ci(deploy): build multi-arch images for amd64 + arm64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -39,6 +42,7 @@ jobs:
           context: .
           file: Dockerfile.api
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_PREFIX }}-api:latest
             ${{ env.IMAGE_PREFIX }}-api:${{ github.sha }}
@@ -51,6 +55,7 @@ jobs:
           context: .
           file: Dockerfile.worker
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_PREFIX }}-worker:latest
             ${{ env.IMAGE_PREFIX }}-worker:${{ github.sha }}
@@ -63,6 +68,7 @@ jobs:
           context: .
           file: Dockerfile.web
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_PREFIX }}-web:latest
             ${{ env.IMAGE_PREFIX }}-web:${{ github.sha }}


### PR DESCRIPTION
## Summary

GHCR images are currently amd64-only because the Deploy workflow doesn't pass `platforms:` to `docker/build-push-action`. This blocks `docker compose -f docker-compose.prod.yml pull` on any arm64 host (Apple Silicon, AWS Graviton, Raspberry Pi).

This PR adds `linux/amd64,linux/arm64` to all three build-push steps and pulls in `docker/setup-qemu-action@v3` so the `ubuntu-latest` runner can build the non-native architecture via emulation.

## Why now

Caught after merging #122 while trying to do a manual `docker compose pull` on the Apple Silicon Mac that's currently serving as the production host:

```
✘ Image ghcr.io/mriechers/cardigan-worker:latest
  Error no matching manifest for linux/arm64/v8 in the manifest list entries
```

The Mac has been operating off locally-built images (via `docker-compose.yml`, which has `build:` directives), so the deploy chain happened to work end-to-end this session. But Watchtower polling against GHCR hasn't actually been able to deploy anything for as long as the Mac has been "prod," and any future remote arm64 host (e.g., AWS Graviton) would hit the same wall.

## Cost

Build time roughly doubles — Docker buildx executes the foreign architecture under QEMU emulation. Empirically the previous amd64-only build took ~50s; expect ~2-3 min total with both platforms. GitHub-hosted runner minutes are essentially free for public/personal repos in this size range.

## Test plan

- [ ] Deploy workflow's "Build & Push Images" job succeeds on both platforms (visible in CI checks)
- [ ] `docker manifest inspect ghcr.io/mriechers/cardigan-api:latest` shows both `linux/amd64` and `linux/arm64` entries after merge
- [ ] On the Mac, `docker compose -f docker-compose.prod.yml pull` succeeds without manifest errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)