### PR TITLE
chore(versioning): drive version from git tags via setuptools_scm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve version from git tags
+        id: version
+        run: |
+          python3 -m pip install --quiet setuptools_scm
+          VERSION=$(python3 -m setuptools_scm)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build API image
@@ -143,6 +152,8 @@ jobs:
           context: .
           file: Dockerfile.api
           push: false
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=api
           cache-to: type=gha,mode=max,scope=api
       - name: Build Worker image
@@ -151,6 +162,8 @@ jobs:
           context: .
           file: Dockerfile.worker
           push: false
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
       - name: Build Web image
@@ -161,3 +174,16 @@ jobs:
           push: false
           cache-from: type=gha,scope=web
           cache-to: type=gha,mode=max,scope=web
+
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Check pyproject / package.json / git tag agree on release line
+        run: python3 scripts/check_versions.py

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,18 @@ jobs:
       packages: write
 
     steps:
+      # fetch-depth: 0 pulls full history + tags so setuptools_scm can compute version
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version from git tags
+        id: version
+        run: |
+          python3 -m pip install --quiet setuptools_scm
+          VERSION=$(python3 -m setuptools_scm)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -43,6 +54,8 @@ jobs:
           file: Dockerfile.api
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${{ steps.version.outputs.version }}
           tags: |
             ${{ env.IMAGE_PREFIX }}-api:latest
             ${{ env.IMAGE_PREFIX }}-api:${{ github.sha }}
@@ -56,6 +69,8 @@ jobs:
           file: Dockerfile.worker
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${{ steps.version.outputs.version }}
           tags: |
             ${{ env.IMAGE_PREFIX }}-worker:latest
             ${{ env.IMAGE_PREFIX }}-worker:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@ OUTPUT/
 transcripts/
 transcripts/archive/
 
