### PR TITLE
feat: Sprint 4 — Cost visibility & observability (rebased)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,7 @@ from api.middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from api.services import database
 from api.services.ingest_config import ensure_defaults as ensure_ingest_defaults
 from api.services.ingest_scheduler import start_scheduler, stop_scheduler
+from api.services.langfuse_client import get_langfuse_client
 from api.services.llm import close_llm_client, get_llm_client
 from api.services.logging import get_logger, setup_logging
 
@@ -48,6 +49,9 @@ async def lifespan(app: FastAPI):
     logger.info("Database initialized")
     get_llm_client()  # Initialize LLM client
     logger.info("LLM client initialized")
+    langfuse = get_langfuse_client()
+    await langfuse.initialize()
+    logger.info("Langfuse client initialized")
     # Initialize ingest config defaults (Sprint 11.1)
     await ensure_ingest_defaults()
     logger.info("Ingest configuration initialized")

--- a/api/models/job.py
+++ b/api/models/job.py
@@ -42,6 +42,8 @@ class JobPhase(BaseModel):
     completed_at: Optional[datetime] = None
     cost: float = Field(default=0.0, description="Cost incurred during this phase")
     tokens: int = Field(default=0, description="Tokens used during this phase")
+    input_tokens: int = Field(default=0, description="Input/prompt tokens used")
+    output_tokens: int = Field(default=0, description="Output/completion tokens used")
     error_message: Optional[str] = None
     output_path: Optional[str] = Field(None, description="Path to phase output file if applicable")
     metadata: Optional[Dict[str, Any]] = Field(default=None, description="Phase-specific metadata")

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -5,11 +5,12 @@ Provides endpoints for viewing and updating LLM routing configuration.
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from api.services.cost_estimator import estimate_job_cost
 from api.services.llm import get_llm_client
 from api.services.model_roster import get_available_models, invalidate_cache
 
@@ -132,6 +133,8 @@ class AvailableModel(BaseModel):
     name: str = Field(..., description="Human-readable model name")
     provider: str = Field(..., description="Model provider (e.g., 'Anthropic', 'Google')")
     tier: int = Field(..., ge=0, le=2, description="Cost tier (0=economy, 1=standard, 2=premium)")
+    pricing_input: Optional[float] = Field(None, description="Cost per 1M input tokens (USD)")
+    pricing_output: Optional[float] = Field(None, description="Cost per 1M output tokens (USD)")
 
 
 class PhaseModelsResponse(BaseModel):
@@ -289,3 +292,55 @@ async def update_worker_config(update: WorkerConfigUpdate):
     _save_config(config)
 
     return await get_worker_config()
+
+
+class CostEstimateRequest(BaseModel):
+    """Request body for cost estimation."""
+
+    word_count: int = Field(..., ge=0, description="Transcript word count")
+    phase_models: Optional[Dict[str, str]] = Field(
+        None, description="Override phase-model assignments (defaults to current config)"
+    )
+
+
+class CostEstimateResponse(BaseModel):
+    """Cost estimate for a job."""
+
+    total_estimated_cost: float
+    estimated_input_tokens: int
+    phase_estimates: List[Dict[str, Any]]
+
+
+@router.post("/estimate-cost", response_model=CostEstimateResponse)
+async def get_cost_estimate(body: CostEstimateRequest):
+    """Estimate the cost of processing a transcript.
+
+    Uses current phase-model assignments (or overrides) and model pricing
+    to estimate total cost. Useful for showing users expected costs
+    before submitting a job.
+    """
+    config = _load_config()
+
+    # Use provided phase_models or fall back to current config
+    phase_models = body.phase_models or config.get("phase_models", DEFAULT_PHASE_MODELS)
+
+    # Build pricing overrides from the model roster (has live OpenRouter pricing)
+    pricing_overrides = {}
+    try:
+        models_data = await get_available_models()
+        for m in models_data:
+            if m.get("pricing_input") is not None and m.get("pricing_output") is not None:
+                pricing_overrides[m["id"]] = {
+                    "input": m["pricing_input"],
+                    "output": m["pricing_output"],
+                }
+    except Exception:
+        pass  # Fall through to MODEL_PRICING static fallback
+
+    result = estimate_job_cost(
+        word_count=body.word_count,
+        phase_models=phase_models,
+        pricing_overrides=pricing_overrides,
+    )
+
+    return CostEstimateResponse(**result)

--- a/api/services/cost_estimator.py
+++ b/api/services/cost_estimator.py
@@ -1,0 +1,97 @@
+"""Cost estimation service for Cardigan.
+
+Estimates job processing cost based on transcript size,
+configured models, and per-phase output multipliers.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from api.services.llm import MODEL_PRICING
+
+# Approximate tokens-per-word ratio (English text averages ~1.33 tokens/word)
+TOKENS_PER_WORD = 1.33
+
+# Per-phase multipliers: how many output tokens relative to input tokens.
+# Based on observed production data:
+# - Analyst: produces ~0.25x input (summary + analysis)
+# - Formatter: produces ~0.9x input (reformats full transcript)
+# - SEO: produces ~0.15x input (short metadata)
+# - Validator: produces ~0.05x input (brief pass/fail report)
+# - Timestamp: produces ~0.1x input (chapter markers)
+PHASE_OUTPUT_MULTIPLIERS = {
+    "analyst": 0.25,
+    "formatter": 0.90,
+    "seo": 0.15,
+    "validator": 0.05,
+    "timestamp": 0.10,
+    "copy_editor": 0.90,
+}
+
+# Conservative fallback pricing (per 1M tokens) for unknown models
+FALLBACK_PRICING = {"input": 1.0, "output": 3.0}
+
+
+def _get_pricing(model_id: str, pricing_overrides: Optional[Dict[str, Dict[str, float]]] = None) -> Dict[str, float]:
+    """Get per-1M-token pricing for a model.
+
+    Checks overrides first, then MODEL_PRICING, then falls back to conservative estimate.
+    """
+    if pricing_overrides and model_id in pricing_overrides:
+        return pricing_overrides[model_id]
+    return MODEL_PRICING.get(model_id, FALLBACK_PRICING)
+
+
+def estimate_job_cost(
+    word_count: int,
+    phase_models: Dict[str, str],
+    pricing_overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Dict[str, Any]:
+    """Estimate the total cost for processing a transcript.
+
+    Args:
+        word_count: Number of words in the transcript
+        phase_models: Dict mapping phase name to model ID
+        pricing_overrides: Optional dict of {model_id: {"input": float, "output": float}}
+            for pricing not in MODEL_PRICING (e.g., from OpenRouter roster)
+
+    Returns:
+        Dict with total_estimated_cost and per-phase breakdown
+    """
+    if word_count == 0:
+        return {
+            "total_estimated_cost": 0,
+            "estimated_input_tokens": 0,
+            "phase_estimates": [],
+        }
+
+    base_input_tokens = int(word_count * TOKENS_PER_WORD)
+    total_cost = 0.0
+    phase_estimates: List[Dict[str, Any]] = []
+
+    for phase, model_id in phase_models.items():
+        output_multiplier = PHASE_OUTPUT_MULTIPLIERS.get(phase, 0.25)
+        est_input = base_input_tokens
+        est_output = int(base_input_tokens * output_multiplier)
+
+        pricing = _get_pricing(model_id, pricing_overrides)
+        input_cost = (est_input / 1_000_000) * pricing["input"]
+        output_cost = (est_output / 1_000_000) * pricing["output"]
+        phase_cost = input_cost + output_cost
+
+        phase_estimates.append(
+            {
+                "phase": phase,
+                "model": model_id,
+                "estimated_input_tokens": est_input,
+                "estimated_output_tokens": est_output,
+                "estimated_cost": round(phase_cost, 6),
+            }
+        )
+
+        total_cost += phase_cost
+
+    return {
+        "total_estimated_cost": round(total_cost, 4),
+        "estimated_input_tokens": base_input_tokens,
+        "phase_estimates": phase_estimates,
+    }

--- a/api/services/langfuse_client.py
+++ b/api/services/langfuse_client.py
@@ -13,6 +13,7 @@ Langfuse credentials are loaded from:
 2. macOS Keychain via keychain_secrets (fallback)
 """
 
