### PR TITLE
feat: Sprint 5 — Optional speaker diarization service (rebased)

### DIFF
--- a/api/services/diarization_client.py
+++ b/api/services/diarization_client.py
@@ -1,0 +1,101 @@
+"""Async HTTP client for the Cardigan diarization microservice.
+
+The diarization service is optional — if it's unavailable, the pipeline
+runs without speaker verification. All methods return None/False rather
+than raising on service errors.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default URL matches the Docker Compose service name
+DEFAULT_BASE_URL = os.environ.get("DIARIZATION_SERVICE_URL", "http://diarization:8000")
+
+# Generous timeout: diarization of a 30-min episode on CPU can take several minutes
+DIARIZE_TIMEOUT_SECONDS = int(os.environ.get("DIARIZATION_TIMEOUT", "600"))
+HEALTH_TIMEOUT_SECONDS = 5
+
+
+class DiarizationClient:
+    """Async client for the diarization microservice.
+
+    Usage:
+        client = DiarizationClient()
+        if await client.is_available():
+            result = await client.diarize("/path/to/audio.mp4")
+            if result:
+                print(result["speakers"])
+    """
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(DIARIZE_TIMEOUT_SECONDS))
+
+    async def is_available(self) -> bool:
+        """Check if the diarization service is up and the model is loaded.
+
+        Returns False (never raises) if the service is unreachable or not ready.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/health",
+                timeout=HEALTH_TIMEOUT_SECONDS,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("ready", False)
+            return False
+        except (httpx.HTTPError, Exception) as e:
+            logger.debug(f"Diarization service unavailable: {e}")
+            return False
+
+    async def diarize(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """Send an audio/video file to the diarization service.
+
+        Args:
+            file_path: Path to the audio or video file on disk.
+
+        Returns:
+            Parsed JSON response dict with keys: duration_seconds, speakers, segments.
+            Returns None if the request fails for any reason.
+        """
+        path = Path(file_path)
+        if not path.exists():
+            logger.warning(f"Media file not found for diarization: {file_path}")
+            return None
+
+        try:
+            logger.info(f"Sending file to diarization service: {path.name}")
+            with open(path, "rb") as f:
+                resp = await self._client.post(
+                    f"{self.base_url}/diarize",
+                    files={"file": (path.name, f, "application/octet-stream")},
+                )
+
+            if resp.status_code == 200:
+                result = resp.json()
+                logger.info(
+                    f"Diarization complete: {len(result.get('speakers', []))} speakers, "
+                    f"{len(result.get('segments', []))} segments"
+                )
+                return result
+
+            logger.warning(f"Diarization service returned {resp.status_code}: {resp.text[:200]}")
+            return None
+
+        except httpx.TimeoutException:
+            logger.warning(f"Diarization timed out after {DIARIZE_TIMEOUT_SECONDS}s for {path.name}")
+            return None
+        except (httpx.HTTPError, Exception) as e:
+            logger.warning(f"Diarization request failed: {e}")
+            return None
+
+    async def close(self):
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -618,6 +618,38 @@ class JobWorker:
                     extra={"job_id": job_id, "error": str(e)},
                 )
 
+            # Attempt diarization if service is available and media file exists
+            diarization_result = None
+            media_path = self._find_media_file(job)
+            if media_path:
+                try:
+                    from api.services.diarization_client import DiarizationClient
+
+                    diarization_client = DiarizationClient()
+                    if await diarization_client.is_available():
+                        logger.info(
+                            "Diarization service available, processing media file",
+                            extra={"job_id": job_id, "media_file": media_path.name},
+                        )
+                        diarization_result = await diarization_client.diarize(str(media_path))
+                        if diarization_result:
+                            logger.info(
+                                "Diarization complete",
+                                extra={
+                                    "job_id": job_id,
+                                    "speakers": len(diarization_result.get("speakers", [])),
+                                    "segments": len(diarization_result.get("segments", [])),
+                                },
+                            )
+                    else:
+                        logger.debug("Diarization service not available", extra={"job_id": job_id})
+                    await diarization_client.close()
+                except Exception as e:
+                    logger.warning(
+                        "Diarization failed (non-fatal, continuing without it)",
+                        extra={"job_id": job_id, "error": str(e)},
+                    )
+
             # Get existing phases or initialize
             phases = job.get("phases") or []
             if isinstance(phases, str):
@@ -631,6 +663,7 @@ class JobWorker:
                 "transcript_metrics": transcript_metrics,
                 "sst_context": sst_context,  # Add SST context to processing context
                 "content_type": content_type,  # Expose content_type for prompt building
+                "diarization_result": diarization_result,  # Speaker diarization (may be None)
             }
 
             truncation_paused = False
@@ -1156,6 +1189,37 @@ class JobWorker:
                 srt_media_id = extract_media_id(srt_file.name)
                 if srt_media_id == media_id:
                     return srt_file
+
+        return None
+
+    # Media file extensions for diarization, in preference order
+    MEDIA_EXTENSIONS = [".mp4", ".mkv", ".mov", ".webm", ".wav", ".mp3", ".m4a", ".flac"]
+
+    def _find_media_file(self, job: Dict[str, Any], search_dirs: Optional[List[Path]] = None) -> Optional[Path]:
+        """Find an audio/video file matching the job's media ID.
+
+        Searches the transcripts directory (and any extra search_dirs) for files
+        whose name starts with the media ID and has a recognized media extension.
+        Returns the first match in MEDIA_EXTENSIONS preference order (video first).
+
+        Args:
+            job: Job dict with media_id and transcript_file fields.
+            search_dirs: Override search directories (for testing). Defaults to TRANSCRIPTS_DIR.
+
+        Returns:
+            Path to the media file, or None if not found.
+        """
+        media_id = job.get("media_id")
+        if not media_id:
+            return None
+
+        dirs_to_search = search_dirs or [Path(os.environ.get("TRANSCRIPTS_DIR", "transcripts"))]
+
+        for ext in self.MEDIA_EXTENSIONS:
+            for search_dir in dirs_to_search:
+                candidate = search_dir / f"{media_id}{ext}"
+                if candidate.exists():
+                    return candidate
 
         return None
 
@@ -1882,6 +1946,33 @@ Please format this transcript:
 ---
 {transcript}
 ---"""
+
+            # Inject diarization data if available
+            diarization = context.get("diarization_result")
+            if diarization and diarization.get("segments"):
+                speakers = ", ".join(diarization["speakers"])
+                # Format a compact segment list for the prompt
+                seg_lines = []
+                for seg in diarization["segments"][:50]:  # Cap at 50 segments to limit prompt size
+                    start = seg["start"]
+                    end = seg["end"]
+                    speaker = seg["speaker"]
+                    conf = seg.get("confidence", 0)
+                    m_start, s_start = divmod(int(start), 60)
+                    m_end, s_end = divmod(int(end), 60)
+                    seg_lines.append(f"  {m_start}:{s_start:02d}-{m_end}:{s_end:02d}  {speaker} (conf: {conf:.0%})")
+
+                prompt += f"""
+
+## Speaker Diarization Analysis
+
+The following speaker diarization was generated from the audio track. Use this to verify
+and correct speaker labels in the captions. Detected speakers: {speakers}
+
+{chr(10).join(seg_lines)}
+
+Note: Diarization confidence scores below 70% should be treated as uncertain."""
+
             editorial_feedback = context.get("_editorial_feedback")
             if editorial_feedback:
                 prompt += f"""