+# Judge archive — raw transcripts/outputs MUST NOT be committed.
+# This is a public repo; raw data lives in the private second-brain repo
+# at services/crows-nest/data/judge_archive/. Only README.md is tracked.
+data/judge_archive/*.jsonl
+data/judge_archive/findings.md
+
 # IDE
 .idea/
 .vscode/
@@ -39,3 +45,10 @@ logs/
 .snapshots/*
 !.snapshots/.gitkeep
 !.snapshots/dashboard-v2.1-archive.db
+
+# setuptools_scm — generated at build time; never committed.
+# See docs/VERSIONING.md.
+api/_version.py
+
+# pip install -e . metadata — regenerated on every install
+*.egg-info/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -23,6 +23,14 @@ COPY run_worker.py .
 COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
+# Resolve __version__ at build time. Image builds don't have access to .git,
+# so CI passes the version computed from `git describe` as a build arg. The
+# pretend-version env var makes setuptools_scm write api/_version.py during
+# `pip install -e .`. See docs/VERSIONING.md.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=0.0.0+unknown
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT}
+RUN pip install -e . --no-deps
+
 # Create writable directories before switching to non-root user
 RUN mkdir -p logs /data/db /data/output /data/transcripts
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -21,6 +21,11 @@ COPY run_worker.py .
 COPY entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
+# Resolve __version__ at build time. See Dockerfile.api / docs/VERSIONING.md.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=0.0.0+unknown
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT}
+RUN pip install -e . --no-deps
+
 # Create writable directories before switching to non-root user
 RUN mkdir -p logs /data/db /data/output /data/transcripts
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,7 +1,17 @@
 """
-Cardigan v4.0 API
+Cardigan API
 
 FastAPI-based control plane for the Cardigan system.
+
+Version is sourced from git tags via setuptools_scm at build time.
+The build writes api/_version.py, which we import below. If the file
+is missing (e.g., editable checkout without a build run), fall back
+to a sentinel so imports never fail.
+
+See docs/VERSIONING.md for the release/bump policy.
 """
 
-__version__ = "4.0.0"
+try:
+    from api._version import __version__  # type: ignore[import-not-found]
+except ImportError:
+    __version__ = "0.0.0+unknown"

--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
+from api import __version__
 from api.middleware.auth import APIKeyMiddleware
 from api.middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from api.services import database
@@ -65,7 +66,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Cardigan API",
     description="API for Cardigan - PBS Wisconsin transcript processing and metadata generation",
-    version="4.0.0",
+    version=__version__,
     lifespan=lifespan,
 )
 
@@ -109,7 +110,7 @@ async def global_exception_handler(request, exc):
 @app.get("/")
 async def root():
     """Health check endpoint."""
-    return {"status": "ok", "version": "4.0.0"}
+    return {"status": "ok", "version": __version__}
 
 
 @app.get("/api/system/health")

--- a/api/services/database.py
+++ b/api/services/database.py
@@ -36,11 +36,32 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+
+def _default_app_version() -> str:
+    """Derive the cost-epoch tag from the package version's major.minor.
+
+    Examples:
+        "4.1.0"               → "v4.1"
+        "4.1.1.dev3+g8a1b2c3" → "v4.1"
+        "0.0.0+unknown"       → "v0.0"  (build without git access; sentinel)
+
+    The CARDIGAN_VERSION env var (set in docker-compose.yml) overrides
+    this for short-lived experiments — useful when testing a model
+    routing change without wanting the rows tagged with the next epoch.
+    """
+    from api import __version__  # local import to avoid circular at module load
+
+    parts = __version__.split(".")[:2]
+    if len(parts) < 2:
+        parts = ["0", "0"]
+    return f"v{'.'.join(parts)}"
+
+
 # App version tag stamped on all rows produced by this process.
-# Override via CARDIGAN_VERSION env var (set in docker-compose.yml).
-# Bump the default literal each time the codebase changes meaningfully
-# enough that cost/quality should not be averaged with the prior epoch.
-APP_VERSION = os.getenv("CARDIGAN_VERSION") or "v4.1"
+# Source of truth: git tag → setuptools_scm → api/__version__ → here.
+# Override at runtime via CARDIGAN_VERSION env var (set in docker-compose.yml).
+# See docs/VERSIONING.md for release/bump policy.
+APP_VERSION = os.getenv("CARDIGAN_VERSION") or _default_app_version()
 
 from api.models.chat import ChatMessage, ChatSession, ChatSessionStatus
 from api.models.config import ConfigItem, ConfigValueType

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,133 @@
+# Versioning
+
+Cardigan uses **git tags** as the single source of truth for the application
+version. The Python package, the FastAPI app, the Docker images, and the cost
+data epoch all read from the same place.
+
+## How it works
+
+```
+git tag (vX.Y.Z)
+    │
+    ▼
+setuptools_scm  ─►  api/_version.py  ─►  api/__init__.py  ─►  __version__
+                          │                                       │
+                          │                                       ▼
+                          │                              FastAPI(version=…)
+                          │                              /api/system/health
+                          │                              CARDIGAN_VERSION default
+                          ▼
+                   Docker build-arg
+                   (CI computes via `python -m setuptools_scm`)
+```
+
+- `pyproject.toml` declares `version` as `dynamic` and points
+  `[tool.setuptools_scm]` at `api/_version.py`.
+- `api/_version.py` is **gitignored** — it is regenerated on every build.
+- In CI, `python -m setuptools_scm` resolves the version from the latest
+  `vX.Y.Z` tag plus distance/sha and passes it to Docker via
+  `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT`.
+- At runtime, `api/services/database.py` derives the cost-data
+  `app_version` (e.g. `v4.1`) from `__version__` unless `CARDIGAN_VERSION`
+  is set explicitly.
+- `web/package.json` carries a static version string that npm requires.
+  CI's `version-consistency` job (see `scripts/check_versions.py`) enforces
+  that its MAJOR.MINOR matches the latest git tag.
+
+## When to bump — threshold table
+
+The team has been undisciplined about version bumps in the past. These rules
+make it explicit. Bump when **any** row applies; pick the highest precedence.
+
+| Bump   | When                                                         | Examples                                                                 |
+| ------ | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| MAJOR  | Breaking API change, schema migration users must coordinate  | `v4 → v5`: ingest API rewrite, change to job state machine              |
+| MINOR  | Sprint completion with user-visible behavior change          | `v4.0 → v4.1`: cost data preservation sprint, multi-arch images         |
+| PATCH  | Bug fix or operator-visible change to a shipping behavior    | `v4.1.0 → v4.1.1`: ingest scanner crash fix, prompt routing fix         |
+| _none_ | Pure refactor, internal docs, dev-tooling, CI changes        | Workflow YAML edits, test-only changes, README updates                   |
+
+A few sharper edges worth calling out:
+
+- **No-op refactors don't bump.** If behavior is identical, do not tag. The
+  next real change picks up the bump. Avoid version-noise commits.
+- **Cost epoch changes are MINOR.** Anything that materially shifts model
+  selection, retry strategy, or pricing assumptions is a new pricing era.
+  Bump MINOR so the `app_version` tag in `jobs` / `chat_sessions` separates
+  cleanly. See `docs/COST_DATA_VERSIONING.md`.
+- **DB schema changes don't automatically bump.** If users won't notice (a
+  new index, a nullable column with a backfill), no bump. If users _will_
+  notice (a re-keyed table, a re-run requirement), MINOR or MAJOR.
+- **Frontend-only releases bump too.** If `web/` ships a meaningful change
+  to the dashboard, bump PATCH and the consistency check will keep
+  `web/package.json` aligned.
+
+## How to release
+
+1. Confirm `main` is green, the work you want to ship is merged, and the
+   release notes are ready.
+2. Tag locally with an annotated tag:
+   ```bash
+   git tag -a v4.1.1 -m "v4.1.1: <one-line summary>"
+   git push origin v4.1.1
+   ```
+3. The `Deploy` workflow runs on push to `main`, so tagging itself does
+   not trigger a build. To redeploy with the new version baked in, push
+   any commit to `main` (or merge a release-notes PR that touches at
+   least one file).
+4. Verify the deployed version after Watchtower picks up the new image:
+   ```bash
+   curl -s http://<host>/api/system/health | jq '.version // .status'
+   curl -s http://<host>/ | jq '.version'
+   ```
+5. If you bumped MAJOR or MINOR and a cost epoch change is part of it,
+   follow `docs/COST_DATA_VERSIONING.md` for the snapshot/backfill flow.
+
+## How to bump web/package.json
+
+When you tag a new MAJOR.MINOR (e.g. `v4.2.0`), update
+`web/package.json` and `web/package-lock.json` to match in the same PR.
+PATCH-level drift is tolerated — the CI consistency check only enforces
+MAJOR.MINOR.
+
+```bash
+cd web
+npm version --no-git-tag-version 4.2.0
+```
+
+## Local development
+
+If you check out the repo without running a build, `api/_version.py`
+won't exist. `api/__init__.py` falls back to `"0.0.0+unknown"` so imports
+never fail. To populate the file:
+
+```bash
+pip install -e .  # writes api/_version.py via setuptools_scm
+```
+
+`./init.sh` does this for you on every dev session.
+
+## Docker builds
+
+Local builds work three ways:
+
+1. **With `.git` available in the build context** — setuptools_scm reads
+   the tag directly. (Default is to exclude `.git` via `.dockerignore`,
+   so this requires removing the entry temporarily.)
+2. **With a build-arg** — pass the version explicitly:
+   ```bash
+   docker build \
+     -f Dockerfile.api \
+     --build-arg SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=$(python -m setuptools_scm) \
+     -t cardigan-api .
+   ```
+3. **Without either** — falls back to `0.0.0+unknown`. Fine for one-off
+   smoke tests; never ship this to production.
+
+CI always uses option (2).
+
+## Why setuptools_scm and not a hand-edited version string
+
+We tried hand-edited version strings. Four files drifted (api/main.py,
+api/__init__.py, web/package.json, FastAPI title). Bumping consistently
+turned into a checklist nobody followed. setuptools_scm collapses the
+checklist to one action — `git tag` — and the rest follows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "editorial-assistant"
-version = "3.5.0"
+dynamic = ["version"]
 requires-python = ">=3.13"
+
+[tool.setuptools_scm]
+# Source of truth: git tags (e.g., v4.1.0). See docs/VERSIONING.md.
+# At build time, setuptools_scm writes api/_version.py with the resolved version.
+# api/_version.py is gitignored — never commit it; it's regenerated on each build.
+version_file = "api/_version.py"
+fallback_version = "0.0.0+unknown"
+
+[tool.setuptools.packages.find]
+include = ["api*", "scripts*", "mcp_server*"]
+exclude = ["tests*", "web*", "alembic*", "claude-desktop-project*", "knowledge*", "config*", "docs*", "planning*", ".claude*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify that web/package.json and the latest git tag agree on the release line.
+
+Source of truth: the latest annotated `vX.Y.Z` git tag.
+- pyproject.toml declares version dynamic via setuptools_scm — no static value to check.
+- web/package.json carries a static version string (npm requires it).
+- The script enforces that package.json's MAJOR.MINOR matches the latest tag's MAJOR.MINOR.
+  Patch-level drift is tolerated: package.json doesn't need to bump on every backend patch.
+
+Run locally before opening a release PR:
+    python3 scripts/check_versions.py
+
+Exits non-zero if the release lines have diverged.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def latest_tag_version() -> str | None:
+    """Return the most recent vMAJOR.MINOR.PATCH tag reachable from HEAD, or None."""
+    try:
+        out = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return out.lstrip("v") if out else None
+
+
+def package_json_version() -> str:
+    data = json.loads((REPO_ROOT / "web" / "package.json").read_text())
+    return data["version"]
+
+
+def major_minor(version: str) -> tuple[int, int]:
+    match = re.match(r"(\d+)\.(\d+)", version)
+    if not match:
+        raise ValueError(f"Cannot parse MAJOR.MINOR from {version!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def main() -> int:
+    pkg = package_json_version()
+    tag = latest_tag_version()
+
+    print(f"web/package.json version: {pkg}")
+    print(f"latest git tag:           {tag or '(none)'}")
+
+    if tag is None:
+        print("WARN: no git tag found — skipping consistency check.")
+        return 0
+
+    if major_minor(pkg) != major_minor(tag):
+        print(
+            f"ERROR: web/package.json ({pkg}) and git tag (v{tag}) " f"are on different MAJOR.MINOR lines.",
+            file=sys.stderr,
+        )
+        print("Bump web/package.json to match the release line.", file=sys.stderr)
+        return 1
+
+    print("OK: release lines agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cardigan-dashboard",
-  "version": "3.5.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cardigan-dashboard",
-      "version": "3.5.0",
+      "version": "4.1.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "react": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cardigan-dashboard",
   "private": true,
-  "version": "3.5.0",
+  "version": "4.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Make the latest `vX.Y.Z` git tag the single source of truth for the version. setuptools_scm writes `api/_version.py` at build time; `__version__` flows through `api/__init__.py` to FastAPI, `/api/system/health`, and the cost-data `app_version` epoch.
- CI/Deploy resolve the version with \`python -m setuptools_scm\` and pass it to Docker as \`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT\` (no .git needed in image).
- Replaces hand-edited \`"4.0.0"\` strings that had silently drifted across four files. Tagged \`v4.1.0\` first as the baseline, then this PR adds the machinery on top.
- Adds \`scripts/check_versions.py\` + \`version-consistency\` CI job to keep \`web/package.json\` MAJOR.MINOR aligned with the latest tag.
- Adds \`docs/VERSIONING.md\` with a threshold table for when to bump (sprint = MINOR, behavior fix = PATCH, refactor = none, breaking = MAJOR).
- Bumps \`web/package.json\` 3.5.0 → 4.1.0.

## Test plan
- [x] Local: \`from api import __version__\` returns \`4.1.1.dev0+ga7424b63f.d…\`
- [x] Local: \`APP_VERSION\` (cost-data tag) derives \`v4.1\`
- [x] Local: \`scripts/check_versions.py\` exits 0
- [x] Docker smoke: \`docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EDITORIAL_ASSISTANT=4.1.1.dev0+test … && docker run … python -c 'from api import __version__; print(__version__)'\` → \`4.1.1.dev0+test\`
- [x] Lint: ruff + black clean
- [x] Targeted tests pass (\`tests/test_backfill_v21.py\`, \`tests/api/test_database.py\`, \`tests/api/test_app_version_migration.py\`)
- [ ] CI green (this PR)

## Notes
- After merge, tag \`v4.1.1\` and push \`main\` so the deploy workflow rebuilds with the resolved version baked in.
- Future: bumping is now \`git tag -a vX.Y.Z\` + same-PR \`web/package.json\` bump on MAJOR.MINOR boundaries; everything else flows from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)