+import asyncio
 import json
 import uuid
 from dataclasses import dataclass
@@ -62,6 +63,14 @@ class LangfuseClient:
         self._initialized = False
         self._init_error: Optional[str] = None
         self._host: Optional[str] = None
+
+    async def initialize(self) -> bool:
+        """Eagerly initialize the Langfuse client.
+
+        Call this at app startup to avoid lazy-init delays during job processing.
+        Returns True if client is ready, False if credentials are missing.
+        """
+        return self._ensure_initialized()
 
     def _ensure_initialized(self) -> bool:
         """Lazily initialize credentials and HTTP client."""
@@ -192,9 +201,12 @@ class LangfuseClient:
                 },
             ]
 
-            resp = await self._http_client.post(
-                "/api/public/ingestion",
-                json={"batch": batch},
+            resp = await asyncio.wait_for(
+                self._http_client.post(
+                    "/api/public/ingestion",
+                    json={"batch": batch},
+                ),
+                timeout=5.0,
             )
             resp.raise_for_status()
 

--- a/api/services/model_roster.py
+++ b/api/services/model_roster.py
@@ -88,6 +88,20 @@ def _classify_models(raw_models: List[dict], families: List[dict]) -> List[dict]
         if family is None:
             continue
 
+        # Extract pricing (OpenRouter reports cost per token as strings)
+        pricing_input = None
+        pricing_output = None
+        raw_pricing = model.get("pricing", {})
+        if raw_pricing:
+            try:
+                prompt_per_token = float(raw_pricing.get("prompt", 0))
+                completion_per_token = float(raw_pricing.get("completion", 0))
+                # Convert per-token to per-1M-tokens
+                pricing_input = round(prompt_per_token * 1_000_000, 4)
+                pricing_output = round(completion_per_token * 1_000_000, 4)
+            except (ValueError, TypeError):
+                pass
+
         seen_ids.add(model_id)
         results.append(
             {
@@ -95,6 +109,8 @@ def _classify_models(raw_models: List[dict], families: List[dict]) -> List[dict]
                 "name": model.get("name", model_id),
                 "provider": family["provider"],
                 "tier": family["tier"],
+                "pricing_input": pricing_input,
+                "pricing_output": pricing_output,
             }
         )
 

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -431,6 +431,8 @@ class JobWorker:
                     p["status"] = phase_result.get("status", "completed")
                     p["cost"] = phase_result.get("cost", 0)
                     p["tokens"] = phase_result.get("tokens", 0)
+                    p["input_tokens"] = phase_result.get("input_tokens", 0)
+                    p["output_tokens"] = phase_result.get("output_tokens", 0)
                     p["model"] = phase_result.get("model")
                     p["completed_at"] = datetime.now(timezone.utc).isoformat()
                     phase_updated = True
@@ -444,6 +446,8 @@ class JobWorker:
                         "status": "completed",
                         "cost": phase_result.get("cost", 0),
                         "tokens": phase_result.get("tokens", 0),
+                        "input_tokens": phase_result.get("input_tokens", 0),
+                        "output_tokens": phase_result.get("output_tokens", 0),
                         "model": phase_result.get("model"),
                         "completed_at": datetime.now(timezone.utc).isoformat(),
                     }
@@ -655,6 +659,8 @@ class JobWorker:
                     "status": "completed" if phase_result["success"] else "failed",
                     "cost": phase_result.get("cost", 0),
                     "tokens": phase_result.get("tokens", 0),
+                    "input_tokens": phase_result.get("input_tokens", 0),
+                    "output_tokens": phase_result.get("output_tokens", 0),
                     "completed_at": datetime.now(timezone.utc).isoformat(),
                     "model": phase_result.get("model"),
                     "attempts": phase_result.get("attempts", 1),
@@ -811,6 +817,8 @@ class JobWorker:
                         "status": "completed" if phase_result["success"] else "failed",
                         "cost": phase_result.get("cost", 0),
                         "tokens": phase_result.get("tokens", 0),
+                        "input_tokens": phase_result.get("input_tokens", 0),
+                        "output_tokens": phase_result.get("output_tokens", 0),
                         "completed_at": datetime.now(timezone.utc).isoformat(),
                         "model": phase_result.get("model"),
                         "optional": True,  # Mark as optional phase
@@ -1402,6 +1410,8 @@ class JobWorker:
                 "output": response.content,
                 "cost": response.cost,
                 "tokens": response.total_tokens,
+                "input_tokens": response.input_tokens,
+                "output_tokens": response.output_tokens,
                 "model": response.model,
             }
 
@@ -1556,7 +1566,13 @@ Please format this transcript section:
                     },
                 )
 
-                return {"content": response.content, "cost": response.cost, "tokens": response.total_tokens}
+                return {
+                    "content": response.content,
+                    "cost": response.cost,
+                    "tokens": response.total_tokens,
+                    "input_tokens": response.input_tokens,
+                    "output_tokens": response.output_tokens,
+                }
 
         # Log phase start
         await log_event(
@@ -1606,6 +1622,8 @@ Please format this transcript section:
             # Aggregate cost/tokens from all chunks
             total_cost = sum(r["cost"] for r in chunk_results)
             total_tokens = sum(r["tokens"] for r in chunk_results)
+            total_input_tokens = sum(r.get("input_tokens", 0) for r in chunk_results)
+            total_output_tokens = sum(r.get("output_tokens", 0) for r in chunk_results)
 
             # Merge text outputs
             merged = merge_formatter_chunks([r["content"] for r in chunk_results])
@@ -1646,6 +1664,8 @@ Please format this transcript section:
                 "output": merged,
                 "cost": total_cost,
                 "tokens": total_tokens,
+                "input_tokens": total_input_tokens,
+                "output_tokens": total_output_tokens,
                 "model": f"chunked ({total_chunks} chunks via {backend})",
             }
 