--- a/diarization/Dockerfile
+++ b/diarization/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.10-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# System dependencies: ffmpeg for audio extraction
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+# PyTorch CPU-only from the official CPU index to avoid pulling CUDA libs
+COPY requirements.txt .
+RUN pip install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    -r requirements.txt
+
+COPY app.py .
+
+# Pre-download whisper model at build time (avoids download on first request).
+# Uses the smallest model by default; override WHISPER_MODEL_SIZE at runtime for larger.
+ARG WHISPER_MODEL_SIZE=base
+RUN python -c "import whisperx; whisperx.load_model('${WHISPER_MODEL_SIZE}', device='cpu', compute_type='int8')"
+
+EXPOSE 8000
+
+# Run as non-root
+RUN useradd --create-home appuser
+USER appuser
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/diarization/app.py
+++ b/diarization/app.py
@@ -1,0 +1,183 @@
+"""Diarization microservice — identifies speakers in audio/video files using WhisperX."""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+logger = logging.getLogger("diarization")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Cardigan Diarization Service", version="0.1.0")
+
+# WhisperX model — loaded once at startup
+_model = None
+_diarize_pipeline = None
+
+# Configuration
+WHISPER_MODEL_SIZE = os.environ.get("WHISPER_MODEL_SIZE", "base")
+DEVICE = "cpu"
+COMPUTE_TYPE = "int8"
+
+
+def _read_hf_token() -> str:
+    """Read HuggingFace token from Docker secret file or environment."""
+    token_file = os.environ.get("HF_TOKEN_FILE", "/run/secrets/hf_token")
+    if os.path.exists(token_file):
+        return Path(token_file).read_text().strip()
+    return os.environ.get("HF_TOKEN", "")
+
+
+HF_TOKEN = _read_hf_token()
+
+
+class DiarizationSegment(BaseModel):
+    start: float
+    end: float
+    speaker: str
+    confidence: float
+
+
+class DiarizationResponse(BaseModel):
+    duration_seconds: float
+    speakers: list[str]
+    segments: list[DiarizationSegment]
+
+
+@app.get("/health")
+def health():
+    """Health check. Returns ready=True only when the WhisperX model is loaded."""
+    return {
+        "status": "ok",
+        "model_loaded": _model is not None,
+        "ready": _model is not None,
+    }
+
+
+@app.on_event("startup")
+def load_model():
+    """Load WhisperX model and diarization pipeline at startup."""
+    global _model, _diarize_pipeline
+    import whisperx
+
+    logger.info(f"Loading WhisperX model: {WHISPER_MODEL_SIZE} (device={DEVICE})")
+    _model = whisperx.load_model(
+        WHISPER_MODEL_SIZE,
+        device=DEVICE,
+        compute_type=COMPUTE_TYPE,
+    )
+    logger.info("WhisperX model loaded")
+
+    if HF_TOKEN:
+        logger.info("Loading pyannote diarization pipeline")
+        _diarize_pipeline = whisperx.DiarizationPipeline(
+            use_auth_token=HF_TOKEN,
+            device=DEVICE,
+        )
+        logger.info("Diarization pipeline loaded")
+    else:
+        logger.warning(
+            "HF_TOKEN not set — diarization pipeline unavailable. "
+            "Speaker labels will not be assigned. "
+            "Set HF_TOKEN to a HuggingFace token that has accepted pyannote terms."
+        )
+
+
+@app.post("/diarize", response_model=DiarizationResponse)
+async def diarize(file: UploadFile = File(...)):
+    """Run speaker diarization on an uploaded audio or video file.
+
+    Accepts common audio formats (wav, mp3, m4a, flac) and video formats
+    (mp4, mkv, mov, webm). Video files are automatically transcoded to audio.
+    """
+    import whisperx
+
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    # Validate file extension
+    suffix = Path(file.filename or "upload").suffix.lower()
+    allowed = {".wav", ".mp3", ".m4a", ".flac", ".mp4", ".mkv", ".mov", ".webm"}
+    if suffix not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {suffix}. Allowed: {sorted(allowed)}",
+        )
+
+    # Save upload to temp file (WhisperX needs a file path)
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+
+    try:
+        logger.info(f"Processing file: {file.filename} ({suffix})")
+
+        # Step 1: Transcribe with WhisperX
+        audio = whisperx.load_audio(tmp_path)
+        result = _model.transcribe(audio, batch_size=4)
+        logger.info(f"Transcription complete: {len(result['segments'])} segments")
+
+        # Step 2: Align timestamps
+        align_model, align_metadata = whisperx.load_align_model(
+            language_code=result["language"],
+            device=DEVICE,
+        )
+        result = whisperx.align(
+            result["segments"],
+            align_model,
+            align_metadata,
+            audio,
+            DEVICE,
+            return_char_alignments=False,
+        )
+        logger.info("Alignment complete")
+
+        # Step 3: Diarize speakers (if pipeline available)
+        if _diarize_pipeline is not None:
+            diarize_segments = _diarize_pipeline(audio)
+            result = whisperx.assign_word_speakers(diarize_segments, result)
+            logger.info("Speaker diarization complete")
+
+        # Build response
+        segments = []
+        speakers_seen = set()
+        duration_seconds = 0.0
+
+        for seg in result["segments"]:
+            speaker = seg.get("speaker", "Unknown")
+            start = round(seg.get("start", 0.0), 2)
+            end = round(seg.get("end", 0.0), 2)
+            # WhisperX doesn't provide per-segment confidence for diarization;
+            # use word-level confidence average if available, else 0.0
+            words = seg.get("words", [])
+            if words:
+                confidences = [w.get("score", 0.0) for w in words if "score" in w]
+                confidence = round(sum(confidences) / len(confidences), 3) if confidences else 0.0
+            else:
+                confidence = 0.0
+
+            segments.append(
+                DiarizationSegment(
+                    start=start,
+                    end=end,
+                    speaker=speaker,
+                    confidence=confidence,
+                )
+            )
+            speakers_seen.add(speaker)
+            duration_seconds = max(duration_seconds, end)
+
+        return DiarizationResponse(
+            duration_seconds=round(duration_seconds, 1),
+            speakers=sorted(speakers_seen),
+            segments=segments,
+        )
+
+    except Exception as e:
+        logger.exception(f"Diarization failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Diarization failed: {e}")
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)

--- a/diarization/requirements.txt
+++ b/diarization/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+python-multipart==0.0.20
+whisperx @ git+https://github.com/m-bain/whisperX.git
+torch==2.6.0+cpu
+torchaudio==2.6.0+cpu

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,7 @@ services:
       - TRANSCRIPTS_DIR=/data/transcripts
       - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
       - CARDIGAN_VERSION=${CARDIGAN_VERSION:-v4.1}
