### PR TITLE
fix(docker): align api/mcp image build, healthcheck, and migration handling

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -40,9 +40,8 @@ USER appuser
 
 ENTRYPOINT ["./entrypoint.sh"]
 
-EXPOSE 8000
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/system/health')" || exit 1
+# No EXPOSE or HEALTHCHECK here: this image runs both the api (port 8000)
+# and the mcp server (port 8080) depending on which compose service uses it.
+# Each compose service declares its own ports and healthcheck.
 
 CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   api:
+    image: cardigan-v4-api
     build:
       context: .
       dockerfile: Dockerfile.api
@@ -68,9 +69,10 @@ services:
       - api
 
   mcp:
-    build:
-      context: .
-      dockerfile: Dockerfile.api
+    # Shares the api image — same content, different command. Mirrors prod
+    # (docker-compose.prod.yml), where both services pull the same GHCR tag.
+    # Build with `docker compose build api` (mcp has no build of its own).
+    image: cardigan-v4-api
     command: ["python", "-m", "mcp_server.server"]
     ports:
       - "8180:8080"
@@ -89,6 +91,12 @@ services:
       - db-data:/data/db
       - output-data:/data/output
       - ./transcripts:/data/transcripts
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket,sys; s=socket.socket(); s.settimeout(3); s.connect(('localhost', 8080)); s.close()"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     depends_on:
       api:
         condition: service_healthy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,16 @@ set -e
 # Ensure writable directories exist
 mkdir -p /data/db /data/output /data/transcripts logs
 
-# Run database migrations if alembic is configured
-if [ -f alembic.ini ]; then
+# Run database migrations if this image carries them. The api image bundles
+# alembic.ini + alembic/; the worker image only ships alembic.ini and relies
+# on api having already migrated the shared DB. Both conditions are required
+# so a partially-built image fails fast instead of silently skipping.
+# Fails loudly on error: a migration failure means image and DB are out of
+# sync (e.g. image built before a new revision was added) and continuing
+# would mask schema drift.
+if [ -f alembic.ini ] && [ -d alembic ]; then
     echo "[entrypoint] Running database migrations..."
-    alembic upgrade head || echo "[entrypoint] WARNING: Alembic migration failed (may be OK on first run)"
+    alembic upgrade head
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Four cohesive fixes uncovered while debugging an \"unhealthy\" `cardigan-mcp` container. The original symptom (container marked unhealthy) was a misconfigured healthcheck, but the investigation surfaced three more issues in adjacent layers — all caused by a single piece of swallowed error output that had been hiding drift for weeks.

- **MCP healthcheck** — `mcp` service inherited `Dockerfile.api`'s healthcheck, which probes port 8000. MCP listens on 8080. Added an explicit `healthcheck:` block (TCP probe on 8080) to the `mcp` service in `docker-compose.yml`.
- **Dockerfile.api cleanup** — removed `EXPOSE 8000` and `HEALTHCHECK` from `Dockerfile.api` since the image is used by two services on different ports. Each compose service declares its own.
- **Entrypoint fail-loud** — `entrypoint.sh` no longer swallows alembic errors with `|| echo WARNING`. Added a `[ -d alembic ]` guard so the worker image (which ships `alembic.ini` but no `alembic/` dir) skips cleanly instead of erroring on every startup.
- **Shared image** — `api` and `mcp` now both reference `image: cardigan-v4-api` in dev compose (build: only on api), mirroring the prod compose pattern. Eliminates the image-drift class that caused the original stale-MCP-image bug.

## Why bundled

These four changes are tightly coupled — splitting them would leave intermediate broken states (e.g., fail-loud entrypoint without rebuilding stale images would crash the MCP container). Easier to land as one cohesive fix.

## Related

- Issue #142 — latent alembic revision conflicts in `v4.1/sprint-3` and `v4.1/sprint-4` worktrees, discovered during this investigation. Not in scope for this PR.

## Test plan

- [x] `docker compose --profile mcp up -d` — all four containers (api, mcp, worker, web) start healthy
- [x] MCP container healthcheck transitions `starting → healthy` (FailingStreak: 0)
- [x] Alembic startup logs are clean (no \"Can't locate revision\" warnings, no swallowed errors)
- [x] Worker no longer prints the silent alembic warning on startup
- [x] `docker compose build` produces 3 images (api, worker, web) instead of 4 — mcp shares api's image
- [x] MCP container `Image` field confirmed as `cardigan-v4-api` via `docker inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)