--- a/docs/superpowers/plans/2026-05-01-v4.1-sprint-4-cost-observability.md
+++ b/docs/superpowers/plans/2026-05-01-v4.1-sprint-4-cost-observability.md
@@ -1,0 +1,1099 @@
+# v4.1 Sprint 4: Cost & Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users cost visibility (per-phase token breakdown, pre-submission estimates) and ensure Langfuse observability is reliable and non-blocking.
+
+**Architecture:** Extend `_run_phase` return values to include `input_tokens` / `output_tokens` separately. Store these on `JobPhase`. Add a pricing endpoint backed by `MODEL_PRICING` dict. Build a cost estimation service that multiplies transcript token count by per-phase multipliers. Move Langfuse init to app startup. Add cost breakdown table to JobDetail UI.
+
+**Tech Stack:** Python/FastAPI (backend), React/TypeScript (frontend), SQLite (storage), OpenRouter API (pricing data)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `api/services/worker.py` | Modify | Return `input_tokens`/`output_tokens` from `_run_phase`, store in phase data |
+| `api/models/job.py` | Modify | Add `input_tokens`/`output_tokens` fields to `JobPhase` |
+| `api/services/cost_estimator.py` | Create | Estimate job cost from word count + model pricing + phase multipliers |
+| `api/routers/config.py` | Modify | Add `pricing` field to `AvailableModel`, add `/config/estimate-cost` endpoint |
+| `api/services/model_roster.py` | Modify | Pass through OpenRouter pricing data in model classification |
+| `api/services/langfuse_client.py` | Modify | Add `async initialize()` method, convert lazy init to eager |
+| `api/main.py` | Modify | Call Langfuse `initialize()` at startup |
+| `web/src/pages/JobDetail.tsx` | Modify | Add cost breakdown table with input/output token columns |
+| `web/src/pages/QueuePage.tsx` | Modify | Show estimated cost before submission |
+| `tests/test_cost_estimator.py` | Create | Unit tests for cost estimation service |
+| `tests/test_cost_visibility.py` | Create | Tests for token granularity in phase data and pricing endpoint |
+| `tests/test_langfuse_eager.py` | Create | Tests for Langfuse eager initialization |
+
+---
+
+### Task 1: Add input_tokens/output_tokens to JobPhase model
+
+**Files:**
+- Modify: `api/models/job.py:32-53` (JobPhase class)
+- Test: `tests/test_cost_visibility.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cost_visibility.py
+"""Tests for cost visibility: token granularity and pricing."""
+
+
+def test_job_phase_has_token_breakdown():
+    """JobPhase should support input_tokens and output_tokens fields."""
+    from api.models.job import JobPhase
+
+    phase = JobPhase(
+        name="analyst",
+        input_tokens=12000,
+        output_tokens=3000,
+        tokens=15000,
+        cost=0.02,
+    )
+    assert phase.input_tokens == 12000
+    assert phase.output_tokens == 3000
+    assert phase.tokens == 15000
+
+
+def test_job_phase_token_breakdown_defaults_to_zero():
+    """Token breakdown fields should default to 0."""
+    from api.models.job import JobPhase
+
+    phase = JobPhase(name="analyst")
+    assert phase.input_tokens == 0
+    assert phase.output_tokens == 0
+    assert phase.tokens == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cost_visibility.py -v`
+Expected: FAIL — `JobPhase` has no `input_tokens` / `output_tokens` fields
+
+- [ ] **Step 3: Add fields to JobPhase**
+
+In `api/models/job.py`, add to the `JobPhase` class (after `tokens` field at line 44):
+
+```python
+    input_tokens: int = Field(default=0, description="Input/prompt tokens used")
+    output_tokens: int = Field(default=0, description="Output/completion tokens used")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cost_visibility.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/models/job.py tests/test_cost_visibility.py
+git commit -m "feat: Add input_tokens/output_tokens fields to JobPhase model"
+```
+
+---
+
+### Task 2: Return token breakdown from _run_phase and store in phase data
+
+**Files:**
+- Modify: `api/services/worker.py:1402-1408` (_run_phase return dict)
+- Modify: `api/services/worker.py:654-662` (phase_data dict in process_job main loop)
+- Modify: `api/services/worker.py:811-819` (phase_data dict in optional timestamp phase)
+- Modify: `api/services/worker.py:436-447` (phase_data dict in retry_single_phase)
+- Test: `tests/test_cost_visibility.py`
+
+`_run_phase` already has access to `response.input_tokens` and `response.output_tokens` from the `LLMResponse` dataclass (see `api/services/llm.py:84-96`). We just need to include them in the return dict and store them in phase data.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cost_visibility.py`:
+
+```python
+def test_run_phase_return_includes_token_breakdown():
+    """_run_phase return dict should include input_tokens and output_tokens."""
+    # We test this through the phase_data dict structure
+    # Verifying that the worker stores token breakdown when processing phases
+    from api.models.job import JobPhase
+
+    # Simulate what the worker builds from _run_phase result
+    phase_result = {
+        "success": True,
+        "output": "test content",
+        "cost": 0.02,
+        "tokens": 15000,
+        "input_tokens": 12000,
+        "output_tokens": 3000,
+        "model": "anthropic/claude-haiku-4.5",
+    }
+
+    phase = JobPhase(
+        name="analyst",
+        status="completed",
+        cost=phase_result["cost"],
+        tokens=phase_result["tokens"],
+        input_tokens=phase_result["input_tokens"],
+        output_tokens=phase_result["output_tokens"],
+        model=phase_result["model"],
+    )
+
+    assert phase.input_tokens == 12000
+    assert phase.output_tokens == 3000
+```
+
+- [ ] **Step 2: Run test to verify it passes** (this test validates the model works with the new fields from Task 1)
+
+Run: `pytest tests/test_cost_visibility.py::test_run_phase_return_includes_token_breakdown -v`
+Expected: PASS
+
+- [ ] **Step 3: Update _run_phase success return to include token breakdown**
+
+In `api/services/worker.py`, find the return dict at line 1402:
+
+```python
+            return {
+                "success": True,
+                "output": response.content,
+                "cost": response.cost,
+                "tokens": response.total_tokens,
+                "model": response.model,
+            }
+```
+
+Replace with:
+
+```python
+            return {
+                "success": True,
+                "output": response.content,
+                "cost": response.cost,
+                "tokens": response.total_tokens,
+                "input_tokens": response.input_tokens,
+                "output_tokens": response.output_tokens,
+                "model": response.model,
+            }
+```
+
+- [ ] **Step 4: Update phase_data in process_job main loop**
+
+In `api/services/worker.py`, find the phase_data dict at line 654:
+
+```python
+                phase_data = {
+                    "name": phase_name,
+                    "status": "completed" if phase_result["success"] else "failed",
+                    "cost": phase_result.get("cost", 0),
+                    "tokens": phase_result.get("tokens", 0),
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "model": phase_result.get("model"),
+                    "attempts": phase_result.get("attempts", 1),
+                }
+```
+
+Replace with:
+
+```python
+                phase_data = {
+                    "name": phase_name,
+                    "status": "completed" if phase_result["success"] else "failed",
+                    "cost": phase_result.get("cost", 0),
+                    "tokens": phase_result.get("tokens", 0),
+                    "input_tokens": phase_result.get("input_tokens", 0),
+                    "output_tokens": phase_result.get("output_tokens", 0),
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "model": phase_result.get("model"),
+                    "attempts": phase_result.get("attempts", 1),
+                }
+```
+
+- [ ] **Step 5: Update phase_data in optional timestamp phase**
+
+In `api/services/worker.py`, find the phase_data dict at line 811:
+
+```python
+                    phase_data = {
+                        "name": phase_name,
+                        "status": "completed" if phase_result["success"] else "failed",
+                        "cost": phase_result.get("cost", 0),
+                        "tokens": phase_result.get("tokens", 0),
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                        "model": phase_result.get("model"),
+                        "optional": True,  # Mark as optional phase
+                    }
+```
+
+Replace with:
+
+```python
+                    phase_data = {
+                        "name": phase_name,
+                        "status": "completed" if phase_result["success"] else "failed",
+                        "cost": phase_result.get("cost", 0),
+                        "tokens": phase_result.get("tokens", 0),
+                        "input_tokens": phase_result.get("input_tokens", 0),
+                        "output_tokens": phase_result.get("output_tokens", 0),
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                        "model": phase_result.get("model"),
+                        "optional": True,  # Mark as optional phase
+                    }
+```
+
+- [ ] **Step 6: Update phase_data in retry_single_phase**
+
+In `api/services/worker.py`, find the phase archive dict at line 436 (inside `retry_single_phase`):
+
+```python
+                phases.append(
+                    {
+                        "name": phase_name,
+                        "status": "completed",
+                        "cost": phase_result.get("cost", 0),
+                        "tokens": phase_result.get("tokens", 0),
+                        "model": phase_result.get("model"),
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+```
+
+Replace with:
+
+```python
+                phases.append(
+                    {
+                        "name": phase_name,
+                        "status": "completed",
+                        "cost": phase_result.get("cost", 0),
+                        "tokens": phase_result.get("tokens", 0),
+                        "input_tokens": phase_result.get("input_tokens", 0),
+                        "output_tokens": phase_result.get("output_tokens", 0),
+                        "model": phase_result.get("model"),
+                        "completed_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+```
+
+- [ ] **Step 7: Run full test suite to verify nothing broke**
+
+Run: `pytest tests/ -x --timeout=30 --ignore=tests/test_ingest_scanner.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/services/worker.py tests/test_cost_visibility.py
+git commit -m "feat: Store input/output token breakdown per phase"
+```
+
+---
+
+### Task 3: Add pricing to model roster
+
+**Files:**
+- Modify: `api/services/model_roster.py:73-103` (_classify_models function)
+- Modify: `api/routers/config.py:128-134` (AvailableModel schema)
+- Test: `tests/test_cost_visibility.py`
+
+The OpenRouter `/api/v1/models` response includes `pricing.prompt` and `pricing.completion` (cost per token as strings). We need to pass this through `_classify_models` and add pricing fields to `AvailableModel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cost_visibility.py`:
+
+```python
+def test_available_model_includes_pricing():
+    """AvailableModel should include input/output pricing fields."""
+    from api.routers.config import AvailableModel
+
+    model = AvailableModel(
+        id="anthropic/claude-haiku-4.5",
+        name="Claude Haiku 4.5",
+        provider="Anthropic",
+        tier=0,
+        pricing_input=0.80,
+        pricing_output=4.00,
+    )
+    assert model.pricing_input == 0.80
+    assert model.pricing_output == 4.00
+
+
+def test_available_model_pricing_defaults_to_none():
+    """Pricing fields should default to None when not available."""
+    from api.routers.config import AvailableModel
+
+    model = AvailableModel(
+        id="test/model",
+        name="Test",
+        provider="Test",
+        tier=0,
+    )
+    assert model.pricing_input is None
+    assert model.pricing_output is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cost_visibility.py::test_available_model_includes_pricing -v`
+Expected: FAIL — `AvailableModel` has no `pricing_input` / `pricing_output` fields
+
+- [ ] **Step 3: Add pricing fields to AvailableModel**
+
+In `api/routers/config.py`, update the `AvailableModel` class:
+
+```python
+class AvailableModel(BaseModel):
+    """A model available for phase assignment."""
+
+    id: str = Field(..., description="OpenRouter model ID (e.g., 'anthropic/claude-sonnet-4-5-20250514')")
+    name: str = Field(..., description="Human-readable model name")
+    provider: str = Field(..., description="Model provider (e.g., 'Anthropic', 'Google')")
+    tier: int = Field(..., ge=0, le=2, description="Cost tier (0=economy, 1=standard, 2=premium)")
+    pricing_input: Optional[float] = Field(None, description="Cost per 1M input tokens (USD)")
+    pricing_output: Optional[float] = Field(None, description="Cost per 1M output tokens (USD)")
+```
+
+Add `Optional` to the imports at the top of config.py if not already present (it is — line 3).
+
+- [ ] **Step 4: Update _classify_models to pass through pricing**
+
+In `api/services/model_roster.py`, update `_classify_models` to extract pricing from the raw OpenRouter response. Each model in the raw list has a `pricing` dict with `prompt` and `completion` fields (cost per token, as strings).
+
+Replace the `results.append(...)` block at line 92:
+
+```python
+        # Extract pricing (OpenRouter reports cost per token as strings)
+        pricing_input = None
+        pricing_output = None
+        raw_pricing = model.get("pricing", {})
+        if raw_pricing:
+            try:
+                prompt_per_token = float(raw_pricing.get("prompt", 0))
+                completion_per_token = float(raw_pricing.get("completion", 0))
+                # Convert per-token to per-1M-tokens
+                pricing_input = round(prompt_per_token * 1_000_000, 4)
+                pricing_output = round(completion_per_token * 1_000_000, 4)
+            except (ValueError, TypeError):
+                pass
+
+        seen_ids.add(model_id)
+        results.append(
+            {
+                "id": model_id,
+                "name": model.get("name", model_id),
+                "provider": family["provider"],
+                "tier": family["tier"],
+                "pricing_input": pricing_input,
+                "pricing_output": pricing_output,
+            }
+        )
+```
+
+- [ ] **Step 5: Run tests to verify**
+
+Run: `pytest tests/test_cost_visibility.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routers/config.py api/services/model_roster.py tests/test_cost_visibility.py
+git commit -m "feat: Include model pricing in roster from OpenRouter data"
+```
+
+---
+
+### Task 4: Cost estimation service
+
+**Files:**
+- Create: `api/services/cost_estimator.py`
+- Create: `tests/test_cost_estimator.py`
+
+The estimator takes a word count and a dict of `{phase: model_id}` assignments, looks up pricing for each model, applies per-phase multipliers (how much output each phase typically produces relative to input), and returns a total estimated cost.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cost_estimator.py
+"""Tests for cost estimation service."""
+
+
+def test_estimate_job_cost_basic():
+    """Should estimate cost from word count and model pricing."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    # 1000 words ≈ 1333 tokens (4 chars/token, ~5 chars/word)
+    result = estimate_job_cost(
+        word_count=1000,
+        phase_models={
+            "analyst": "anthropic/claude-haiku-4.5",
+            "formatter": "anthropic/claude-haiku-4.5",
+            "seo": "anthropic/claude-haiku-4.5",
+            "validator": "anthropic/claude-haiku-4.5",
+        },
+    )
+    assert "total_estimated_cost" in result
+    assert result["total_estimated_cost"] > 0
+    assert "phase_estimates" in result
+    assert len(result["phase_estimates"]) == 4
+
+
+def test_estimate_job_cost_returns_per_phase_breakdown():
+    """Each phase should have its own cost estimate."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=5000,
+        phase_models={
+            "analyst": "anthropic/claude-haiku-4.5",
+            "formatter": "anthropic/claude-sonnet-4.6",
+        },
+    )
+    for phase_est in result["phase_estimates"]:
+        assert "phase" in phase_est
+        assert "model" in phase_est
+        assert "estimated_input_tokens" in phase_est
+        assert "estimated_output_tokens" in phase_est
+        assert "estimated_cost" in phase_est
+
+
+def test_estimate_job_cost_zero_words():
+    """Zero word count should return zero cost."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=0,
+        phase_models={"analyst": "anthropic/claude-haiku-4.5"},
+    )
+    assert result["total_estimated_cost"] == 0
+
+
+def test_estimate_job_cost_unknown_model_uses_conservative_estimate():
+    """Unknown models should fall back to conservative pricing."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=1000,
+        phase_models={"analyst": "unknown/model-xyz"},
+    )
+    assert result["total_estimated_cost"] > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cost_estimator.py -v`
+Expected: FAIL — `api.services.cost_estimator` module not found
+
+- [ ] **Step 3: Implement cost_estimator.py**
+
+```python
+# api/services/cost_estimator.py
+"""Cost estimation service for Cardigan.
+
+Estimates job processing cost based on transcript size,
+configured models, and per-phase output multipliers.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from api.services.llm import MODEL_PRICING
+
+# Approximate tokens-per-word ratio (English text averages ~1.33 tokens/word)
+TOKENS_PER_WORD = 1.33
+
+# Per-phase multipliers: how many output tokens relative to input tokens.
+# Based on observed production data:
+# - Analyst: produces ~0.25x input (summary + analysis)
+# - Formatter: produces ~0.9x input (reformats full transcript)
+# - SEO: produces ~0.15x input (short metadata)
+# - Validator: produces ~0.05x input (brief pass/fail report)
+# - Timestamp: produces ~0.1x input (chapter markers)
+PHASE_OUTPUT_MULTIPLIERS = {
+    "analyst": 0.25,
+    "formatter": 0.90,
+    "seo": 0.15,
+    "validator": 0.05,
+    "timestamp": 0.10,
+    "copy_editor": 0.90,
+}
+
+# Conservative fallback pricing (per 1M tokens) for unknown models
+FALLBACK_PRICING = {"input": 1.0, "output": 3.0}
+
+
+def _get_pricing(model_id: str, pricing_overrides: Optional[Dict[str, Dict[str, float]]] = None) -> Dict[str, float]:
+    """Get per-1M-token pricing for a model.
+
+    Checks overrides first, then MODEL_PRICING, then falls back to conservative estimate.
+    """
+    if pricing_overrides and model_id in pricing_overrides:
+        return pricing_overrides[model_id]
+    return MODEL_PRICING.get(model_id, FALLBACK_PRICING)
+
+
+def estimate_job_cost(
+    word_count: int,
+    phase_models: Dict[str, str],
+    pricing_overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Dict[str, Any]:
+    """Estimate the total cost for processing a transcript.
+
+    Args:
+        word_count: Number of words in the transcript
+        phase_models: Dict mapping phase name to model ID
+        pricing_overrides: Optional dict of {model_id: {"input": float, "output": float}}
+            for pricing not in MODEL_PRICING (e.g., from OpenRouter roster)
+
+    Returns:
+        Dict with total_estimated_cost and per-phase breakdown
+    """
+    if word_count == 0:
+        return {
+            "total_estimated_cost": 0,
+            "estimated_input_tokens": 0,
+            "phase_estimates": [],
+        }
+
+    base_input_tokens = int(word_count * TOKENS_PER_WORD)
+    total_cost = 0.0
+    phase_estimates: List[Dict[str, Any]] = []
+
+    for phase, model_id in phase_models.items():
+        output_multiplier = PHASE_OUTPUT_MULTIPLIERS.get(phase, 0.25)
+        est_input = base_input_tokens
+        est_output = int(base_input_tokens * output_multiplier)
+
+        pricing = _get_pricing(model_id, pricing_overrides)
+        input_cost = (est_input / 1_000_000) * pricing["input"]
+        output_cost = (est_output / 1_000_000) * pricing["output"]
+        phase_cost = input_cost + output_cost
+
+        phase_estimates.append({
+            "phase": phase,
+            "model": model_id,
+            "estimated_input_tokens": est_input,
+            "estimated_output_tokens": est_output,
+            "estimated_cost": round(phase_cost, 6),
+        })
+
+        total_cost += phase_cost
+
+    return {
+        "total_estimated_cost": round(total_cost, 4),
+        "estimated_input_tokens": base_input_tokens,
+        "phase_estimates": phase_estimates,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cost_estimator.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/services/cost_estimator.py tests/test_cost_estimator.py
+git commit -m "feat: Add cost estimation service with per-phase multipliers"
+```
+
+---
+
+### Task 5: Cost estimation API endpoint
+
+**Files:**
+- Modify: `api/routers/config.py` — add `/config/estimate-cost` endpoint
+- Test: `tests/test_cost_visibility.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cost_visibility.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_estimate_cost_endpoint():
+    """The /config/estimate-cost endpoint should return a cost estimate."""
+    from httpx import ASGITransport, AsyncClient
+    from api.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/config/estimate-cost",
+            json={"word_count": 5000},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_estimated_cost" in data
+    assert data["total_estimated_cost"] > 0
+    assert "phase_estimates" in data
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cost_visibility.py::test_estimate_cost_endpoint -v`
+Expected: FAIL — 404 or 405 (endpoint does not exist)
+
+- [ ] **Step 3: Add the endpoint**
+
+In `api/routers/config.py`, add at the bottom of the file:
+
+```python
+from api.services.cost_estimator import estimate_job_cost
+
+
+class CostEstimateRequest(BaseModel):
+    """Request body for cost estimation."""
+
+    word_count: int = Field(..., ge=0, description="Transcript word count")
+    phase_models: Optional[Dict[str, str]] = Field(
+        None, description="Override phase-model assignments (defaults to current config)"
+    )
+
+
+class CostEstimateResponse(BaseModel):
+    """Cost estimate for a job."""
+
+    total_estimated_cost: float
+    estimated_input_tokens: int
+    phase_estimates: List[Dict[str, Any]]
+
+
+@router.post("/estimate-cost", response_model=CostEstimateResponse)
+async def get_cost_estimate(body: CostEstimateRequest):
+    """Estimate the cost of processing a transcript.
+
+    Uses current phase-model assignments (or overrides) and model pricing
+    to estimate total cost. Useful for showing users expected costs
+    before submitting a job.
+    """
+    config = _load_config()
+
+    # Use provided phase_models or fall back to current config
+    phase_models = body.phase_models or config.get("phase_models", DEFAULT_PHASE_MODELS)
+
+    # Build pricing overrides from the model roster (has live OpenRouter pricing)
+    pricing_overrides = {}
+    try:
+        models_data = await get_available_models()
+        for m in models_data:
+            if m.get("pricing_input") is not None and m.get("pricing_output") is not None:
+                pricing_overrides[m["id"]] = {
+                    "input": m["pricing_input"],
+                    "output": m["pricing_output"],
+                }
+    except Exception:
+        pass  # Fall through to MODEL_PRICING static fallback
+
+    result = estimate_job_cost(
+        word_count=body.word_count,
+        phase_models=phase_models,
+        pricing_overrides=pricing_overrides,
+    )
+
+    return CostEstimateResponse(**result)
+```
+
+Also add `Any` to the `typing` import at the top of `config.py` (line 3) if not already present.
+
+- [ ] **Step 4: Run tests to verify**
+
+Run: `pytest tests/test_cost_visibility.py::test_estimate_cost_endpoint -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/routers/config.py tests/test_cost_visibility.py
+git commit -m "feat: Add /config/estimate-cost endpoint for pre-submission cost estimates"
+```
+
+---
+
+### Task 6: Langfuse eager initialization
+
+**Files:**
+- Modify: `api/services/langfuse_client.py:60-94` (LangfuseClient init)
+- Modify: `api/main.py` (app startup)
+- Test: `tests/test_langfuse_eager.py`
+
+The current lazy `_ensure_initialized()` pattern caused ~60s delays when first called from a concurrent context inside `asyncio.gather`. We'll add an explicit `async initialize()` method called at app startup, while keeping the lazy path as a safety net.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_langfuse_eager.py
+"""Tests for Langfuse eager initialization."""
+
+from unittest.mock import patch
+
+
+def test_langfuse_client_has_initialize_method():
+    """LangfuseClient should expose an async initialize() method."""
+    from api.services.langfuse_client import LangfuseClient
+    import inspect
+
+    assert hasattr(LangfuseClient, "initialize")
+    assert inspect.iscoroutinefunction(LangfuseClient.initialize)
+
+
+@patch("api.services.langfuse_client._get_langfuse_credential")
+def test_langfuse_initialize_sets_initialized_flag(mock_cred):
+    """After initialize(), _ensure_initialized should be a no-op."""
+    import asyncio
+    from api.services.langfuse_client import LangfuseClient
+
+    mock_cred.return_value = None  # No credentials — init will "fail" but flag set
+
+    client = LangfuseClient()
+    assert not client._initialized
+
+    asyncio.get_event_loop().run_until_complete(client.initialize())
+    assert client._initialized
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_langfuse_eager.py -v`
+Expected: FAIL — `LangfuseClient` has no `initialize` method
+
+- [ ] **Step 3: Add initialize() method to LangfuseClient**
+
+In `api/services/langfuse_client.py`, add after the `__init__` method (after line 64):
+
+```python
+    async def initialize(self) -> bool:
+        """Eagerly initialize the Langfuse client.
+
+        Call this at app startup to avoid lazy-init delays during job processing.
+        Returns True if client is ready, False if credentials are missing.
+        """
+        return self._ensure_initialized()
+```
+
+- [ ] **Step 4: Add startup call in api/main.py**
+
+Find the startup event or lifespan handler in `api/main.py` and add:
+
+```python
+from api.services.langfuse_client import get_langfuse_client
+
+# Inside the startup/lifespan handler:
+langfuse = get_langfuse_client()
+await langfuse.initialize()
+```
+
+The exact location depends on whether main.py uses `@app.on_event("startup")` or a lifespan context manager. Read main.py to determine the pattern, then add the call in the appropriate place.
+
+- [ ] **Step 5: Run tests to verify**
+
+Run: `pytest tests/test_langfuse_eager.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pytest tests/ -x --timeout=30 --ignore=tests/test_ingest_scanner.py`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/services/langfuse_client.py api/main.py tests/test_langfuse_eager.py
+git commit -m "fix: Eagerly initialize Langfuse client at app startup to avoid lazy-init delays"
+```
+
+---
+
+### Task 7: Cost breakdown table in JobDetail UI
+
+**Files:**
+- Modify: `web/src/pages/JobDetail.tsx`
+
+Add a cost breakdown table to the job detail page showing per-phase model, input/output tokens, and cost. Retries (from `previous_runs`) show as additional rows.
+
+- [ ] **Step 1: Update Phase TypeScript interface**
+
+In `web/src/pages/JobDetail.tsx`, find the `Phase` interface (near line 8) and add:
+
+```typescript
+interface Phase {
+  name: string
+  status: string
+  cost?: number
+  tokens?: number
+  input_tokens?: number
+  output_tokens?: number
+  model?: string
+  retry_count?: number
+  previous_runs?: Array<{
+    model?: string
+    cost?: number
+    tokens?: number
+    input_tokens?: number
+    output_tokens?: number
+    completed_at?: string
+  }>
+  // ... existing fields
+}
+```
+
+- [ ] **Step 2: Add CostBreakdownTable component**
+
+Add a new component inside `JobDetail.tsx` (above the main export), or inline it in the JSX. The table should:
+
+- List each phase as a row
+- Show columns: Phase | Model | Input Tokens | Output Tokens | Cost
+- For phases with `previous_runs`, show each prior run as a sub-row (indented, lighter text)
+- Show a total row at the bottom
+- Only render when the job has at least one completed phase with cost data
+
+```tsx
+function CostBreakdownTable({ phases }: { phases: Phase[] }) {
+  const phasesWithCost = phases.filter(p => p.cost !== undefined && p.cost > 0)
+  if (phasesWithCost.length === 0) return null
+
+  const totalCost = phases.reduce((sum, p) => {
+    let phaseCost = p.cost || 0
+    if (p.previous_runs) {
+      phaseCost += p.previous_runs.reduce((s, r) => s + (r.cost || 0), 0)
+    }
+    return sum + phaseCost
+  }, 0)
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-4">
+      <h3 className="text-sm font-medium text-gray-400 mb-3">Cost Breakdown</h3>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-gray-500 text-left">
+            <th className="pb-2">Phase</th>
+            <th className="pb-2">Model</th>
+            <th className="pb-2 text-right">In Tokens</th>
+            <th className="pb-2 text-right">Out Tokens</th>
+            <th className="pb-2 text-right">Cost</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-300">
+          {phases.map(phase => (
+            <>
+              {phase.previous_runs?.map((run, i) => (
+                <tr key={`${phase.name}-prev-${i}`} className="text-gray-500 text-xs">
+                  <td className="py-1 pl-4">{phase.name} (attempt {i + 1})</td>
+                  <td className="py-1">{run.model?.split('/').pop() || '-'}</td>
+                  <td className="py-1 text-right font-mono">{run.input_tokens?.toLocaleString() || '-'}</td>
+                  <td className="py-1 text-right font-mono">{run.output_tokens?.toLocaleString() || '-'}</td>
+                  <td className="py-1 text-right font-mono">${(run.cost || 0).toFixed(4)}</td>
+                </tr>
+              ))}
+              <tr key={phase.name}>
+                <td className="py-1">{phase.name}</td>
+                <td className="py-1">{phase.model?.split('/').pop() || '-'}</td>
+                <td className="py-1 text-right font-mono">{phase.input_tokens?.toLocaleString() || '-'}</td>
+                <td className="py-1 text-right font-mono">{phase.output_tokens?.toLocaleString() || '-'}</td>
+                <td className="py-1 text-right font-mono">${(phase.cost || 0).toFixed(4)}</td>
+              </tr>
+            </>
+          ))}
+          <tr className="border-t border-gray-700 font-medium text-white">
+            <td className="pt-2" colSpan={4}>Total</td>
+            <td className="pt-2 text-right font-mono">${totalCost.toFixed(4)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Render CostBreakdownTable in the job detail view**
+
+Find where phases are displayed (around line 700-720) and add the table above or below the phase list:
+
+```tsx
+{job.phases && <CostBreakdownTable phases={job.phases} />}
+```
+
+- [ ] **Step 4: Test in browser**
+
+Run: `cd web && npm run dev`
+Navigate to a completed job's detail page. Verify:
+- Cost breakdown table renders with per-phase rows
+- Input/output token columns show data (will be 0 for old jobs without the new fields)
+- Total row sums correctly
+- Retry previous_runs show as sub-rows if present
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/JobDetail.tsx
+git commit -m "feat: Add cost breakdown table with per-phase token details to job detail page"
+```
+
+---
+
+### Task 8: Pre-submission cost estimate in queue UI
+
+**Files:**
+- Modify: `web/src/pages/QueuePage.tsx` (or whichever page handles job submission)
+
+After the user selects a transcript file and before they confirm submission, fetch an estimate from `/api/config/estimate-cost` using the transcript's word count and display "Estimated cost: ~$X.XX".
+
+- [ ] **Step 1: Identify the submission page**
+
+Check which page handles job submission. Likely `QueuePage.tsx` or a submit modal. Read the file to find the submit form.
+
+- [ ] **Step 2: Add estimate fetch**
+
+After the transcript file is selected (and word count is available from the API response or computed client-side), call the estimate endpoint:
+
+```typescript
+const [estimatedCost, setEstimatedCost] = useState<number | null>(null)
+
+// When word_count changes (after file selection or job creation):
+useEffect(() => {
+  if (!wordCount || wordCount === 0) {
+    setEstimatedCost(null)
+    return
+  }
+  fetch('/api/config/estimate-cost', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ word_count: wordCount }),
+  })
+    .then(r => r.json())
+    .then(data => setEstimatedCost(data.total_estimated_cost))
+    .catch(() => setEstimatedCost(null))
+}, [wordCount])
+```
+
+- [ ] **Step 3: Display the estimate**
+
+Add near the submit button:
+
+```tsx
+{estimatedCost !== null && (
+  <p className="text-sm text-gray-400">
+    Estimated cost: <span className="text-green-400 font-mono">~${estimatedCost.toFixed(2)}</span>
+  </p>
+)}
+```
+
+- [ ] **Step 4: Test in browser**
+
+Run the dev server and navigate to the queue/submit page. Select a transcript, verify the estimated cost appears before submission.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/pages/QueuePage.tsx
+git commit -m "feat: Show estimated cost before job submission"
+```
+
+---
+
+### Task 9: Langfuse non-blocking guarantee and observability audit
+
+**Files:**
+- Modify: `api/services/langfuse_client.py` — add timeout to trace_generation
+- Modify: `api/services/worker.py` — verify phase status accuracy
+
+- [ ] **Step 1: Add timeout to Langfuse trace_generation**
+
+In `api/services/langfuse_client.py`, the `trace_generation` method already catches exceptions and returns `None`. But the httpx POST could hang. Add a shorter timeout for the individual call:
+
+In the `trace_generation` method, replace:
+
+```python
+            resp = await self._http_client.post(
+                "/api/public/ingestion",
+                json={"batch": batch},
+            )
+```
+
+With:
+
+```python
+            resp = await asyncio.wait_for(
+                self._http_client.post(
+                    "/api/public/ingestion",
+                    json={"batch": batch},
+                ),
+                timeout=5.0,
+            )
+```
+
+Add `import asyncio` at the top of the file if not already present.
+
+- [ ] **Step 2: Audit phase status reporting**
+
+Read through `process_job()` in worker.py and verify:
+- Every phase that succeeds is marked `"completed"` 
+- Every phase that fails is marked `"failed"` 
+- The `error_message` field is populated on failure
+- The job's `actual_cost` is updated on both success and failure paths
+
+Check the following specific paths:
+1. Normal phase completion (line ~654): status comes from `phase_result["success"]` — correct
+2. Optional phase failure (line ~836): logged as warning, doesn't fail job — correct by design
+3. Truncation pause (line ~768): job set to `paused` — correct
+4. Exception in phase loop (line ~880+): job set to `failed` — verify `actual_cost` is set
+
+Document findings and fix any discrepancies.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pytest tests/ -x --timeout=30 --ignore=tests/test_ingest_scanner.py`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/services/langfuse_client.py api/services/worker.py
+git commit -m "fix: Add timeout to Langfuse calls, audit phase status reporting"
+```
+
+---
+
+### Task 10: Final integration verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest tests/ -x --timeout=30 --ignore=tests/test_ingest_scanner.py -v`
+Expected: All PASS
+
+- [ ] **Step 2: Start dev servers and verify UI**
+
+```bash
+# Terminal 1
+uvicorn api.main:app --reload
+
+# Terminal 2
+cd web && npm run dev
+```
+
+Verify in browser:
+1. Job detail page shows cost breakdown table with token columns
+2. Queue page shows estimated cost before submission
+3. Settings page model dropdowns still work
+4. Langfuse initializes at startup (check server logs for "Langfuse REST client initialized")
+
+- [ ] **Step 3: Verify API responses**
+
+```bash
+# Check models endpoint includes pricing
+curl -s http://localhost:8000/api/config/models | python -m json.tool | head -30
+
+# Check estimate endpoint
+curl -s -X POST http://localhost:8000/api/config/estimate-cost \
+  -H "Content-Type: application/json" \
+  -d '{"word_count": 5000}' | python -m json.tool
+```
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+```bash
+git add -A
+git commit -m "chore: Sprint 4 integration verification and cleanup"
+```

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -1,0 +1,61 @@
+"""Tests for cost estimation service."""
+
+
+def test_estimate_job_cost_basic():
+    """Should estimate cost from word count and model pricing."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=1000,
+        phase_models={
+            "analyst": "anthropic/claude-haiku-4.5",
+            "formatter": "anthropic/claude-haiku-4.5",
+            "seo": "anthropic/claude-haiku-4.5",
+            "validator": "anthropic/claude-haiku-4.5",
+        },
+    )
+    assert "total_estimated_cost" in result
+    assert result["total_estimated_cost"] > 0
+    assert "phase_estimates" in result
+    assert len(result["phase_estimates"]) == 4
+
+
+def test_estimate_job_cost_returns_per_phase_breakdown():
+    """Each phase should have its own cost estimate."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=5000,
+        phase_models={
+            "analyst": "anthropic/claude-haiku-4.5",
+            "formatter": "anthropic/claude-sonnet-4.6",
+        },
+    )
+    for phase_est in result["phase_estimates"]:
+        assert "phase" in phase_est
+        assert "model" in phase_est
+        assert "estimated_input_tokens" in phase_est
+        assert "estimated_output_tokens" in phase_est
+        assert "estimated_cost" in phase_est
+
+
+def test_estimate_job_cost_zero_words():
+    """Zero word count should return zero cost."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=0,
+        phase_models={"analyst": "anthropic/claude-haiku-4.5"},
+    )
+    assert result["total_estimated_cost"] == 0
+
+
+def test_estimate_job_cost_unknown_model_uses_conservative_estimate():
+    """Unknown models should fall back to conservative pricing."""
+    from api.services.cost_estimator import estimate_job_cost
+
+    result = estimate_job_cost(
+        word_count=1000,
+        phase_models={"analyst": "unknown/model-xyz"},
+    )
+    assert result["total_estimated_cost"] > 0