+      - DIARIZATION_SERVICE_URL=http://diarization:8000
     secrets:
       - openrouter_api_key
       - airtable_api_key
@@ -102,6 +103,25 @@ services:
       - mcp
     restart: unless-stopped
 
+  diarization:
+    image: ghcr.io/mriechers/cardigan-diarization:latest
+    environment:
+      - WHISPER_MODEL_SIZE=base
+      - HF_TOKEN_FILE=/run/secrets/hf_token
+    secrets:
+      - hf_token
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    profiles:
+      - diarization
+    restart: unless-stopped
+
   tunnel:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate run
@@ -139,6 +159,8 @@ secrets:
     file: ./secrets/langfuse_public_key
   langfuse_secret_key:
     file: ./secrets/langfuse_secret_key
+  hf_token:
+    file: ./secrets/hf_token
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - TRANSCRIPTS_DIR=/data/transcripts
       - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
       - CARDIGAN_VERSION=${CARDIGAN_VERSION:-v4.1}
+      - DIARIZATION_SERVICE_URL=http://diarization:8000
     secrets:
       - openrouter_api_key
       - airtable_api_key
@@ -104,6 +105,24 @@ services:
       - mcp
     restart: unless-stopped
 
+  diarization:
+    build:
+      context: ./diarization
+    environment:
+      - WHISPER_MODEL_SIZE=base
+      - HF_TOKEN_FILE=/run/secrets/hf_token
+    secrets:
+      - hf_token
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
+    profiles:
+      - diarization
+    restart: unless-stopped
+
   tunnel:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate run
@@ -127,6 +146,8 @@ secrets:
     file: ./secrets/langfuse_public_key
   langfuse_secret_key:
     file: ./secrets/langfuse_secret_key
+  hf_token:
+    file: ./secrets/hf_token
 
 volumes:
   db-data:

--- a/docs/superpowers/plans/2026-05-01-v4.1-sprint-5-diarization-service.md
+++ b/docs/superpowers/plans/2026-05-01-v4.1-sprint-5-diarization-service.md
@@ -1,0 +1,1154 @@
+# Sprint 5: Diarization Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional speaker diarization service that identifies who is speaking when, providing the formatter phase with speaker verification data.
+
+**Architecture:** A standalone Docker container runs WhisperX (CPU mode) behind a FastAPI endpoint. The worker calls this service over HTTP before the formatter phase, injecting speaker-timestamped segments into the formatter's prompt context. The service is purely additive — if unavailable or no media file exists, the pipeline runs normally without it.
+
+**Tech Stack:** Python 3.10, FastAPI, WhisperX, PyTorch (CPU), pyannote-audio, ffmpeg, httpx (async client)
+
+**Design spec:** `docs/superpowers/specs/2026-04-30-v4.1-pipeline-redesign-design.md` Section 6
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `diarization/Dockerfile` | Container image: Python 3.10 + WhisperX + ffmpeg |
+| `diarization/requirements.txt` | Python dependencies for the diarization service |
+| `diarization/app.py` | FastAPI app with `GET /health` and `POST /diarize` endpoints |
+| `api/services/diarization_client.py` | Async HTTP client for calling the diarization service from the worker |
+| `tests/test_diarization_client.py` | Tests for the diarization client (mocked HTTP) |
+| `tests/test_diarization_integration.py` | Tests for worker integration (media file discovery, prompt injection) |
+
+### Modified files
+
+| File | What changes |
+|------|-------------|
+| `api/services/worker.py` | Add `_find_media_file()`, call diarization before formatter, inject results into context |
+| `api/services/worker.py` | Update `_build_phase_prompt()` for formatter to include diarization data |
+| `docker-compose.yml` | Add `diarization` service |
+| `docker-compose.prod.yml` | Add `diarization` service |
+
+---
+
+## Task 1: Diarization Service — Dockerfile and Health Check
+
+**Files:**
+- Create: `diarization/requirements.txt`
+- Create: `diarization/app.py`
+- Create: `diarization/Dockerfile`
+
+This task creates the container scaffold with a health endpoint. WhisperX processing comes in Task 2.
+
+- [ ] **Step 1: Create requirements.txt**
+
+```bash
+ls diarization 2>/dev/null || mkdir diarization
+```
+
+Write `diarization/requirements.txt`:
+
+```
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+python-multipart==0.0.20
+whisperx @ git+https://github.com/m-bain/whisperX.git
+torch==2.6.0+cpu
+torchaudio==2.6.0+cpu
+```
+
+Note: `torch` and `torchaudio` CPU-only builds are installed from the PyTorch CPU index in the Dockerfile (not from PyPI). The versions here are markers; the Dockerfile `--extra-index-url` handles the actual install. `whisperx` pulls in `pyannote-audio` as a transitive dependency.
+
+- [ ] **Step 2: Create the FastAPI app with health check only**
+
+Write `diarization/app.py`:
+
+```python
+"""Diarization microservice — identifies speakers in audio/video files using WhisperX."""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+logger = logging.getLogger("diarization")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Cardigan Diarization Service", version="0.1.0")
+
+# WhisperX model — loaded once at startup
+_model = None
+_diarize_pipeline = None
+
+# Configuration
+WHISPER_MODEL_SIZE = os.environ.get("WHISPER_MODEL_SIZE", "base")
+HF_TOKEN = os.environ.get("HF_TOKEN", "")
+DEVICE = "cpu"
+COMPUTE_TYPE = "int8"
+
+
+class DiarizationSegment(BaseModel):
+    start: float
+    end: float
+    speaker: str
+    confidence: float
+
+
+class DiarizationResponse(BaseModel):
+    duration_seconds: float
+    speakers: list[str]
+    segments: list[DiarizationSegment]
+
+
+@app.get("/health")
+def health():
+    """Health check. Returns ready=True only when the WhisperX model is loaded."""
+    return {
+        "status": "ok",
+        "model_loaded": _model is not None,
+        "ready": _model is not None,
+    }
+```
+
+- [ ] **Step 3: Create the Dockerfile**
+
+Write `diarization/Dockerfile`:
+
+```dockerfile
+FROM python:3.10-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# System dependencies: ffmpeg for audio extraction
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+# PyTorch CPU-only from the official CPU index to avoid pulling CUDA libs
+COPY requirements.txt .
+RUN pip install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    -r requirements.txt
+
+COPY app.py .
+
+# Pre-download whisper model at build time (avoids download on first request).
+# Uses the smallest model by default; override WHISPER_MODEL_SIZE at runtime for larger.
+ARG WHISPER_MODEL_SIZE=base
+RUN python -c "import whisperx; whisperx.load_model('${WHISPER_MODEL_SIZE}', device='cpu', compute_type='int8')"
+
+EXPOSE 8000
+
+# Run as non-root
+RUN useradd --create-home appuser
+USER appuser
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add diarization/
+git commit -m "feat: Scaffold diarization service with Dockerfile and health check
+
+Creates the diarization microservice container structure:
+- FastAPI app with /health endpoint
+- Dockerfile with Python 3.10, WhisperX, PyTorch CPU, ffmpeg
+- Pre-downloads whisper base model at build time
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 2: Diarization Service — POST /diarize Endpoint
+
+**Files:**
+- Modify: `diarization/app.py`
+
+This task adds the actual diarization endpoint that accepts audio/video files, runs WhisperX, and returns speaker-timestamped segments.
+
+- [ ] **Step 1: Add model loading at startup**
+
+In `diarization/app.py`, add a startup event that loads the WhisperX model and pyannote diarization pipeline:
+
+```python
+@app.on_event("startup")
+def load_model():
+    """Load WhisperX model and diarization pipeline at startup."""
+    global _model, _diarize_pipeline
+    import whisperx
+
+    logger.info(f"Loading WhisperX model: {WHISPER_MODEL_SIZE} (device={DEVICE})")
+    _model = whisperx.load_model(
+        WHISPER_MODEL_SIZE,
+        device=DEVICE,
+        compute_type=COMPUTE_TYPE,
+    )
+    logger.info("WhisperX model loaded")
+
+    if HF_TOKEN:
+        logger.info("Loading pyannote diarization pipeline")
+        _diarize_pipeline = whisperx.DiarizationPipeline(
+            use_auth_token=HF_TOKEN,
+            device=DEVICE,
+        )
+        logger.info("Diarization pipeline loaded")
+    else:
+        logger.warning(
+            "HF_TOKEN not set — diarization pipeline unavailable. "
+            "Speaker labels will not be assigned. "
+            "Set HF_TOKEN to a HuggingFace token that has accepted pyannote terms."
+        )
+```
+
+- [ ] **Step 2: Add the /diarize endpoint**
+
+Add to `diarization/app.py`:
+
+```python
+@app.post("/diarize", response_model=DiarizationResponse)
+async def diarize(file: UploadFile = File(...)):
+    """Run speaker diarization on an uploaded audio or video file.
+
+    Accepts common audio formats (wav, mp3, m4a, flac) and video formats
+    (mp4, mkv, mov, webm). Video files are automatically transcoded to audio.
+    """
+    import whisperx
+
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    # Validate file extension
+    suffix = Path(file.filename or "upload").suffix.lower()
+    allowed = {".wav", ".mp3", ".m4a", ".flac", ".mp4", ".mkv", ".mov", ".webm"}
+    if suffix not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {suffix}. Allowed: {sorted(allowed)}",
+        )
+
+    # Save upload to temp file (WhisperX needs a file path)
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+
+    try:
+        logger.info(f"Processing file: {file.filename} ({suffix})")
+
+        # Step 1: Transcribe with WhisperX
+        audio = whisperx.load_audio(tmp_path)
+        result = _model.transcribe(audio, batch_size=4)
+        logger.info(f"Transcription complete: {len(result['segments'])} segments")
+
+        # Step 2: Align timestamps
+        align_model, align_metadata = whisperx.load_align_model(
+            language_code=result["language"],
+            device=DEVICE,
+        )
+        result = whisperx.align(
+            result["segments"],
+            align_model,
+            align_metadata,
+            audio,
+            DEVICE,
+            return_char_alignments=False,
+        )
+        logger.info("Alignment complete")
+
+        # Step 3: Diarize speakers (if pipeline available)
+        if _diarize_pipeline is not None:
+            diarize_segments = _diarize_pipeline(audio)
+            result = whisperx.assign_word_speakers(diarize_segments, result)
+            logger.info("Speaker diarization complete")
+
+        # Build response
+        segments = []
+        speakers_seen = set()
+        duration_seconds = 0.0
+
+        for seg in result["segments"]:
+            speaker = seg.get("speaker", "Unknown")
+            start = round(seg.get("start", 0.0), 2)
+            end = round(seg.get("end", 0.0), 2)
+            # WhisperX doesn't provide per-segment confidence for diarization;
+            # use word-level confidence average if available, else 0.0
+            words = seg.get("words", [])
+            if words:
+                confidences = [w.get("score", 0.0) for w in words if "score" in w]
+                confidence = round(sum(confidences) / len(confidences), 3) if confidences else 0.0
+            else:
+                confidence = 0.0
+
+            segments.append(DiarizationSegment(
+                start=start,
+                end=end,
+                speaker=speaker,
+                confidence=confidence,
+            ))
+            speakers_seen.add(speaker)
+            duration_seconds = max(duration_seconds, end)
+
+        return DiarizationResponse(
+            duration_seconds=round(duration_seconds, 1),
+            speakers=sorted(speakers_seen),
+            segments=segments,
+        )
+
+    except Exception as e:
+        logger.exception(f"Diarization failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Diarization failed: {e}")
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add diarization/app.py
+git commit -m "feat: Add POST /diarize endpoint with WhisperX pipeline
+
+Implements the full diarization flow:
+1. Accepts audio/video file upload
+2. Transcribes with WhisperX (batch_size=4)
+3. Aligns timestamps with wav2vec2
+4. Diarizes speakers with pyannote (when HF_TOKEN set)
+5. Returns speaker-timestamped segments with confidence scores
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 3: Diarization Client Library
+
+**Files:**
+- Create: `api/services/diarization_client.py`
+- Create: `tests/test_diarization_client.py`
+
+The worker needs an async HTTP client to call the diarization service. This is a thin wrapper around httpx with timeout handling and graceful degradation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Write `tests/test_diarization_client.py`:
+
+```python
+"""Tests for the diarization HTTP client."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_true_when_healthy():
+    """Client reports available when the service health check returns ready=True."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "ready": True}
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(return_value=mock_response)
+        result = await client.is_available()
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_false_when_not_ready():
+    """Client reports unavailable when service is up but model not loaded."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "ready": False}
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(return_value=mock_response)
+        result = await client.is_available()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_false_on_connection_error():
+    """Client reports unavailable when service is unreachable."""
+    import httpx
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        result = await client.is_available()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_parsed_response():
+    """Client parses a successful diarization response."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "duration_seconds": 1088.5,
+        "speakers": ["Speaker 1", "Speaker 2"],
+        "segments": [
+            {"start": 0.0, "end": 4.2, "speaker": "Speaker 1", "confidence": 0.94},
+            {"start": 4.2, "end": 11.8, "speaker": "Speaker 2", "confidence": 0.87},
+        ],
+    }
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.post = AsyncMock(return_value=mock_response)
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is not None
+    assert result["duration_seconds"] == 1088.5
+    assert len(result["speakers"]) == 2
+    assert len(result["segments"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_none_on_error():
+    """Client returns None when diarization service returns an error."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.post = AsyncMock(return_value=mock_response)
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_none_on_timeout():
+    """Client returns None when diarization times out (graceful degradation)."""
+    import httpx
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("Timed out"))
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_client.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'api.services.diarization_client'`
+
+- [ ] **Step 3: Implement the diarization client**
+
+Write `api/services/diarization_client.py`:
+
+```python
+"""Async HTTP client for the Cardigan diarization microservice.
+
+The diarization service is optional — if it's unavailable, the pipeline
+runs without speaker verification. All methods return None/False rather
+than raising on service errors.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default URL matches the Docker Compose service name
+DEFAULT_BASE_URL = os.environ.get("DIARIZATION_SERVICE_URL", "http://diarization:8000")
+
+# Generous timeout: diarization of a 30-min episode on CPU can take several minutes
+DIARIZE_TIMEOUT_SECONDS = int(os.environ.get("DIARIZATION_TIMEOUT", "600"))
+HEALTH_TIMEOUT_SECONDS = 5
+
+
+class DiarizationClient:
+    """Async client for the diarization microservice.
+
+    Usage:
+        client = DiarizationClient()
+        if await client.is_available():
+            result = await client.diarize("/path/to/audio.mp4")
+            if result:
+                print(result["speakers"])
+    """
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(DIARIZE_TIMEOUT_SECONDS))
+
+    async def is_available(self) -> bool:
+        """Check if the diarization service is up and the model is loaded.
+
+        Returns False (never raises) if the service is unreachable or not ready.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/health",
+                timeout=HEALTH_TIMEOUT_SECONDS,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("ready", False)
+            return False
+        except (httpx.HTTPError, Exception) as e:
+            logger.debug(f"Diarization service unavailable: {e}")
+            return False
+
+    async def diarize(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """Send an audio/video file to the diarization service.
+
+        Args:
+            file_path: Path to the audio or video file on disk.
+
+        Returns:
+            Parsed JSON response dict with keys: duration_seconds, speakers, segments.
+            Returns None if the request fails for any reason.
+        """
+        path = Path(file_path)
+        if not path.exists():
+            logger.warning(f"Media file not found for diarization: {file_path}")
+            return None
+
+        try:
+            logger.info(f"Sending file to diarization service: {path.name}")
+            with open(path, "rb") as f:
+                resp = await self._client.post(
+                    f"{self.base_url}/diarize",
+                    files={"file": (path.name, f, "application/octet-stream")},
+                )
+
+            if resp.status_code == 200:
+                result = resp.json()
+                logger.info(
+                    f"Diarization complete: {len(result.get('speakers', []))} speakers, "
+                    f"{len(result.get('segments', []))} segments"
+                )
+                return result
+
+            logger.warning(f"Diarization service returned {resp.status_code}: {resp.text[:200]}")
+            return None
+
+        except httpx.TimeoutException:
+            logger.warning(f"Diarization timed out after {DIARIZE_TIMEOUT_SECONDS}s for {path.name}")
+            return None
+        except (httpx.HTTPError, Exception) as e:
+            logger.warning(f"Diarization request failed: {e}")
+            return None
+
+    async def close(self):
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_client.py -v`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/services/diarization_client.py tests/test_diarization_client.py
+git commit -m "feat: Add async diarization client with graceful degradation
+
+HTTP client for calling the diarization microservice:
+- is_available() checks health endpoint (5s timeout)
+- diarize() sends file and returns parsed response (10min timeout)
+- All errors return None/False — never raises, never blocks pipeline
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 4: Worker Integration — Media File Discovery
+
+**Files:**
+- Modify: `api/services/worker.py:1140-1165` (near `_find_srt_file`)
+- Create: `tests/test_diarization_integration.py`
+
+The worker needs a method to find audio/video files that correspond to a job, similar to `_find_srt_file` but for media formats.
+
+- [ ] **Step 1: Write the failing test**
+
+Write `tests/test_diarization_integration.py`:
+
+```python
+"""Tests for diarization integration in the worker pipeline."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestFindMediaFile:
+    """Tests for TranscriptWorker._find_media_file()."""
+
+    def _make_worker(self):
+        """Create a TranscriptWorker with mocked dependencies."""
+        with patch("api.services.worker.LLMClient"):
+            from api.services.worker import TranscriptWorker
+            return TranscriptWorker.__new__(TranscriptWorker)
+
+    def test_finds_mp4_matching_media_id(self, tmp_path):
+        """Finds an mp4 file in the transcripts directory matching the media ID."""
+        worker = self._make_worker()
+        media_file = tmp_path / "2WLI1209HD.mp4"
+        media_file.write_bytes(b"fake video data")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        assert result.name == "2WLI1209HD.mp4"
+
+    def test_finds_wav_matching_media_id(self, tmp_path):
+        """Finds a wav file matching the media ID."""
+        worker = self._make_worker()
+        media_file = tmp_path / "2WLI1209HD.wav"
+        media_file.write_bytes(b"fake audio data")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        assert result.name == "2WLI1209HD.wav"
+
+    def test_returns_none_when_no_media_file(self, tmp_path):
+        """Returns None when no media file matches the media ID."""
+        worker = self._make_worker()
+        # Only a transcript, no media
+        (tmp_path / "2WLI1209HD.srt").write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is None
+
+    def test_returns_none_when_no_media_id(self, tmp_path):
+        """Returns None when job has no media_id."""
+        worker = self._make_worker()
+        job = {"transcript_file": "unknown.txt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is None
+
+    def test_prefers_mp4_over_wav(self, tmp_path):
+        """When multiple media files exist, prefers video over audio."""
+        worker = self._make_worker()
+        (tmp_path / "2WLI1209HD.mp4").write_bytes(b"video")
+        (tmp_path / "2WLI1209HD.wav").write_bytes(b"audio")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        # mp4 is preferred (first in MEDIA_EXTENSIONS list)
+        assert result.suffix == ".mp4"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_integration.py::TestFindMediaFile -v`
+Expected: FAIL — `AttributeError: 'TranscriptWorker' object has no attribute '_find_media_file'`
+
+- [ ] **Step 3: Add _find_media_file to the worker**
+
+In `api/services/worker.py`, add this method to the `TranscriptWorker` class, right after the `_find_srt_file` method (around line 1164):
+
+```python
+    # Media file extensions for diarization, in preference order
+    MEDIA_EXTENSIONS = [".mp4", ".mkv", ".mov", ".webm", ".wav", ".mp3", ".m4a", ".flac"]
+
+    def _find_media_file(
+        self, job: Dict[str, Any], search_dirs: Optional[List[Path]] = None
+    ) -> Optional[Path]:
+        """Find an audio/video file matching the job's media ID.
+
+        Searches the transcripts directory (and any extra search_dirs) for files
+        whose name starts with the media ID and has a recognized media extension.
+        Returns the first match in MEDIA_EXTENSIONS preference order (video first).
+
+        Args:
+            job: Job dict with media_id and transcript_file fields.
+            search_dirs: Override search directories (for testing). Defaults to TRANSCRIPTS_DIR.
+
+        Returns:
+            Path to the media file, or None if not found.
+        """
+        media_id = job.get("media_id")
+        if not media_id:
+            return None
+
+        dirs_to_search = search_dirs or [Path(os.environ.get("TRANSCRIPTS_DIR", "transcripts"))]
+
+        for ext in self.MEDIA_EXTENSIONS:
+            for search_dir in dirs_to_search:
+                candidate = search_dir / f"{media_id}{ext}"
+                if candidate.exists():
+                    return candidate
+
+        return None
+```
+
+Also add `import os` at the top of the file if not already present (it is — `os` is already imported).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_integration.py::TestFindMediaFile -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/services/worker.py tests/test_diarization_integration.py
+git commit -m "feat: Add media file discovery for diarization
+
+Worker can now locate audio/video files matching a job's media ID.
+Searches transcripts directory for common media extensions (.mp4, .wav, etc).
+Prefers video over audio when both exist.
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 5: Worker Integration — Diarization Call and Formatter Injection
+
+**Files:**
+- Modify: `api/services/worker.py:595-640` (before the phase loop, after content type detection)
+- Modify: `api/services/worker.py:1861-1896` (`_build_phase_prompt` formatter section)
+- Modify: `tests/test_diarization_integration.py`
+
+Wire the diarization client into the pipeline: call before the formatter phase, inject results into the formatter's prompt context.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_diarization_integration.py`:
+
+```python
+class TestFormatterDiarizationPrompt:
+    """Tests for diarization data injection into the formatter prompt."""
+
+    def _make_worker(self):
+        """Create a TranscriptWorker with mocked dependencies."""
+        with patch("api.services.worker.LLMClient"):
+            from api.services.worker import TranscriptWorker
+            worker = TranscriptWorker.__new__(TranscriptWorker)
+            worker.llm = MagicMock()
+            worker.llm.config = {}
+            return worker
+
+    def test_formatter_prompt_includes_diarization_when_present(self):
+        """Formatter prompt includes diarization section when data is in context."""
+        worker = self._make_worker()
+        context = {
+            "transcript": "Hello world",
+            "analyst_output": "Analysis here",
+            "transcript_metrics": {"estimated_duration_minutes": 30},
+            "content_type": "full",
+            "diarization_result": {
+                "duration_seconds": 1800,
+                "speakers": ["Speaker 1", "Speaker 2"],
+                "segments": [
+                    {"start": 0.0, "end": 10.0, "speaker": "Speaker 1", "confidence": 0.95},
+                    {"start": 10.0, "end": 20.0, "speaker": "Speaker 2", "confidence": 0.88},
+                ],
+            },
+        }
+
+        prompt = worker._build_phase_prompt("formatter", context)
+        assert "Speaker Diarization" in prompt
+        assert "Speaker 1" in prompt
+        assert "Speaker 2" in prompt
+
+    def test_formatter_prompt_omits_diarization_when_absent(self):
+        """Formatter prompt has no diarization section when data is not in context."""
+        worker = self._make_worker()
+        context = {
+            "transcript": "Hello world",
+            "analyst_output": "Analysis here",
+            "transcript_metrics": {"estimated_duration_minutes": 30},
+            "content_type": "full",
+        }
+
+        prompt = worker._build_phase_prompt("formatter", context)
+        assert "Speaker Diarization" not in prompt
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_integration.py::TestFormatterDiarizationPrompt -v`
+Expected: FAIL — `test_formatter_prompt_includes_diarization_when_present` fails because the formatter prompt doesn't reference diarization data yet.
+
+- [ ] **Step 3: Update _build_phase_prompt to inject diarization data**
+
+In `api/services/worker.py`, find the `_build_phase_prompt` method's `elif phase_name == "formatter":` block (around line 1861). After the existing prompt is built (before the editorial feedback section at line 1887), add a diarization section:
+
+Find this code block (around line 1882-1886):
+
+```python
+            prompt += f"""---
+{analysis}
+---
+
+Please format this transcript:
+
+---
+{transcript}
+---"""
+```
+
+Replace with:
+
+```python
+            prompt += f"""---
+{analysis}
+---
+
+Please format this transcript:
+
+---
+{transcript}
+---"""
+
+            # Inject diarization data if available
+            diarization = context.get("diarization_result")
+            if diarization and diarization.get("segments"):
+                speakers = ", ".join(diarization["speakers"])
+                # Format a compact segment list for the prompt
+                seg_lines = []
+                for seg in diarization["segments"][:50]:  # Cap at 50 segments to limit prompt size
+                    start = seg["start"]
+                    end = seg["end"]
+                    speaker = seg["speaker"]
+                    conf = seg.get("confidence", 0)
+                    m_start, s_start = divmod(int(start), 60)
+                    m_end, s_end = divmod(int(end), 60)
+                    seg_lines.append(f"  {m_start}:{s_start:02d}-{m_end}:{s_end:02d}  {speaker} (conf: {conf:.0%})")
+
+                prompt += f"""
+
+## Speaker Diarization Analysis
+
+The following speaker diarization was generated from the audio track. Use this to verify
+and correct speaker labels in the captions. Detected speakers: {speakers}
+
+{chr(10).join(seg_lines)}
+
+Note: Diarization confidence scores below 70% should be treated as uncertain."""
+```
+
+- [ ] **Step 4: Add the diarization call to the main run loop**
+
+In `api/services/worker.py`, find the section in `run_job()` after content type detection and before the phase loop (around line 621-635). After the `content_type` is persisted to the DB and before `phases = job.get("phases") or []`, add the diarization call:
+
+Find this block (around line 620-622):
+
+```python
+            except Exception as e:
+                logger.warning(
+                    "Failed to persist content_type (non-fatal)",
+                    extra={"job_id": job_id, "error": str(e)},
+                )
+```
+
+After this block, before `# Get existing phases or initialize`, add:
+
+```python
+            # Attempt diarization if service is available and media file exists
+            diarization_result = None
+            media_path = self._find_media_file(job)
+            if media_path:
+                try:
+                    from api.services.diarization_client import DiarizationClient
+
+                    diarization_client = DiarizationClient()
+                    if await diarization_client.is_available():
+                        logger.info(
+                            "Diarization service available, processing media file",
+                            extra={"job_id": job_id, "media_file": media_path.name},
+                        )
+                        diarization_result = await diarization_client.diarize(str(media_path))
+                        if diarization_result:
+                            logger.info(
+                                "Diarization complete",
+                                extra={
+                                    "job_id": job_id,
+                                    "speakers": len(diarization_result.get("speakers", [])),
+                                    "segments": len(diarization_result.get("segments", [])),
+                                },
+                            )
+                    else:
+                        logger.debug("Diarization service not available", extra={"job_id": job_id})
+                    await diarization_client.close()
+                except Exception as e:
+                    logger.warning(
+                        "Diarization failed (non-fatal, continuing without it)",
+                        extra={"job_id": job_id, "error": str(e)},
+                    )
+```
+
+Then in the context dict construction (around line 627-635), add the diarization result:
+
+Find:
+
+```python
+            context = {
+                "project_name": job.get("project_name") or "Unknown",
+                "transcript_file": job.get("transcript_file", ""),
+                "project_path": project_path,
+                "transcript_metrics": transcript_metrics,
+                "sst_context": sst_context,  # Add SST context to processing context
+                "content_type": content_type,  # Expose content_type for prompt building
+            }
+```
+
+Replace with:
+
+```python
+            context = {
+                "project_name": job.get("project_name") or "Unknown",
+                "transcript_file": job.get("transcript_file", ""),
+                "project_path": project_path,
+                "transcript_metrics": transcript_metrics,
+                "sst_context": sst_context,  # Add SST context to processing context
+                "content_type": content_type,  # Expose content_type for prompt building
+                "diarization_result": diarization_result,  # Speaker diarization (may be None)
+            }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/test_diarization_integration.py -v`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/services/worker.py tests/test_diarization_integration.py
+git commit -m "feat: Integrate diarization into formatter pipeline
+
+Worker now calls the diarization service before the formatter phase:
+1. Finds media file matching job's media ID
+2. Checks diarization service availability (health check)
+3. Sends media file for processing
+4. Injects speaker segments into formatter prompt context
+
+Diarization is fully optional — if service is down, media missing,
+or processing fails, the pipeline continues without it.
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 6: Docker Compose Configuration
+
+**Files:**
+- Modify: `docker-compose.yml`
+- Modify: `docker-compose.prod.yml`
+
+Add the diarization service to both Docker Compose files. It runs on a `diarization` profile so it doesn't start by default — only when explicitly enabled.
+
+- [ ] **Step 1: Update docker-compose.yml**
+
+In `docker-compose.yml`, add the `diarization` service after the `mcp` service block (before the `tunnel` service, around line 96). Also add the `hf_token` secret and update the worker's environment:
+
+Add this service block before the `tunnel:` service:
+
+```yaml
+  diarization:
+    build:
+      context: ./diarization
+    environment:
+      - WHISPER_MODEL_SIZE=base
+      - HF_TOKEN_FILE=/run/secrets/hf_token
+    secrets:
+      - hf_token
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
+    profiles:
+      - diarization
+    restart: unless-stopped
+```
+
+Add the diarization service URL to the `worker` service's environment section:
+
+```yaml
+      - DIARIZATION_SERVICE_URL=http://diarization:8000
+```
+
+Add `hf_token` to the secrets section:
+
+```yaml
+  hf_token:
+    file: ./secrets/hf_token
+```
+
+- [ ] **Step 2: Update docker-compose.prod.yml**
+
+In `docker-compose.prod.yml`, add the same diarization service (but using a pre-built image). Add after the `mcp` service, before `tunnel`:
+
+```yaml
+  diarization:
+    image: ghcr.io/mriechers/cardigan-diarization:latest
+    environment:
+      - WHISPER_MODEL_SIZE=base
+      - HF_TOKEN_FILE=/run/secrets/hf_token
+    secrets:
+      - hf_token
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    profiles:
+      - diarization
+    restart: unless-stopped
+```
+
+Add to the `worker` service's environment:
+
+```yaml
+      - DIARIZATION_SERVICE_URL=http://diarization:8000
+```
+
+Add `hf_token` to the secrets section:
+
+```yaml
+  hf_token:
+    file: ./secrets/hf_token
+```
+
+- [ ] **Step 3: Update diarization/app.py to read HF_TOKEN from secret file**
+
+The Docker secret is mounted as a file. Update the `HF_TOKEN` resolution at the top of `diarization/app.py`:
+
+Find:
+
+```python
+HF_TOKEN = os.environ.get("HF_TOKEN", "")
+```
+
+Replace with:
+
+```python
+def _read_hf_token() -> str:
+    """Read HuggingFace token from Docker secret file or environment."""
+    token_file = os.environ.get("HF_TOKEN_FILE", "/run/secrets/hf_token")
+    if os.path.exists(token_file):
+        return Path(token_file).read_text().strip()
+    return os.environ.get("HF_TOKEN", "")
+
+
+HF_TOKEN = _read_hf_token()
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml docker-compose.prod.yml diarization/app.py
+git commit -m "feat: Add diarization service to Docker Compose
+
+Adds diarization container to both dev and prod compose files:
+- Runs on 'diarization' profile (opt-in, not started by default)
+- HuggingFace token via Docker secret for pyannote model access
+- Health check with 60s start period (model loading takes time)
+- Worker configured with DIARIZATION_SERVICE_URL env var
+
+Usage: docker compose --profile diarization up
+
+[Agent: Subagent]"
+```
+
+---
+
+## Task 7: Run Full Test Suite and Fix Issues
+
+**Files:**
+- Possibly modify: any files with test failures
+
+Verify nothing is broken by running the complete test suite.
+
+- [ ] **Step 1: Run all tests**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4 && venv/bin/python3 -m pytest tests/ -v --ignore=tests/test_ingest_scanner.py`
+
+Note: `test_ingest_scanner.py` is excluded due to pre-existing hanging issue (#102).
+
+Expected: All tests pass, including the new diarization tests.
+
+- [ ] **Step 2: Run TypeScript checks**
+
+Run: `cd /Users/mriechers/Developer/pbswi/cardigan-v4/.worktrees/v4.1-sprint-5/web && npx tsc --noEmit`
+
+Expected: No TypeScript errors (this sprint doesn't touch frontend code, so this is a safety check).
+
+- [ ] **Step 3: Fix any issues found**
+
+If any tests fail, investigate and fix. Common issues to watch for:
+- Import errors from the new `diarization_client` module
+- Mock patching paths being incorrect
+- Worker test fixtures not accounting for the new `diarization_result` context key
+
+- [ ] **Step 4: Final commit (if fixes needed)**
+
+```bash
+git add -u
+git commit -m "fix: Resolve test issues from diarization integration
+
+[Agent: Subagent]"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks complete, verify:
+
+- [ ] `diarization/Dockerfile` builds successfully: `docker build -t cardigan-diarization diarization/`
+- [ ] Health check works: `docker run -d -p 8000:8000 cardigan-diarization && curl localhost:8000/health`
+- [ ] All Python tests pass: `pytest tests/ -v --ignore=tests/test_ingest_scanner.py`
+- [ ] No TS errors: `cd web && npx tsc --noEmit`
+- [ ] Docker Compose validates: `docker compose config --quiet`
+- [ ] Worker runs without diarization service (graceful fallback): start worker alone, submit a job, confirm it completes without errors