--- a/tests/test_cost_visibility.py
+++ b/tests/test_cost_visibility.py
@@ -1,7 +1,6 @@
 """Tests for cost visibility: token granularity and pricing."""
 
 
-
 def test_job_phase_has_token_breakdown():
     """JobPhase should support input_tokens and output_tokens fields."""
     from api.models.job import JobPhase

--- a/tests/test_cost_visibility.py
+++ b/tests/test_cost_visibility.py
@@ -1,0 +1,101 @@
+"""Tests for cost visibility: token granularity and pricing."""
+
+
+
+def test_job_phase_has_token_breakdown():
+    """JobPhase should support input_tokens and output_tokens fields."""
+    from api.models.job import JobPhase
+
+    phase = JobPhase(
+        name="analyst",
+        input_tokens=12000,
+        output_tokens=3000,
+        tokens=15000,
+        cost=0.02,
+    )
+    assert phase.input_tokens == 12000
+    assert phase.output_tokens == 3000
+    assert phase.tokens == 15000
+
+
+def test_job_phase_token_breakdown_defaults_to_zero():
+    """Token breakdown fields should default to 0."""
+    from api.models.job import JobPhase
+
+    phase = JobPhase(name="analyst")
+    assert phase.input_tokens == 0
+    assert phase.output_tokens == 0
+    assert phase.tokens == 0
+
+
+def test_run_phase_return_includes_token_breakdown():
+    """_run_phase return dict should include input_tokens and output_tokens."""
+    from api.models.job import JobPhase
+
+    phase_result = {
+        "success": True,
+        "output": "test content",
+        "cost": 0.02,
+        "tokens": 15000,
+        "input_tokens": 12000,
+        "output_tokens": 3000,
+        "model": "anthropic/claude-haiku-4.5",
+    }
+
+    phase = JobPhase(
+        name="analyst",
+        status="completed",
+        cost=phase_result["cost"],
+        tokens=phase_result["tokens"],
+        input_tokens=phase_result["input_tokens"],
+        output_tokens=phase_result["output_tokens"],
+        model=phase_result["model"],
+    )
+
+    assert phase.input_tokens == 12000
+    assert phase.output_tokens == 3000
+
+
+def test_available_model_includes_pricing():
+    """AvailableModel should include input/output pricing fields."""
+    from api.routers.config import AvailableModel
+
+    model = AvailableModel(
+        id="anthropic/claude-haiku-4.5",
+        name="Claude Haiku 4.5",
+        provider="Anthropic",
+        tier=0,
+        pricing_input=0.80,
+        pricing_output=4.00,
+    )
+    assert model.pricing_input == 0.80
+    assert model.pricing_output == 4.00
+
+
+def test_available_model_pricing_defaults_to_none():
+    """Pricing fields should default to None when not available."""
+    from api.routers.config import AvailableModel
+
+    model = AvailableModel(
+        id="test/model",
+        name="Test",
+        provider="Test",
+        tier=0,
+    )
+    assert model.pricing_input is None
+    assert model.pricing_output is None
+
+
+def test_estimate_cost_endpoint():
+    """The /config/estimate-cost endpoint should return a cost estimate."""
+    from starlette.testclient import TestClient
+
+    from api.main import app
+
+    client = TestClient(app)
+    resp = client.post("/api/config/estimate-cost", json={"word_count": 5000})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_estimated_cost" in data
+    assert data["total_estimated_cost"] > 0
+    assert "phase_estimates" in data

--- a/tests/test_langfuse_eager.py
+++ b/tests/test_langfuse_eager.py
@@ -1,0 +1,29 @@
+"""Tests for Langfuse eager initialization."""
+
+from unittest.mock import patch
+
+
+def test_langfuse_client_has_initialize_method():
+    """LangfuseClient should expose an async initialize() method."""
+    import inspect
+
+    from api.services.langfuse_client import LangfuseClient
+
+    assert hasattr(LangfuseClient, "initialize")
+    assert inspect.iscoroutinefunction(LangfuseClient.initialize)
+
+
+@patch("api.services.langfuse_client._get_langfuse_credential")
+def test_langfuse_initialize_sets_initialized_flag(mock_cred):
+    """After initialize(), _ensure_initialized should be a no-op."""
+    import asyncio
+
+    from api.services.langfuse_client import LangfuseClient
+
+    mock_cred.return_value = None  # No credentials — init will "fail" but flag set
+
+    client = LangfuseClient()
+    assert not client._initialized
+
+    asyncio.run(client.initialize())
+    assert client._initialized

--- a/web/src/components/TranscriptUploader.tsx
+++ b/web/src/components/TranscriptUploader.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useToast } from './ui/Toast'
 
 interface UploadStatus {
@@ -28,7 +28,35 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
   const [uploadStatuses, setUploadStatuses] = useState<UploadStatus[]>([])
   const [isUploading, setIsUploading] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
+  const [estimatedCost, setEstimatedCost] = useState<number | null>(null)
   const { toast } = useToast()
+
+  useEffect(() => {
+    if (files.length === 0) {
+      setEstimatedCost(null)
+      return
+    }
+
+    // Estimate word count from total file size (~5 bytes per word for English text)
+    const totalBytes = files.reduce((sum, f) => sum + f.size, 0)
+    const estimatedWords = Math.round(totalBytes / 5)
+
+    if (estimatedWords === 0) {
+      setEstimatedCost(null)
+      return
+    }
+
+    fetch('/api/config/estimate-cost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ word_count: estimatedWords }),
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data) setEstimatedCost(data.total_estimated_cost)
+      })
+      .catch(() => setEstimatedCost(null))
+  }, [files])
 
   const validateFile = (file: File): string | null => {
     const ext = '.' + file.name.split('.').pop()?.toLowerCase()
@@ -278,19 +306,27 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
 
       {/* Upload Button */}
       {files.length > 0 && (
-        <button
-          onClick={uploadFiles}
-          disabled={isUploading}
-          className={`
-            w-full py-2 px-4 rounded-lg font-medium transition-colors
-            ${isUploading
-              ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
-              : 'bg-green-600 hover:bg-green-500 text-white'
-            }
-          `}
-        >
-          {isUploading ? 'Uploading...' : `Upload ${files.length} file${files.length !== 1 ? 's' : ''}`}
-        </button>
+        <>
+          {estimatedCost !== null && (
+            <p className="text-sm text-gray-400 text-center">
+              Estimated cost: <span className="text-green-400 font-mono">~${estimatedCost.toFixed(2)}</span>
+              <span className="text-gray-500 ml-1">(based on file size)</span>
+            </p>
+          )}
+          <button
+            onClick={uploadFiles}
+            disabled={isUploading}
+            className={`
+              w-full py-2 px-4 rounded-lg font-medium transition-colors
+              ${isUploading
+                ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                : 'bg-green-600 hover:bg-green-500 text-white'
+              }
+            `}
+          >
+            {isUploading ? 'Uploading...' : `Upload ${files.length} file${files.length !== 1 ? 's' : ''}`}
+          </button>
+        </>
       )}
     </div>
   )

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState, useRef, Fragment } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -13,6 +13,8 @@ interface PreviousRun {
   model?: string
   cost?: number
   tokens?: number
+  input_tokens?: number
+  output_tokens?: number
   completed_at?: string
   feedback?: string
 }