--- a/tests/test_diarization_client.py
+++ b/tests/test_diarization_client.py
@@ -1,0 +1,127 @@
+"""Tests for the diarization HTTP client."""
+
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_true_when_healthy():
+    """Client reports available when the service health check returns ready=True."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "ready": True}
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(return_value=mock_response)
+        result = await client.is_available()
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_false_when_not_ready():
+    """Client reports unavailable when service is up but model not loaded."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "ready": False}
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(return_value=mock_response)
+        result = await client.is_available()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_returns_false_on_connection_error():
+    """Client reports unavailable when service is unreachable."""
+    import httpx
+
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        result = await client.is_available()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_parsed_response():
+    """Client parses a successful diarization response."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "duration_seconds": 1088.5,
+        "speakers": ["Speaker 1", "Speaker 2"],
+        "segments": [
+            {"start": 0.0, "end": 4.2, "speaker": "Speaker 1", "confidence": 0.94},
+            {"start": 4.2, "end": 11.8, "speaker": "Speaker 2", "confidence": 0.87},
+        ],
+    }
+
+    with (
+        patch.object(client, "_client") as mock_client,
+        patch("api.services.diarization_client.Path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data=b"")),
+    ):
+        mock_client.post = AsyncMock(return_value=mock_response)
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is not None
+    assert result["duration_seconds"] == 1088.5
+    assert len(result["speakers"]) == 2
+    assert len(result["segments"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_none_on_error():
+    """Client returns None when diarization service returns an error."""
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+
+    with (
+        patch.object(client, "_client") as mock_client,
+        patch("api.services.diarization_client.Path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data=b"")),
+    ):
+        mock_client.post = AsyncMock(return_value=mock_response)
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_diarize_returns_none_on_timeout():
+    """Client returns None when diarization times out (graceful degradation)."""
+    import httpx
+
+    from api.services.diarization_client import DiarizationClient
+
+    client = DiarizationClient(base_url="http://localhost:8000")
+
+    with (
+        patch.object(client, "_client") as mock_client,
+        patch("api.services.diarization_client.Path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data=b"")),
+    ):
+        mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("Timed out"))
+        result = await client.diarize("/tmp/test.mp4")
+
+    assert result is None

--- a/tests/test_diarization_integration.py
+++ b/tests/test_diarization_integration.py
@@ -1,0 +1,118 @@
+"""Tests for diarization integration in the worker pipeline."""
+
+from unittest.mock import MagicMock
+
+
+class TestFindMediaFile:
+    """Tests for TranscriptWorker._find_media_file()."""
+
+    def _make_worker(self):
+        """Create a JobWorker with mocked dependencies."""
+        from api.services.worker import JobWorker
+
+        return JobWorker.__new__(JobWorker)
+
+    def test_finds_mp4_matching_media_id(self, tmp_path):
+        """Finds an mp4 file in the transcripts directory matching the media ID."""
+        worker = self._make_worker()
+        media_file = tmp_path / "2WLI1209HD.mp4"
+        media_file.write_bytes(b"fake video data")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        assert result.name == "2WLI1209HD.mp4"
+
+    def test_finds_wav_matching_media_id(self, tmp_path):
+        """Finds a wav file matching the media ID."""
+        worker = self._make_worker()
+        media_file = tmp_path / "2WLI1209HD.wav"
+        media_file.write_bytes(b"fake audio data")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        assert result.name == "2WLI1209HD.wav"
+
+    def test_returns_none_when_no_media_file(self, tmp_path):
+        """Returns None when no media file matches the media ID."""
+        worker = self._make_worker()
+        # Only a transcript, no media
+        (tmp_path / "2WLI1209HD.srt").write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is None
+
+    def test_returns_none_when_no_media_id(self, tmp_path):
+        """Returns None when job has no media_id."""
+        worker = self._make_worker()
+        job = {"transcript_file": "unknown.txt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is None
+
+    def test_prefers_mp4_over_wav(self, tmp_path):
+        """When multiple media files exist, prefers video over audio."""
+        worker = self._make_worker()
+        (tmp_path / "2WLI1209HD.mp4").write_bytes(b"video")
+        (tmp_path / "2WLI1209HD.wav").write_bytes(b"audio")
+
+        job = {"media_id": "2WLI1209HD", "transcript_file": "2WLI1209HD.srt"}
+
+        result = worker._find_media_file(job, search_dirs=[tmp_path])
+        assert result is not None
+        # mp4 is preferred (first in MEDIA_EXTENSIONS list)
+        assert result.suffix == ".mp4"
+
+
+class TestFormatterDiarizationPrompt:
+    """Tests for diarization data injection into the formatter prompt."""
+
+    def _make_worker(self):
+        """Create a JobWorker with mocked dependencies."""
+        from api.services.worker import JobWorker
+
+        worker = JobWorker.__new__(JobWorker)
+        worker.llm = MagicMock()
+        worker.llm.config = {}
+        return worker
+
+    def test_formatter_prompt_includes_diarization_when_present(self):
+        """Formatter prompt includes diarization section when data is in context."""
+        worker = self._make_worker()
+        context = {
+            "transcript": "Hello world",
+            "analyst_output": "Analysis here",
+            "transcript_metrics": {"estimated_duration_minutes": 30},
+            "content_type": "full",
+            "diarization_result": {
+                "duration_seconds": 1800,
+                "speakers": ["Speaker 1", "Speaker 2"],
+                "segments": [
+                    {"start": 0.0, "end": 10.0, "speaker": "Speaker 1", "confidence": 0.95},
+                    {"start": 10.0, "end": 20.0, "speaker": "Speaker 2", "confidence": 0.88},
+                ],
+            },
+        }
+
+        prompt = worker._build_phase_prompt("formatter", context)
+        assert "Speaker Diarization" in prompt
+        assert "Speaker 1" in prompt
+        assert "Speaker 2" in prompt
+
+    def test_formatter_prompt_omits_diarization_when_absent(self):
+        """Formatter prompt has no diarization section when data is not in context."""
+        worker = self._make_worker()
+        context = {
+            "transcript": "Hello world",
+            "analyst_output": "Analysis here",
+            "transcript_metrics": {"estimated_duration_minutes": 30},
+            "content_type": "full",
+        }
+
+        prompt = worker._build_phase_prompt("formatter", context)
+        assert "Speaker Diarization" not in prompt


### PR DESCRIPTION
Stacked on #149 (Sprint 4 rebased). Will cascade-retarget as earlier sprints land.

## What's new (over Sprint 4)

- Standalone **WhisperX diarization microservice** (\`diarization/\`) with \`POST /diarize\`
- **Async HTTP client** with health check and graceful degradation
- **Worker integration** — media file discovery + speaker segment injection into formatter prompt
- **Docker Compose** — diarization service on opt-in \`diarization\` profile; \`DIARIZATION_SERVICE_URL\` env var on worker; \`hf_token\` secret defined
- **Fully optional** — behind Docker profile; pipeline works without it; all client errors return None/False

## Diff

+1846 / -0 across 10 files (1154 lines are the implementation plan doc; real code is ~700 lines).

## Conflict resolutions

The only non-trivial resolution: original Sprint 5 inserted \`DIARIZATION_SERVICE_URL\` between \`LANGFUSE_BASE_URL\` and \`secrets:\` in the worker service block of both compose files. Main has since added \`CARDIGAN_VERSION\` in that same spot, so the original hunk's context didn't match. Resolution: placed \`DIARIZATION_SERVICE_URL\` after \`CARDIGAN_VERSION\` (worker service only — not api, matching original Sprint 5's intent).

## Replaces

Closes #107.

## Test plan

- [x] 405 tests pass (up from Sprint 4's 392 — adds 13 diarization tests)
- [x] Python compile clean
- [ ] Manual: \`docker compose --profile diarization up diarization\` — verify service starts and \`/healthz\` returns OK
- [ ] Manual: queue a job with matching media file — verify speaker segments in formatter prompt
- [ ] Manual: queue a job without media file — verify pipeline runs without diarization

## Out of scope

- Ingest scanner integration for automatic media file discovery (see memory: project_diarization_ingest_integration)

## Stack

| Sprint | PR | Base |
|---|---|---|
| 2 | #147 | \`main\` |
| 3 | #148 | #147 |
| 4 | #149 | #148 |
| 5 | this | #149 |
| 6 | next | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)