@@ -22,6 +24,8 @@ interface JobPhase {
   status: string
   cost?: number
   tokens?: number
+  input_tokens?: number
+  output_tokens?: number
   started_at?: string
   completed_at?: string
   model?: string
@@ -93,6 +97,62 @@ const OUTPUT_TO_PHASE: Record<string, string> = {
   formatted_transcript: 'formatter',
   seo_metadata: 'seo',
   timestamp_report: 'timestamp',
+}
+
+function CostBreakdownTable({ phases }: { phases: JobPhase[] }) {
+  const phasesWithCost = phases.filter(p => p.cost !== undefined && p.cost > 0)
+  if (phasesWithCost.length === 0) return null
+
+  const totalCost = phasesWithCost.reduce((sum, p) => {
+    let phaseCost = p.cost || 0
+    if (p.previous_runs) {
+      phaseCost += p.previous_runs.reduce((s, r) => s + (r.cost || 0), 0)
+    }
+    return sum + phaseCost
+  }, 0)
+
+  return (
+    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+      <h2 className="text-lg font-medium text-white mb-3">Cost Breakdown</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-gray-500 text-left">
+            <th className="pb-2">Phase</th>
+            <th className="pb-2">Model</th>
+            <th className="pb-2 text-right">In Tokens</th>
+            <th className="pb-2 text-right">Out Tokens</th>
+            <th className="pb-2 text-right">Cost</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-300">
+          {phasesWithCost.map(phase => (
+            <Fragment key={phase.name}>
+              {phase.previous_runs?.map((run, i) => (
+                <tr key={`${phase.name}-prev-${i}`} className="text-gray-500 text-xs">
+                  <td className="py-1 pl-4">{phase.name} (attempt {i + 1})</td>
+                  <td className="py-1 font-mono">{run.model?.split('/').pop() || '-'}</td>
+                  <td className="py-1 text-right font-mono">{run.input_tokens?.toLocaleString() || '-'}</td>
+                  <td className="py-1 text-right font-mono">{run.output_tokens?.toLocaleString() || '-'}</td>
+                  <td className="py-1 text-right font-mono">${(run.cost || 0).toFixed(4)}</td>
+                </tr>
+              ))}
+              <tr>
+                <td className="py-1">{phase.name}</td>
+                <td className="py-1 font-mono">{phase.model?.split('/').pop() || '-'}</td>
+                <td className="py-1 text-right font-mono">{phase.input_tokens?.toLocaleString() || '-'}</td>
+                <td className="py-1 text-right font-mono">{phase.output_tokens?.toLocaleString() || '-'}</td>
+                <td className="py-1 text-right font-mono">${(phase.cost || 0).toFixed(4)}</td>
+              </tr>
+            </Fragment>
+          ))}
+          <tr className="border-t border-gray-700 font-medium text-white">
+            <td className="pt-2" colSpan={4}>Total</td>
+            <td className="pt-2 text-right font-mono">${totalCost.toFixed(4)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
 }
 
 export default function JobDetail() {
@@ -744,6 +804,11 @@ export default function JobDetail() {
             ))}
           </div>
         </div>
+      )}
+
+      {/* Cost Breakdown */}
+      {job.phases && job.phases.length > 0 && (
+        <CostBreakdownTable phases={job.phases} />
       )}
 
       {/* Outputs */}


### PR DESCRIPTION
Stacked on #148 (Sprint 3 rebased). Will cascade-retarget to \`main\` once #147 → #148 land.

Applied as the pure increment between Sprint 3 and Sprint 4 branch tips. Patch applied cleanly with no conflicts.

## What's new (over Sprint 3)

- **Per-phase token granularity** — JobPhase stores input/output tokens separately
- **Model pricing in roster** — AvailableModel includes pricing_input/pricing_output from OpenRouter
- **Cost estimation service** — new \`api/services/cost_estimator.py\` (word count + model pricing + per-phase output multipliers)
- **POST /config/estimate-cost** — pre-submission cost estimates with per-phase breakdown
- **Cost breakdown table in JobDetail** — per-phase model, tokens, cost; retries as sub-rows
- **Pre-submission cost estimate** — TranscriptUploader shows ~$X.XX before upload
- **Langfuse eager init** — avoids lazy-init delays during concurrent processing
- **Langfuse timeout** — \`trace_generation\` POST wrapped in 5s \`asyncio.wait_for\`

## Diff

+1613 / -20 across 13 files (1099 lines are the implementation plan doc; real code is ~500 lines).

## Replaces

Closes #105.

## Test plan

- [x] 392 tests pass (up from Sprint 3's 380 — 12 new tests across test_cost_estimator, test_cost_visibility, test_langfuse_eager)
- [x] Python compile clean
- [ ] Manual: cost breakdown table renders on completed job detail
- [ ] Manual: estimated cost appears in TranscriptUploader pre-upload
- [ ] Manual: /api/config/models returns pricing_input/pricing_output
- [ ] Manual: Langfuse "initialized" log at app startup

## Stack

| Sprint | PR | Base |
|---|---|---|
| 2 | #147 | \`main\` |
| 3 | #148 | #147 |
| 4 | this | #148 |
| 5 | next | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)