### PR TITLE
feat: Sprint 6 — UI/UX Review & Report Export (rebased)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -157,7 +157,7 @@ async def health():
 
 
 # Register routers
-from api.routers import config, ingest, jobs, langfuse, queue, system, upload, websocket
+from api.routers import config, export, ingest, jobs, langfuse, queue, system, upload, websocket
 
 app.include_router(queue.router, prefix="/api/queue", tags=["queue"])
 app.include_router(jobs.router, prefix="/api/jobs", tags=["jobs"])
@@ -167,3 +167,4 @@ app.include_router(upload.router, prefix="/api/upload", tags=["upload"])
 app.include_router(system.router, prefix="/api/system", tags=["system"])
 app.include_router(ingest.router, prefix="/api/ingest", tags=["ingest"])
 app.include_router(langfuse.router, prefix="/api/langfuse", tags=["langfuse"])
+app.include_router(export.router, prefix="/api", tags=["export"])

--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -1,0 +1,98 @@
+"""Export API endpoints for uploading reports to external services."""
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from api.services.database import get_job
+from api.services.google_drive import GoogleDriveService
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+# Same allowlist as jobs.py — keep in sync
+_ALLOWED_FILES = {
+    "analyst_output.md",
+    "formatter_output.md",
+    "seo_output.md",
+    "validator_output.md",
+    "timestamp_output.md",
+    "copy_editor_output.md",
+    "recovery_analysis.md",
+}
+
+
+class ExportStatusResponse(BaseModel):
+    google_drive: dict
+
+
+class DriveUploadResponse(BaseModel):
+    drive_url: str
+    file_id: str
+
+
+def _make_export_filename(project_name: str, filename: str) -> str:
+    """Create an export filename prefixed with sanitized project name."""
+    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", project_name)
+    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
+    return f"{sanitized}-{filename}"
+
+
+@router.get("/status", response_model=ExportStatusResponse)
+async def get_export_status():
+    """Check which export services are configured and available."""
+    drive = GoogleDriveService()
+    return ExportStatusResponse(
+        google_drive={
+            "configured": drive.is_configured(),
+        }
+    )
+
+
+@router.post("/google-drive/{job_id}/{filename}", response_model=DriveUploadResponse)
+async def upload_to_google_drive(
+    job_id: int,
+    filename: str,
+    folder_id: Optional[str] = Query(default=None, description="Google Drive folder ID"),
+):
+    """Upload a job output file to Google Drive."""
+    job = await get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    is_revision = bool(re.match(r"^copy_revision_v\d+\.md$", filename))
+    if filename not in _ALLOWED_FILES and not is_revision:
+        raise HTTPException(status_code=400, detail=f"Invalid filename: {filename}")
+
+    drive = GoogleDriveService()
+    if not drive.is_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Google Drive export is not configured. Add GOOGLE_DRIVE_CREDENTIALS secret.",
+        )
+
+    if not job.project_path:
+        raise HTTPException(status_code=404, detail="Job has no output directory")
+
+    output_dir = Path(os.getenv("OUTPUT_DIR", "OUTPUT")).resolve()
+    file_path = (Path(job.project_path) / filename).resolve()
+
+    if not file_path.is_relative_to(output_dir):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail=f"Output file '{filename}' not found")
+
+    drive_filename = _make_export_filename(job.project_name or f"job-{job_id}", filename)
+    result = drive.upload_file(file_path, filename=drive_filename, folder_id=folder_id)
+
+    if result is None:
+        raise HTTPException(status_code=500, detail="Upload to Google Drive failed")
+
+    return DriveUploadResponse(
+        drive_url=result["webViewLink"],
+        file_id=result["id"],
+    )

--- a/api/routers/jobs.py
+++ b/api/routers/jobs.py
@@ -495,6 +495,17 @@ async def get_job_events(job_id: int):
     return events
 
 
+def _make_download_filename(project_name: str, filename: str) -> str:
+    """Create a download filename prefixed with sanitized project name.
+
+    Example: "Wisconsin Life / 2WLI1209HD" + "analyst_output.md"
+             → "Wisconsin-Life-2WLI1209HD-analyst_output.md"
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", project_name)
+    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
+    return f"{sanitized}-{filename}"
+
+
 @router.get("/{job_id}/outputs/{filename}")
 async def get_job_output(job_id: int, filename: str, download: bool = Query(default=False)):
     """Retrieve an output file for a specific job.
@@ -562,7 +573,8 @@ async def get_job_output(job_id: int, filename: str, download: bool = Query(defa
     media_type = "application/json" if filename.endswith(".json") else "text/markdown"
     headers = {}
     if download:
-        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        download_name = _make_download_filename(job.project_name or "", filename)
+        headers["Content-Disposition"] = f'attachment; filename="{download_name}"'
     return PlainTextResponse(content, media_type=media_type, headers=headers)
 
 

--- a/api/services/google_drive.py
+++ b/api/services/google_drive.py
@@ -1,0 +1,87 @@
+"""Google Drive upload service for Cardigan report export.
+
+Uses a Google service account for authentication. The service account
+JSON credentials are resolved through the standard secrets system
+(Docker secret file → env var → macOS Keychain).
+
+Secret key: GOOGLE_DRIVE_CREDENTIALS (JSON string of service account key)
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from api.services.secrets import get_secret
+
+logger = logging.getLogger(__name__)
+
+# Google libraries are optional — only needed when Drive export is configured
+try:
+    from google.oauth2.service_account import Credentials
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaFileUpload
+
+    _GOOGLE_AVAILABLE = True
+except ImportError:
+    _GOOGLE_AVAILABLE = False
+
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+class GoogleDriveService:
+    """Upload files to Google Drive using a service account."""
+
+    def __init__(self) -> None:
+        self._creds_json = get_secret("GOOGLE_DRIVE_CREDENTIALS")
+
+    def is_configured(self) -> bool:
+        """Check if Google Drive credentials are available."""
+        return _GOOGLE_AVAILABLE and self._creds_json is not None
+
+    def _build_service(self):
+        """Build the Google Drive API service client."""
+        if not self._creds_json:
+            return None
+        info = json.loads(self._creds_json)
+        creds = Credentials.from_service_account_info(info, scopes=SCOPES)
+        return build("drive", "v3", credentials=creds)
+
+    def upload_file(
+        self,
+        file_path: Path,
+        filename: str,
+        folder_id: Optional[str] = None,
+        mime_type: str = "text/markdown",
+    ) -> Optional[dict]:
+        """Upload a file to Google Drive.
+
+        Args:
+            file_path: Local path to the file to upload.
+            filename: Name for the file in Google Drive.
+            folder_id: Optional Drive folder ID to upload into.
+            mime_type: MIME type of the file.
+
+        Returns:
+            Dict with 'id' and 'webViewLink' on success, None on failure.
+        """
+        if not self.is_configured():
+            logger.warning("Google Drive not configured — skipping upload")
+            return None
+
+        try:
+            service = self._build_service()
+            if service is None:
+                return None
+
+            metadata: dict = {"name": filename}
+            if folder_id:
+                metadata["parents"] = [folder_id]
+
+            media = MediaFileUpload(str(file_path), mimetype=mime_type)
+            result = service.files().create(body=metadata, media_body=media, fields="id,webViewLink").execute()
+            logger.info("Uploaded %s to Google Drive: %s", filename, result.get("id"))
+            return result
+        except Exception:
+            logger.exception("Failed to upload %s to Google Drive", filename)
+            return None

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,7 @@ services:
       - airtable_api_key
       - langfuse_public_key
       - langfuse_secret_key
+      - google_drive_credentials
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -161,6 +162,8 @@ secrets:
     file: ./secrets/langfuse_secret_key
   hf_token:
     file: ./secrets/hf_token
+  google_drive_credentials:
+    file: ./secrets/google_drive_credentials
 
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - airtable_api_key
       - langfuse_public_key
       - langfuse_secret_key
+      - google_drive_credentials
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -148,6 +149,8 @@ secrets:
     file: ./secrets/langfuse_secret_key
   hf_token:
     file: ./secrets/hf_token
+  google_drive_credentials:
+    file: ./secrets/google_drive_credentials
 
 volumes:
   db-data:

--- a/docs/superpowers/plans/2026-05-01-v4.1-sprint-6-ui-ux-review-export.md
+++ b/docs/superpowers/plans/2026-05-01-v4.1-sprint-6-ui-ux-review-export.md
@@ -1,0 +1,1202 @@
+# v4.1 Sprint 6: UI/UX Review & Report Export — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the dashboard's markdown rendering for all phase outputs, improve download UX, add Google Drive export, and review all v4.1 UI elements for consistency.
+
+**Architecture:** Markdown rendering improvements are pure frontend (Tailwind prose classes). Download polish adds project-name prefixing in the API. Google Drive export is a new backend service (`api/services/google_drive.py`) using a service account, with a settings tab for configuration and upload buttons on each output file. The UX pass addresses specific inconsistencies found during code review.
+
+**Tech Stack:** React 18 + TypeScript, Tailwind CSS typography plugin, FastAPI, `google-api-python-client` + `google-auth` (new dependencies), Docker secrets for credentials.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `web/src/components/ProseContainer.tsx` | Create | Reusable prose wrapper with consistent dark-mode typography styling |
+| `web/src/pages/JobDetail.tsx` | Modify | Use ProseContainer in output modal, add Google Drive upload buttons, UX fixes |
+| `web/src/pages/Projects.tsx` | Modify | Use ProseContainer in artifact viewer |
+| `api/routers/jobs.py` | Modify | Prefix download filenames with project name |
+| `api/services/google_drive.py` | Create | Google Drive upload service using service account |
+| `api/routers/export.py` | Create | Export API endpoints (Google Drive upload, config) |
+| `web/src/pages/Settings.tsx` | Modify | Add Export tab for Google Drive configuration |
+| `requirements.txt` | Modify | Add google-api-python-client, google-auth |
+| `docker-compose.yml` | Modify | Add google_drive_credentials secret |
+| `docker-compose.prod.yml` | Modify | Add google_drive_credentials secret |
+| `tests/test_google_drive.py` | Create | Tests for Google Drive service |
+| `tests/test_export_router.py` | Create | Tests for export API endpoints |
+| `tests/test_download_filename.py` | Create | Tests for download filename prefixing |
+
+---
+
+### Task 1: Create ProseContainer Component
+
+Unify markdown rendering styles across the dashboard. Currently, `JobDetail.tsx` (line 1139) has minimal prose styling (just table borders), while `Help.tsx` (lines 99-112) has comprehensive typography. Extract the rich styling into a shared component.
+
+**Files:**
+- Create: `web/src/components/ProseContainer.tsx`
+- Modify: `web/src/pages/JobDetail.tsx:1133-1143`
+- Modify: `web/src/pages/Projects.tsx:579-580`
+
+- [ ] **Step 1: Create ProseContainer component**
+
+```tsx
+// web/src/components/ProseContainer.tsx
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface ProseContainerProps {
+  content: string
+  className?: string
+}
+
+export default function ProseContainer({ content, className = '' }: ProseContainerProps) {
+  return (
+    <div className={`prose prose-invert prose-sm max-w-none
+      prose-headings:text-white
+      prose-h1:text-xl prose-h1:font-bold prose-h1:border-b prose-h1:border-gray-700 prose-h1:pb-2 prose-h1:mb-4
+      prose-h2:text-lg prose-h2:font-semibold prose-h2:mt-6 prose-h2:mb-3
+      prose-h3:text-base prose-h3:font-medium prose-h3:text-gray-200
+      prose-p:text-gray-300 prose-p:leading-relaxed
+      prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
+      prose-strong:text-white
+      prose-code:text-blue-300 prose-code:bg-gray-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+      prose-table:border-collapse
+      prose-th:bg-gray-900 prose-th:text-gray-200 prose-th:text-left prose-th:px-3 prose-th:py-2 prose-th:border prose-th:border-gray-700 prose-th:text-sm
+      prose-td:px-3 prose-td:py-2 prose-td:border prose-td:border-gray-700 prose-td:text-sm prose-td:text-gray-300
+      prose-li:text-gray-300
+      prose-hr:border-gray-700
+      ${className}`}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Update JobDetail.tsx output modal to use ProseContainer**
+
+In `web/src/pages/JobDetail.tsx`, replace lines 1133-1143 (inside the modal content div):
+
+Replace the markdown rendering block:
+```tsx
+{viewingOutput.isJson ? (
+  <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+    {viewingOutput.content}
+  </pre>
+) : (
+  <div className="prose prose-invert prose-sm max-w-none prose-table:border-collapse prose-th:border prose-th:border-gray-600 prose-th:p-2 prose-th:bg-gray-800 prose-td:border prose-td:border-gray-700 prose-td:p-2">
+    <ReactMarkdown remarkPlugins={[remarkGfm]}>{viewingOutput.content}</ReactMarkdown>
+  </div>
+)}
+```
+
+With:
+```tsx
+{viewingOutput.isJson ? (
+  <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+    {viewingOutput.content}
+  </pre>
+) : (
+  <ProseContainer content={viewingOutput.content} />
+)}
+```
+
+Add the import at the top of the file:
+```tsx
+import ProseContainer from '../components/ProseContainer'
+```
+
+Remove the now-unused `ReactMarkdown` and `remarkGfm` imports from JobDetail.tsx (they are only used in the output modal — check that no other usage exists in the file before removing).
+
+- [ ] **Step 3: Update Projects.tsx artifact viewer to use ProseContainer**
+
+In `web/src/pages/Projects.tsx`, replace lines 579-580:
+
+```tsx
+<div className="prose prose-invert prose-sm max-w-none prose-table:border-collapse prose-th:border prose-th:border-gray-600 prose-th:p-2 prose-th:bg-gray-800 prose-td:border prose-td:border-gray-700 prose-td:p-2">
+  <ReactMarkdown remarkPlugins={[remarkGfm]}>{viewingArtifact.content}</ReactMarkdown>
+</div>
+```
+
+With:
+```tsx
+<ProseContainer content={viewingArtifact.content} />
+```
+
+Add the import and remove unused `ReactMarkdown`/`remarkGfm` imports if no other usage remains.
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/ProseContainer.tsx web/src/pages/JobDetail.tsx web/src/pages/Projects.tsx
+git commit -m "feat: Create shared ProseContainer for consistent markdown rendering
+
+Extract rich prose typography styling (headings, code, tables, lists)
+into a reusable ProseContainer component. Replaces minimal inline
+styling in JobDetail output modal and Projects artifact viewer."
+```
+
+---
+
+### Task 2: Polish Download Filenames
+
+Currently, downloads use generic filenames like `analyst_output.md`. Prefix with the project name so downloads are identifiable outside the app (e.g., `Wisconsin-Life-2WLI1209HD-analyst_output.md`).
+
+**Files:**
+- Modify: `api/routers/jobs.py:498-566`
+- Create: `tests/test_download_filename.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_download_filename.py
+"""Tests for download filename prefixing."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from pathlib import Path
+
+
+class TestDownloadFilename:
+    """Tests for project-prefixed download filenames."""
+
+    @pytest.mark.asyncio
+    async def test_download_includes_project_prefix(self, tmp_path):
+        """Download Content-Disposition includes sanitized project name prefix."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("Wisconsin Life / 2WLI1209HD", "analyst_output.md")
+        assert result == "Wisconsin-Life-2WLI1209HD-analyst_output.md"
+
+    @pytest.mark.asyncio
+    async def test_download_filename_sanitizes_special_chars(self):
+        """Special characters in project names are replaced with hyphens."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("Project: Test (v2)", "seo_output.md")
+        assert result == "Project-Test-v2-seo_output.md"
+
+    @pytest.mark.asyncio
+    async def test_download_filename_collapses_multiple_hyphens(self):
+        """Multiple consecutive hyphens are collapsed to one."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("A --- B", "formatter_output.md")
+        assert result == "A-B-formatter_output.md"
+
+    @pytest.mark.asyncio
+    async def test_non_download_has_no_disposition(self):
+        """Non-download requests don't get Content-Disposition header."""
+        # This is tested via the endpoint itself, but verifying the helper
+        # only runs when download=True is done at the integration level.
+        from api.routers.jobs import _make_download_filename
+
+        # Helper always returns a name; the router decides whether to use it
+        result = _make_download_filename("Test", "analyst_output.md")
+        assert result == "Test-analyst_output.md"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_download_filename.py -v`
+Expected: FAIL with `ImportError` (function doesn't exist yet).
+
+- [ ] **Step 3: Add the helper function and update the endpoint**
+
+In `api/routers/jobs.py`, add this helper function before `get_job_output`:
+
+```python
+import re as _re_module  # if re is not already imported (check first — it likely is for revision file matching)
+
+
+def _make_download_filename(project_name: str, filename: str) -> str:
+    """Create a download filename prefixed with sanitized project name.
+
+    Example: "Wisconsin Life / 2WLI1209HD" + "analyst_output.md"
+             → "Wisconsin-Life-2WLI1209HD-analyst_output.md"
+    """
+    # Replace non-alphanumeric chars (except hyphens/underscores/dots) with hyphens
+    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", project_name)
+    # Collapse multiple hyphens and strip leading/trailing
+    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
+    return f"{sanitized}-{filename}"
+```
+
+Then update the download block in `get_job_output` (around line 564):
+
+Replace:
+```python
+    if download:
+        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+```
+
+With:
+```python
+    if download:
+        download_name = _make_download_filename(job.project_name or "", filename)
+        headers["Content-Disposition"] = f'attachment; filename="{download_name}"'
+```
+
+Note: Check the `job` object to confirm `project_name` is available. The `get_job` function returns a row that has `project_name` — verify by reading the database model or the `get_job` function.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_download_filename.py -v`
+Expected: PASS (all 4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/routers/jobs.py tests/test_download_filename.py
+git commit -m "feat: Prefix download filenames with project name
+
+Downloads now include a sanitized project name prefix so files are
+identifiable outside the dashboard. E.g., 'Wisconsin-Life-2WLI1209HD-analyst_output.md'."
+```
+
+---
+
+### Task 3: Google Drive Service
+
+Create a backend service for uploading files to Google Drive using a service account. This is a new integration — no Google libraries exist in the project yet.
+
+**Files:**
+- Modify: `requirements.txt`
+- Create: `api/services/google_drive.py`
+- Create: `tests/test_google_drive.py`
+
+- [ ] **Step 1: Add Google dependencies to requirements.txt**
+
+Add these lines to `requirements.txt`:
+
+```
+google-api-python-client>=2.100.0
+google-auth>=2.25.0
+```
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `pip install google-api-python-client google-auth`
+
+- [ ] **Step 3: Write the failing tests**
+
+```python
+# tests/test_google_drive.py
+"""Tests for Google Drive upload service."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+
+class TestGoogleDriveService:
+    """Tests for GoogleDriveService."""
+
+    def test_is_configured_returns_false_when_no_credentials(self):
+        """Returns False when no service account credentials are available."""
+        from api.services.google_drive import GoogleDriveService
+
+        with patch("api.services.google_drive.get_secret", return_value=None):
+            service = GoogleDriveService()
+            assert service.is_configured() is False
+
+    def test_is_configured_returns_true_with_credentials(self, tmp_path):
+        """Returns True when service account JSON is available."""
+        from api.services.google_drive import GoogleDriveService
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with patch("api.services.google_drive.get_secret", return_value=creds_json):
+            service = GoogleDriveService()
+            assert service.is_configured() is True
+
+    def test_upload_file_returns_file_id_and_url(self, tmp_path):
+        """upload_file returns a dict with id and webViewLink."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test_output.md"
+        test_file.write_text("# Test Content\n\nHello world.")
+
+        mock_service = MagicMock()
+        mock_create = mock_service.files.return_value.create.return_value
+        mock_create.execute.return_value = {
+            "id": "abc123",
+            "webViewLink": "https://drive.google.com/file/d/abc123/view",
+        }
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with patch("api.services.google_drive.get_secret", return_value=creds_json), \
+             patch("api.services.google_drive.GoogleDriveService._build_service", return_value=mock_service):
+            service = GoogleDriveService()
+            result = service.upload_file(test_file, filename="test_output.md")
+
+        assert result["id"] == "abc123"
+        assert "drive.google.com" in result["webViewLink"]
+
+    def test_upload_file_uses_folder_id_when_provided(self, tmp_path):
+        """upload_file passes folder_id as parent when specified."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test_output.md"
+        test_file.write_text("# Content")
+
+        mock_service = MagicMock()
+        mock_create = mock_service.files.return_value.create.return_value
+        mock_create.execute.return_value = {"id": "abc", "webViewLink": "https://drive.google.com/file/d/abc/view"}
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with patch("api.services.google_drive.get_secret", return_value=creds_json), \
+             patch("api.services.google_drive.GoogleDriveService._build_service", return_value=mock_service):
+            service = GoogleDriveService()
+            service.upload_file(test_file, filename="output.md", folder_id="folder123")
+
+        # Verify the create call included the parent folder
+        create_call = mock_service.files.return_value.create.call_args
+        metadata = create_call.kwargs.get("body") or create_call[1].get("body")
+        assert metadata["parents"] == ["folder123"]
+
+    def test_upload_file_returns_none_when_not_configured(self, tmp_path):
+        """upload_file returns None when service is not configured."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("content")
+
+        with patch("api.services.google_drive.get_secret", return_value=None):
+            service = GoogleDriveService()
+            result = service.upload_file(test_file, filename="test.md")
+
+        assert result is None
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pytest tests/test_google_drive.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 5: Implement GoogleDriveService**
+
+```python
+# api/services/google_drive.py
+"""Google Drive upload service for Cardigan report export.
+
+Uses a Google service account for authentication. The service account
+JSON credentials are resolved through the standard secrets system
+(Docker secret file → env var → macOS Keychain).
+
+Secret key: GOOGLE_DRIVE_CREDENTIALS (JSON string of service account key)
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from api.services.secrets import get_secret
+
+logger = logging.getLogger(__name__)
+
+# Google libraries are optional — only needed when Drive export is configured
+try:
+    from google.oauth2.service_account import Credentials
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaFileUpload
+    _GOOGLE_AVAILABLE = True
+except ImportError:
+    _GOOGLE_AVAILABLE = False
+
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+class GoogleDriveService:
+    """Upload files to Google Drive using a service account."""
+
+    def __init__(self) -> None:
+        self._creds_json = get_secret("GOOGLE_DRIVE_CREDENTIALS")
+
+    def is_configured(self) -> bool:
+        """Check if Google Drive credentials are available."""
+        return _GOOGLE_AVAILABLE and self._creds_json is not None
+
+    def _build_service(self):
+        """Build the Google Drive API service client."""
+        if not self._creds_json:
+            return None
+        info = json.loads(self._creds_json)
+        creds = Credentials.from_service_account_info(info, scopes=SCOPES)
+        return build("drive", "v3", credentials=creds)
+
+    def upload_file(
+        self,
+        file_path: Path,
+        filename: str,
+        folder_id: Optional[str] = None,
+        mime_type: str = "text/markdown",
+    ) -> Optional[dict]:
+        """Upload a file to Google Drive.
+
+        Args:
+            file_path: Local path to the file to upload.
+            filename: Name for the file in Google Drive.
+            folder_id: Optional Drive folder ID to upload into.
+            mime_type: MIME type of the file.
+
+        Returns:
+            Dict with 'id' and 'webViewLink' on success, None on failure.
+        """
+        if not self.is_configured():
+            logger.warning("Google Drive not configured — skipping upload")
+            return None
+
+        try:
+            service = self._build_service()
+            if service is None:
+                return None
+
+            metadata: dict = {"name": filename}
+            if folder_id:
+                metadata["parents"] = [folder_id]
+
+            media = MediaFileUpload(str(file_path), mimetype=mime_type)
+            result = (
+                service.files()
+                .create(body=metadata, media_body=media, fields="id,webViewLink")
+                .execute()
+            )
+            logger.info("Uploaded %s to Google Drive: %s", filename, result.get("id"))
+            return result
+        except Exception:
+            logger.exception("Failed to upload %s to Google Drive", filename)
+            return None
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_google_drive.py -v`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add requirements.txt api/services/google_drive.py tests/test_google_drive.py
+git commit -m "feat: Add Google Drive upload service
+
+Service account-based Google Drive integration for report export.
+Credentials resolved via standard secrets system (Docker secret / env / Keychain).
+Graceful degradation when google libraries not installed or credentials missing."
+```
+
+---
+
+### Task 4: Export API Router
+
+Create the API endpoints for Google Drive upload and configuration status.
+
+**Files:**
+- Create: `api/routers/export.py`
+- Modify: `api/main.py` (register the router)
+- Create: `tests/test_export_router.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_export_router.py
+"""Tests for export API endpoints."""
+
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from pathlib import Path
+
+
+class TestExportStatus:
+    """Tests for GET /api/export/status."""
+
+    @pytest.mark.asyncio
+    async def test_status_returns_configured_false_when_no_creds(self, client):
+        """Returns google_drive.configured=false when no credentials."""
+        with patch("api.routers.export.GoogleDriveService") as MockService:
+            MockService.return_value.is_configured.return_value = False
+            response = client.get("/api/export/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["google_drive"]["configured"] is False
+
+    @pytest.mark.asyncio
+    async def test_status_returns_configured_true_with_creds(self, client):
+        """Returns google_drive.configured=true when credentials exist."""
+        with patch("api.routers.export.GoogleDriveService") as MockService:
+            MockService.return_value.is_configured.return_value = True
+            response = client.get("/api/export/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["google_drive"]["configured"] is True
+
+
+class TestExportUpload:
+    """Tests for POST /api/export/google-drive/{job_id}/{filename}."""
+
+    @pytest.mark.asyncio
+    async def test_upload_returns_404_for_missing_job(self, client):
+        """Returns 404 when job doesn't exist."""
+        with patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=None):
+            response = client.post("/api/export/google-drive/999/analyst_output.md")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_upload_returns_503_when_not_configured(self, client):
+        """Returns 503 when Google Drive is not configured."""
+        mock_job = MagicMock()
+        mock_job.project_name = "Test Project"
+        mock_job.project_path = "/data/output/test"
+
+        with patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=mock_job), \
+             patch("api.routers.export.GoogleDriveService") as MockService:
+            MockService.return_value.is_configured.return_value = False
+            response = client.post("/api/export/google-drive/1/analyst_output.md")
+
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_upload_success_returns_drive_link(self, client, tmp_path):
+        """Successful upload returns the Google Drive link."""
+        mock_job = MagicMock()
+        mock_job.project_name = "Test Project"
+        mock_job.project_path = str(tmp_path)
+
+        # Create the output file
+        (tmp_path / "analyst_output.md").write_text("# Analysis\n\nContent here.")
+
+        with patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=mock_job), \
+             patch("api.routers.export.GoogleDriveService") as MockService, \
+             patch("api.routers.export.Path") as MockPath, \
+             patch("os.getenv", return_value=str(tmp_path)):
+            MockService.return_value.is_configured.return_value = True
+            MockService.return_value.upload_file.return_value = {
+                "id": "drive123",
+                "webViewLink": "https://drive.google.com/file/d/drive123/view",
+            }
+            # Let Path resolve work normally for the file
+            MockPath.side_effect = Path
+            response = client.post("/api/export/google-drive/1/analyst_output.md")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["drive_url"] == "https://drive.google.com/file/d/drive123/view"
+```
+
+Note: The `client` fixture is the standard `TestClient` from FastAPI. Check `conftest.py` for the existing fixture. If it doesn't exist, the tests will need a local fixture — adapt accordingly.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_export_router.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement the export router**
+
+```python
+# api/routers/export.py
+"""Export API endpoints for uploading reports to external services."""
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from api.services.database import get_job
+from api.services.google_drive import GoogleDriveService
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+# Same allowlist as jobs.py — keep in sync
+_ALLOWED_FILES = {
+    "analyst_output.md",
+    "formatter_output.md",
+    "seo_output.md",
+    "validator_output.md",
+    "timestamp_output.md",
+    "copy_editor_output.md",
+    "recovery_analysis.md",
+}
+
+
+class ExportStatusResponse(BaseModel):
+    google_drive: dict
+
+
+class DriveUploadResponse(BaseModel):
+    drive_url: str
+    file_id: str
+
+
+def _make_export_filename(project_name: str, filename: str) -> str:
+    """Create an export filename prefixed with sanitized project name.
+
+    Same logic as _make_download_filename in jobs.py — duplicated here
+    to keep routers self-contained. If the logic diverges, extract to a util.
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9._-]+", "-", project_name)
+    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
+    return f"{sanitized}-{filename}"
+
+
+@router.get("/status", response_model=ExportStatusResponse)
+async def get_export_status():
+    """Check which export services are configured and available."""
+    drive = GoogleDriveService()
+    return ExportStatusResponse(
+        google_drive={
+            "configured": drive.is_configured(),
+        }
+    )
+
+
+@router.post("/google-drive/{job_id}/{filename}", response_model=DriveUploadResponse)
+async def upload_to_google_drive(
+    job_id: int,
+    filename: str,
+    folder_id: Optional[str] = Query(default=None, description="Google Drive folder ID"),
+):
+    """Upload a job output file to Google Drive.
+
+    Args:
+        job_id: Job whose output to upload.
+        filename: Output filename (e.g., analyst_output.md).
+        folder_id: Optional Google Drive folder to upload into.
+    """
+    # Verify job exists
+    job = await get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    # Validate filename
+    is_revision = bool(re.match(r"^copy_revision_v\d+\.md$", filename))
+    if filename not in _ALLOWED_FILES and not is_revision:
+        raise HTTPException(status_code=400, detail=f"Invalid filename: {filename}")
+
+    # Check Drive is configured
+    drive = GoogleDriveService()
+    if not drive.is_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Google Drive export is not configured. Add GOOGLE_DRIVE_CREDENTIALS secret.",
+        )
+
+    # Locate the file
+    if not job.project_path:
+        raise HTTPException(status_code=404, detail="Job has no output directory")
+
+    output_dir = Path(os.getenv("OUTPUT_DIR", "OUTPUT")).resolve()
+    file_path = (Path(job.project_path) / filename).resolve()
+
+    if not file_path.is_relative_to(output_dir):
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail=f"Output file '{filename}' not found")
+
+    # Upload
+    drive_filename = _make_export_filename(job.project_name or f"job-{job_id}", filename)
+    result = drive.upload_file(file_path, filename=drive_filename, folder_id=folder_id)
+
+    if result is None:
+        raise HTTPException(status_code=500, detail="Upload to Google Drive failed")
+
+    return DriveUploadResponse(
+        drive_url=result["webViewLink"],
+        file_id=result["id"],
+    )
+```
+
+- [ ] **Step 4: Register the router in main.py**
+
+In `api/main.py`, find the existing router includes (look for `app.include_router`) and add:
+
+```python
+from api.routers.export import router as export_router
+app.include_router(export_router, prefix="/api")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_export_router.py -v`
+Expected: PASS (or adapt test fixtures to match the project's test setup).
+
+Note: If the project uses a different test client pattern, adapt the tests. Check `tests/conftest.py` for existing fixtures. The tests may need to use `from fastapi.testclient import TestClient` with the app directly if no `client` fixture exists.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routers/export.py api/main.py tests/test_export_router.py
+git commit -m "feat: Add export API router for Google Drive uploads
+
+POST /api/export/google-drive/{job_id}/{filename} uploads a job output
+to Google Drive. GET /api/export/status reports configuration state.
+Filename is prefixed with project name for Drive organization."
+```
+
+---
+
+### Task 5: Google Drive Upload Button in Frontend
+
+Add a Google Drive upload button next to each output file's download button in JobDetail. Only shown when Google Drive is configured.
+
+**Files:**
+- Modify: `web/src/pages/JobDetail.tsx`
+
+- [ ] **Step 1: Add state for Drive configuration and upload status**
+
+In JobDetail.tsx, add state variables near the existing state declarations (around line 176):
+
+```tsx
+const [driveConfigured, setDriveConfigured] = useState(false)
+const [uploadingToDrive, setUploadingToDrive] = useState<string | null>(null)
+```
+
+- [ ] **Step 2: Add useEffect to check Drive configuration**
+
+Add a useEffect after the existing availableModels fetch (around line 283):
+
+```tsx
+useEffect(() => {
+  fetch('/api/export/status')
+    .then(res => res.json())
+    .then(data => {
+      setDriveConfigured(data.google_drive?.configured || false)
+    })
+    .catch(() => {})
+}, [])
+```
+
+- [ ] **Step 3: Add the upload handler function**
+
+Add this function after `handleKeywordUpload` (around line 410):
+
+```tsx
+const handleDriveUpload = async (key: string, filename: string) => {
+  setUploadingToDrive(key)
+  try {
+    const response = await fetch(`/api/export/google-drive/${id}/${filename}`, {
+      method: 'POST',
+    })
+    if (response.ok) {
+      const data = await response.json()
+      toast('Uploaded to Google Drive', 'success')
+      // Open the Drive link in a new tab
+      window.open(data.drive_url, '_blank')
+    } else {
+      const data = await response.json()
+      toast(data.detail || 'Failed to upload to Google Drive', 'error')
+    }
+  } catch (err) {
+    console.error('Failed to upload to Drive:', err)
+    toast('Failed to upload to Google Drive', 'error')
+  } finally {
+    setUploadingToDrive(null)
+  }
+}
+```
+
+- [ ] **Step 4: Add the Drive upload button to output file cards**
+
+In the output files grid (around line 831-868), after the retry button's closing `</button>` and before the closing `</div>` of each card, add the Google Drive button conditionally:
+
+```tsx
+{driveConfigured && (
+  <button
+    onClick={() => handleDriveUpload(key, actualFilename)}
+    disabled={uploadingToDrive !== null}
+    className="px-2 py-2 bg-gray-600 hover:bg-green-700 rounded-r-md text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50"
+    aria-label={`Upload ${label} to Google Drive`}
+    title="Upload to Google Drive"
+  >
+    {uploadingToDrive === key ? (
+      <span className="animate-spin">&#8635;</span>
+    ) : (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+      </svg>
+    )}
+  </button>
+)}
+```
+
+Note: When the Drive button is present, the retry button should NOT have `rounded-r-md` — only the last button in the row should be rounded on the right. Update the retry button's className: remove `rounded-r-md` and add it conditionally:
+
+```tsx
+className={`px-2 py-2 bg-gray-600 hover:bg-orange-600 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50`}
+```
+
+- [ ] **Step 5: Verify the build compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/pages/JobDetail.tsx
+git commit -m "feat: Add Google Drive upload button to output files
+
+Each output file card shows a cloud upload button when Google Drive
+is configured. Uploads the file with project-prefixed name and opens
+the Drive link in a new tab on success."
+```
+
+---
+
+### Task 6: Docker Secrets for Google Drive Credentials
+
+Add Google Drive service account credentials as an optional Docker secret.
+
+**Files:**
+- Modify: `docker-compose.yml`
+- Modify: `docker-compose.prod.yml`
+
+- [ ] **Step 1: Add secret to docker-compose.yml**
+
+In `docker-compose.yml`, add `google_drive_credentials` to the `secrets:` section at the bottom:
+
+```yaml
+secrets:
+  openrouter_api_key:
+    file: ./secrets/openrouter_api_key
+  airtable_api_key:
+    file: ./secrets/airtable_api_key
+  langfuse_public_key:
+    file: ./secrets/langfuse_public_key
+  langfuse_secret_key:
+    file: ./secrets/langfuse_secret_key
+  hf_token:
+    file: ./secrets/hf_token
+  google_drive_credentials:
+    file: ./secrets/google_drive_credentials
+```
+
+Add the secret to the `api` service's `secrets:` list:
+
+```yaml
+    secrets:
+      - openrouter_api_key
+      - airtable_api_key
+      - langfuse_public_key
+      - langfuse_secret_key
+      - google_drive_credentials
+```
+
+- [ ] **Step 2: Add secret to docker-compose.prod.yml**
+
+Same changes as dev compose: add `google_drive_credentials` to the global `secrets:` definition and to the `api` service's `secrets:` list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml docker-compose.prod.yml
+git commit -m "feat: Add Google Drive credentials as optional Docker secret
+
+The google_drive_credentials secret contains the service account JSON.
+Optional — Drive export gracefully degrades when not configured."
+```
+
+---
+
+### Task 7: Export Settings Tab
+
+Add an "Export" tab to the Settings page showing Google Drive configuration status and providing a folder ID input.
+
+**Files:**
+- Modify: `web/src/pages/Settings.tsx`
+
+- [ ] **Step 1: Add 'export' to the tab type and TABS array**
+
+In `Settings.tsx`, update the `TabId` type (line 44):
+
+```tsx
+type TabId = 'agents' | 'worker' | 'ingest' | 'system' | 'accessibility' | 'export'
+```
+
+Add the tab to the `TABS` array (line 46, after 'system' and before 'accessibility'):
+
+```tsx
+{ id: 'export', label: 'Export', icon: '📤' },
+```
+
+- [ ] **Step 2: Add state for export config**
+
+Add near the existing state declarations:
+
+```tsx
+const [exportStatus, setExportStatus] = useState<{ google_drive: { configured: boolean } } | null>(null)
+const [driveFolderId, setDriveFolderId] = useState('')
+```
+
+- [ ] **Step 3: Add useEffect to fetch export status**
+
+```tsx
+useEffect(() => {
+  if (activeTab === 'export') {
+    fetch('/api/export/status')
+      .then(res => res.json())
+      .then(setExportStatus)
+      .catch(() => {})
+  }
+}, [activeTab])
+```
+
+- [ ] **Step 4: Add the Export tab panel**
+
+Add a new section in the tab panel rendering (follow the pattern of existing tabs — look for `{activeTab === 'system' && (` and add after the accessibility tab block):
+
+```tsx
+{activeTab === 'export' && (
+  <div className="space-y-6">
+    <div>
+      <h2 className="text-xl font-semibold text-white mb-4">Export Settings</h2>
+
+      {/* Google Drive Status */}
+      <div className="bg-gray-800 rounded-lg border border-gray-700 p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-medium text-white">Google Drive</h3>
+          {exportStatus ? (
+            <span className={`px-2 py-1 rounded text-xs font-medium ${
+              exportStatus.google_drive.configured
+                ? 'bg-green-900/50 text-green-400 border border-green-800'
+                : 'bg-gray-700 text-gray-400'
+            }`}>
+              {exportStatus.google_drive.configured ? 'Connected' : 'Not Configured'}
+            </span>
+          ) : (
+            <span className="text-gray-500 text-sm">Loading...</span>
+          )}
+        </div>
+
+        {exportStatus?.google_drive.configured ? (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-400">
+              Google Drive export is active. Output files can be uploaded directly from job detail pages.
+            </p>
+            <div>
+              <label htmlFor="drive-folder-id" className="block text-sm text-gray-300 mb-1">
+                Default folder ID <span className="text-gray-500">(optional)</span>
+              </label>
+              <input
+                id="drive-folder-id"
+                type="text"
+                value={driveFolderId}
+                onChange={(e) => setDriveFolderId(e.target.value)}
+                placeholder="e.g., 1a2b3c4d5e6f..."
+                className="w-full bg-gray-900 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Find this in the Drive folder URL after /folders/. Leave empty to upload to the service account's root.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-sm text-gray-400">
+              To enable Google Drive export, add a service account credentials JSON file as the <code className="text-blue-300 bg-gray-900 px-1 rounded text-xs">GOOGLE_DRIVE_CREDENTIALS</code> secret.
+            </p>
+            <p className="text-sm text-gray-500">
+              See the project documentation for setup instructions.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+)}
+```
+
+Note: The `driveFolderId` is stored in component state for now. A future enhancement could persist this to a config file via an API endpoint, but for Sprint 6, the Drive upload button on JobDetail.tsx can read a URL query parameter or we can add a localStorage persistence. For simplicity, store in localStorage:
+
+Add to the `driveFolderId` state initialization:
+```tsx
+const [driveFolderId, setDriveFolderId] = useState(() => localStorage.getItem('cardigan_drive_folder_id') || '')
+```
+
+And add a save effect:
+```tsx
+useEffect(() => {
+  if (driveFolderId) {
+    localStorage.setItem('cardigan_drive_folder_id', driveFolderId)
+  } else {
+    localStorage.removeItem('cardigan_drive_folder_id')
+  }
+}, [driveFolderId])
+```
+
+- [ ] **Step 5: Pass folder_id in the Drive upload request (JobDetail.tsx)**
+
+Back in `web/src/pages/JobDetail.tsx`, update the `handleDriveUpload` function to include the folder ID from localStorage:
+
+```tsx
+const handleDriveUpload = async (key: string, filename: string) => {
+  setUploadingToDrive(key)
+  try {
+    const folderId = localStorage.getItem('cardigan_drive_folder_id') || ''
+    const params = folderId ? `?folder_id=${encodeURIComponent(folderId)}` : ''
+    const response = await fetch(`/api/export/google-drive/${id}/${filename}${params}`, {
+      method: 'POST',
+    })
+    // ... rest unchanged
+```
+
+- [ ] **Step 6: Verify the build compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/Settings.tsx web/src/pages/JobDetail.tsx
+git commit -m "feat: Add Export settings tab with Google Drive configuration
+
+Shows connection status, provides folder ID input (persisted to
+localStorage), and includes setup instructions when not configured."
+```
+
+---
+
+### Task 8: UX Polish Pass on v4.1 Elements
+
+Review and fix specific UX inconsistencies in the v4.1 elements: validation badges, retry dialog, cost breakdown table, and model picker.
+
+**Files:**
+- Modify: `web/src/pages/JobDetail.tsx`
+
+- [ ] **Step 1: Audit and list specific issues**
+
+Before making changes, run the dev server and review each v4.1 element in a browser. Use the existing job data to verify rendering. The following are known issues from the code review:
+
+1. **Validation badge alignment**: The header badge (line 509-516) uses emoji checkmarks (✓/✗) while phase-level badges (line 744-750) also use emoji. These render inconsistently across platforms. Standardize to HTML entities or SVG.
+
+2. **Retry dialog model selector**: The dropdown (line 1048-1058) shows raw model IDs from `availableModels`. The `model.name` field should already be human-readable — verify this renders well.
+
+3. **Cost breakdown table**: Previous-run rows (line 131) use `text-xs` and `text-gray-500` which may be too faint. Bump to `text-gray-400` for readability.
+
+4. **Output file grid**: Currently `grid-cols-2 md:grid-cols-4` (line 820). With the Drive button added, each card has 4 buttons (view + download + retry + drive). On small screens, this may overflow. Consider `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`.
+
+- [ ] **Step 2: Fix validation badge consistency**
+
+Replace emoji checkmarks with consistent HTML entities in the header validation badge (around line 514):
+
+Change:
+```tsx
+{job.validation_result.overall === 'pass' ? '✓ Validated' : '✗ Validation Failed'}
+```
+
+To:
+```tsx
+{job.validation_result.overall === 'pass' ? '\u2713 Validated' : '\u2717 Validation Failed'}
+```
+
+And in phase-level badges (around line 749):
+
+Change:
+```tsx
+{job.validation_result.phase_results[phase.name].status === 'pass' ? '✓ Pass' : '✗ Fail'}
+```
+
+To:
+```tsx
+{job.validation_result.phase_results[phase.name].status === 'pass' ? '\u2713 Pass' : '\u2717 Fail'}
+```
+
+- [ ] **Step 3: Improve cost breakdown readability**
+
+Update the previous-run rows in `CostBreakdownTable` (around line 131):
+
+Change `text-gray-500` to `text-gray-400` for better contrast:
+
+```tsx
+<tr key={`${phase.name}-prev-${i}`} className="text-gray-400 text-xs">
+```
+
+- [ ] **Step 4: Adjust output grid for button density**
+
+Change the output grid (line 820):
+
+```tsx
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+```
+
+- [ ] **Step 5: Verify the build compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 6: Visual verification**
+
+Start the dev server and verify:
+- Validation badges render consistently
+- Cost breakdown previous-run rows are readable
+- Output file buttons don't overflow on medium screens
+- All modals open/close correctly
+
+Run: `cd web && npm run dev`
+Then visit `http://localhost:3100` and navigate to a completed job.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/pages/JobDetail.tsx
+git commit -m "polish: UX consistency pass on v4.1 elements
+
+- Standardize validation badges to Unicode entities (cross-platform)
+- Improve cost breakdown readability (lighter text for previous runs)
+- Adjust output grid columns for button density with Drive export"
+```
+
+---
+
+### Task 9: Run Full Test Suite and Final Verification
+
+Verify all changes work together — tests pass, TypeScript compiles, and the app builds cleanly.
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run Python tests**
+
+Run: `pytest tests/ --ignore=tests/test_ingest_scanner.py -v`
+Expected: All tests pass (existing + new tests from Tasks 2-4).
+
+- [ ] **Step 2: Run TypeScript type check**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run ESLint**
+
+Run: `cd web && npx eslint . --max-warnings 0`
+Expected: No errors or warnings.
+
+- [ ] **Step 4: Build the production frontend**
+
+Run: `cd web && npm run build`
+Expected: Successful build with no errors.
+
+- [ ] **Step 5: Visual smoke test**
+
+Start both API and frontend dev servers and verify:
+1. Output viewer modal renders markdown with proper heading sizes, code styling, and table formatting
+2. Download button produces a file named with the project prefix
+3. Export tab appears in Settings (shows "Not Configured" unless you've added credentials)
+4. Google Drive buttons appear/hide correctly based on configuration
+5. Validation badges render consistently
+6. Cost breakdown table is readable
+
+- [ ] **Step 6: Commit any final fixes (if needed)**
+
+If any issues are found during verification, fix and commit them individually with descriptive messages.

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,7 @@ watchfiles>=0.21.0
 # MCP Server (for Claude Desktop integration)
 mcp>=1.27.0
 sse-starlette>=2.0.0
+
+# Google Drive integration (optional — only needed when Drive export is configured)
+google-api-python-client>=2.100.0
+google-auth>=2.25.0

--- a/tests/test_download_filename.py
+++ b/tests/test_download_filename.py
@@ -1,0 +1,33 @@
+"""Tests for download filename prefixing."""
+
+
+class TestDownloadFilename:
+    """Tests for project-prefixed download filenames."""
+
+    def test_download_includes_project_prefix(self):
+        """Download Content-Disposition includes sanitized project name prefix."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("Wisconsin Life / 2WLI1209HD", "analyst_output.md")
+        assert result == "Wisconsin-Life-2WLI1209HD-analyst_output.md"
+
+    def test_download_filename_sanitizes_special_chars(self):
+        """Special characters in project names are replaced with hyphens."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("Project: Test (v2)", "seo_output.md")
+        assert result == "Project-Test-v2-seo_output.md"
+
+    def test_download_filename_collapses_multiple_hyphens(self):
+        """Multiple consecutive hyphens are collapsed to one."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("A --- B", "formatter_output.md")
+        assert result == "A-B-formatter_output.md"
+
+    def test_non_download_has_no_disposition(self):
+        """Helper always returns a name; the router decides whether to use it."""
+        from api.routers.jobs import _make_download_filename
+
+        result = _make_download_filename("Test", "analyst_output.md")
+        assert result == "Test-analyst_output.md"

--- a/tests/test_export_router.py
+++ b/tests/test_export_router.py
@@ -1,0 +1,79 @@
+"""Tests for export API endpoints."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestExportStatus:
+    """Tests for GET /api/export/status."""
+
+    def test_status_returns_configured_false_when_no_creds(self, api_client):
+        """Returns google_drive.configured=false when no credentials."""
+        with patch("api.routers.export.GoogleDriveService") as MockService:
+            MockService.return_value.is_configured.return_value = False
+            response = api_client.get("/api/export/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["google_drive"]["configured"] is False
+
+    def test_status_returns_configured_true_with_creds(self, api_client):
+        """Returns google_drive.configured=true when credentials exist."""
+        with patch("api.routers.export.GoogleDriveService") as MockService:
+            MockService.return_value.is_configured.return_value = True
+            response = api_client.get("/api/export/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["google_drive"]["configured"] is True
+
+
+class TestExportUpload:
+    """Tests for POST /api/export/google-drive/{job_id}/{filename}."""
+
+    def test_upload_returns_404_for_missing_job(self, api_client):
+        """Returns 404 when job doesn't exist."""
+        with patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=None):
+            response = api_client.post("/api/export/google-drive/999/analyst_output.md")
+        assert response.status_code == 404
+
+    def test_upload_returns_503_when_not_configured(self, api_client):
+        """Returns 503 when Google Drive is not configured."""
+        mock_job = MagicMock()
+        mock_job.project_name = "Test Project"
+        mock_job.project_path = "/data/output/test"
+
+        with (
+            patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=mock_job),
+            patch("api.routers.export.GoogleDriveService") as MockService,
+        ):
+            MockService.return_value.is_configured.return_value = False
+            response = api_client.post("/api/export/google-drive/1/analyst_output.md")
+
+        assert response.status_code == 503
+
+    def test_upload_returns_400_for_invalid_filename(self, api_client):
+        """Returns 400 for filenames not in the allowlist."""
+        mock_job = MagicMock()
+        mock_job.project_name = "Test Project"
+        mock_job.project_path = "/data/output/test"
+
+        with patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=mock_job):
+            response = api_client.post("/api/export/google-drive/1/malicious_script.sh")
+
+        assert response.status_code == 400
+
+    def test_upload_accepts_copy_revision_filename(self, api_client):
+        """copy_revision_vN.md filenames pass the allowlist check."""
+        mock_job = MagicMock()
+        mock_job.project_name = "Test Project"
+        mock_job.project_path = "/data/output/test"
+
+        with (
+            patch("api.routers.export.get_job", new_callable=AsyncMock, return_value=mock_job),
+            patch("api.routers.export.GoogleDriveService") as MockService,
+        ):
+            MockService.return_value.is_configured.return_value = False
+            response = api_client.post("/api/export/google-drive/1/copy_revision_v3.md")
+
+        # 503 means we passed the filename check (Drive not configured)
+        assert response.status_code == 503

--- a/tests/test_google_drive.py
+++ b/tests/test_google_drive.py
@@ -1,0 +1,86 @@
+"""Tests for Google Drive upload service."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestGoogleDriveService:
+    """Tests for GoogleDriveService."""
+
+    def test_is_configured_returns_false_when_no_credentials(self):
+        """Returns False when no service account credentials are available."""
+        from api.services.google_drive import GoogleDriveService
+
+        with patch("api.services.google_drive.get_secret", return_value=None):
+            service = GoogleDriveService()
+            assert service.is_configured() is False
+
+    def test_is_configured_returns_true_with_credentials(self):
+        """Returns True when service account JSON is available."""
+        from api.services.google_drive import GoogleDriveService
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with patch("api.services.google_drive.get_secret", return_value=creds_json):
+            service = GoogleDriveService()
+            assert service.is_configured() is True
+
+    def test_upload_file_returns_file_id_and_url(self, tmp_path):
+        """upload_file returns a dict with id and webViewLink."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test_output.md"
+        test_file.write_text("# Test Content\n\nHello world.")
+
+        mock_service = MagicMock()
+        mock_create = mock_service.files.return_value.create.return_value
+        mock_create.execute.return_value = {
+            "id": "abc123",
+            "webViewLink": "https://drive.google.com/file/d/abc123/view",
+        }
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with (
+            patch("api.services.google_drive.get_secret", return_value=creds_json),
+            patch("api.services.google_drive.GoogleDriveService._build_service", return_value=mock_service),
+        ):
+            service = GoogleDriveService()
+            result = service.upload_file(test_file, filename="test_output.md")
+
+        assert result["id"] == "abc123"
+        assert "drive.google.com" in result["webViewLink"]
+
+    def test_upload_file_uses_folder_id_when_provided(self, tmp_path):
+        """upload_file passes folder_id as parent when specified."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test_output.md"
+        test_file.write_text("# Content")
+
+        mock_service = MagicMock()
+        mock_create = mock_service.files.return_value.create.return_value
+        mock_create.execute.return_value = {"id": "abc", "webViewLink": "https://drive.google.com/file/d/abc/view"}
+
+        creds_json = '{"type": "service_account", "project_id": "test"}'
+        with (
+            patch("api.services.google_drive.get_secret", return_value=creds_json),
+            patch("api.services.google_drive.GoogleDriveService._build_service", return_value=mock_service),
+        ):
+            service = GoogleDriveService()
+            service.upload_file(test_file, filename="output.md", folder_id="folder123")
+
+        # Verify the create call included the parent folder
+        create_call = mock_service.files.return_value.create.call_args
+        metadata = create_call.kwargs.get("body") or create_call[1].get("body")
+        assert metadata["parents"] == ["folder123"]
+
+    def test_upload_file_returns_none_when_not_configured(self, tmp_path):
+        """upload_file returns None when service is not configured."""
+        from api.services.google_drive import GoogleDriveService
+
+        test_file = tmp_path / "test.md"
+        test_file.write_text("content")
+
+        with patch("api.services.google_drive.get_secret", return_value=None):
+            service = GoogleDriveService()
+            result = service.upload_file(test_file, filename="test.md")
+
+        assert result is None

--- a/web/src/components/ProseContainer.tsx
+++ b/web/src/components/ProseContainer.tsx
@@ -1,0 +1,30 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface ProseContainerProps {
+  content: string
+  className?: string
+}
+
+export default function ProseContainer({ content, className = '' }: ProseContainerProps) {
+  return (
+    <div className={`prose prose-invert prose-sm max-w-none
+      prose-headings:text-white
+      prose-h1:text-xl prose-h1:font-bold prose-h1:border-b prose-h1:border-gray-700 prose-h1:pb-2 prose-h1:mb-4
+      prose-h2:text-lg prose-h2:font-semibold prose-h2:mt-6 prose-h2:mb-3
+      prose-h3:text-base prose-h3:font-medium prose-h3:text-gray-200
+      prose-p:text-gray-300 prose-p:leading-relaxed
+      prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
+      prose-strong:text-white
+      prose-code:text-blue-300 prose-code:bg-gray-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+      prose-table:border-collapse
+      prose-th:bg-gray-900 prose-th:text-gray-200 prose-th:text-left prose-th:px-3 prose-th:py-2 prose-th:border prose-th:border-gray-700 prose-th:text-sm
+      prose-td:px-3 prose-td:py-2 prose-td:border prose-td:border-gray-700 prose-td:text-sm prose-td:text-gray-300
+      prose-li:text-gray-300
+      prose-hr:border-gray-700
+      ${className}`}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  )
+}

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useState, useRef, Fragment } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { useFocusTrap } from '../hooks/useFocusTrap'
+import ProseContainer from '../components/ProseContainer'
 import { useToast } from '../components/ui/Toast'
 import { Skeleton } from '../components/ui/Skeleton'
 import { formatRelativeTime, formatTimestamp, formatDuration } from '../utils/formatTime'
@@ -128,7 +127,7 @@ function CostBreakdownTable({ phases }: { phases: JobPhase[] }) {
           {phasesWithCost.map(phase => (
             <Fragment key={phase.name}>
               {phase.previous_runs?.map((run, i) => (
-                <tr key={`${phase.name}-prev-${i}`} className="text-gray-500 text-xs">
+                <tr key={`${phase.name}-prev-${i}`} className="text-gray-400 text-xs">
                   <td className="py-1 pl-4">{phase.name} (attempt {i + 1})</td>
                   <td className="py-1 font-mono">{run.model?.split('/').pop() || '-'}</td>
                   <td className="py-1 text-right font-mono">{run.input_tokens?.toLocaleString() || '-'}</td>
@@ -176,6 +175,8 @@ export default function JobDetail() {
   const [availableModels, setAvailableModels] = useState<{id: string, name: string}[]>([])
   const [showScreengrabs, setShowScreengrabs] = useState(false)
   const [hasScreengrabs, setHasScreengrabs] = useState(false)
+  const [driveConfigured, setDriveConfigured] = useState(false)
+  const [uploadingToDrive, setUploadingToDrive] = useState<string | null>(null)
   const [keywordReports, setKeywordReports] = useState<Array<{ filename: string; version: number; uploaded_at?: string }>>([])
   const [keywordUploading, setKeywordUploading] = useState(false)
   const keywordInputRef = useRef<HTMLInputElement | null>(null)
@@ -279,6 +280,15 @@ export default function JobDetail() {
       .then(res => res.json())
       .then(data => {
         setAvailableModels(data.available_models || [])
+      })
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    fetch('/api/export/status')
+      .then(res => res.json())
+      .then(data => {
+        setDriveConfigured(data.google_drive?.configured || false)
       })
       .catch(() => {})
   }, [])
@@ -410,6 +420,30 @@ export default function JobDetail() {
     }
   }
 
+  const handleDriveUpload = async (key: string, filename: string) => {
+    setUploadingToDrive(key)
+    try {
+      const folderId = localStorage.getItem('cardigan_drive_folder_id') || ''
+      const params = folderId ? `?folder_id=${encodeURIComponent(folderId)}` : ''
+      const response = await fetch(`/api/export/google-drive/${id}/${filename}${params}`, {
+        method: 'POST',
+      })
+      if (response.ok) {
+        const data = await response.json()
+        toast('Uploaded to Google Drive', 'success')
+        window.open(data.drive_url, '_blank')
+      } else {
+        const data = await response.json()
+        toast(data.detail || 'Failed to upload to Google Drive', 'error')
+      }
+    } catch (err) {
+      console.error('Failed to upload to Drive:', err)
+      toast('Failed to upload to Google Drive', 'error')
+    } finally {
+      setUploadingToDrive(null)
+    }
+  }
+
   const closeModal = () => {
     setViewingOutput(null)
     // Return focus to trigger button
@@ -511,7 +545,7 @@ export default function JobDetail() {
                   ? 'bg-green-900/50 text-green-400 border border-green-800'
                   : 'bg-red-900/50 text-red-400 border border-red-800'
               }`}>
-                {job.validation_result.overall === 'pass' ? '✓ Validated' : '✗ Validation Failed'}
+                {job.validation_result.overall === 'pass' ? '\u2713 Validated' : '\u2717 Validation Failed'}
               </span>
             )}
           </div>
@@ -746,7 +780,7 @@ export default function JobDetail() {
                           ? 'bg-green-900/30 text-green-400'
                           : 'bg-red-900/30 text-red-400'
                       }`}>
-                        {job.validation_result.phase_results[phase.name].status === 'pass' ? '✓ Pass' : '✗ Fail'}
+                        {job.validation_result.phase_results[phase.name].status === 'pass' ? '\u2713 Pass' : '\u2717 Fail'}
                       </span>
                     )}
                     {phase.model && (
@@ -817,7 +851,7 @@ export default function JobDetail() {
           <h2 className="text-lg font-medium text-white mb-4">
             Output Files
           </h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {Object.entries(job.outputs).map(([key, filename]) => {
               const fileInfo = OUTPUT_FILES[key]
               if (!fileInfo || !filename) return null
@@ -853,7 +887,7 @@ export default function JobDetail() {
                   <button
                     onClick={() => openRetryModal(key, label)}
                     disabled={isRetrying || retryingPhase !== null}
-                    className="px-2 py-2 bg-gray-600 hover:bg-orange-600 rounded-r-md text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50"
+                    className={`px-2 py-2 bg-gray-600 hover:bg-orange-600 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50`}
                     aria-label={`Retry ${label}`}
                     title={`Retry this phase`}
                   >
@@ -863,6 +897,23 @@ export default function JobDetail() {
                       <span>&#8635;</span>
                     )}
                   </button>
+                  {driveConfigured && (
+                    <button
+                      onClick={() => handleDriveUpload(key, actualFilename)}
+                      disabled={uploadingToDrive !== null}
+                      className="px-2 py-2 bg-gray-600 hover:bg-green-700 rounded-r-md text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50"
+                      aria-label={`Upload ${label} to Google Drive`}
+                      title="Upload to Google Drive"
+                    >
+                      {uploadingToDrive === key ? (
+                        <span className="animate-spin">&#8635;</span>
+                      ) : (
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                        </svg>
+                      )}
+                    </button>
+                  )}
                 </div>
               )
             })}
@@ -1136,9 +1187,7 @@ export default function JobDetail() {
                   {viewingOutput.content}
                 </pre>
               ) : (
-                <div className="prose prose-invert prose-sm max-w-none prose-table:border-collapse prose-th:border prose-th:border-gray-600 prose-th:p-2 prose-th:bg-gray-800 prose-td:border prose-td:border-gray-700 prose-td:p-2">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{viewingOutput.content}</ReactMarkdown>
-                </div>
+                <ProseContainer content={viewingOutput.content} />
               )}
             </div>
           </div>

--- a/web/src/pages/Projects.tsx
+++ b/web/src/pages/Projects.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { useFocusTrap } from '../hooks/useFocusTrap'
+import ProseContainer from '../components/ProseContainer'
 import { formatRelativeTime, formatTimestamp } from '../utils/formatTime'
 import { ARTIFACT_LABELS } from '../utils/artifactLabels'
 import ScreengrabsBox from '../components/ScreengrabsBox'
@@ -576,9 +575,7 @@ export default function Projects() {
                   {JSON.stringify(JSON.parse(viewingArtifact.content), null, 2)}
                 </pre>
               ) : (
-                <div className="prose prose-invert prose-sm max-w-none prose-table:border-collapse prose-th:border prose-th:border-gray-600 prose-th:p-2 prose-th:bg-gray-800 prose-td:border prose-td:border-gray-700 prose-td:p-2">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{viewingArtifact.content}</ReactMarkdown>
-                </div>
+                <ProseContainer content={viewingArtifact.content} />
               )}
             </div>
           </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -41,13 +41,14 @@ interface IngestConfigUpdate {
   scan_time?: string  // "HH:MM" format
 }
 
-type TabId = 'agents' | 'worker' | 'ingest' | 'system' | 'accessibility'
+type TabId = 'agents' | 'worker' | 'ingest' | 'system' | 'export' | 'accessibility'
 
 const TABS: { id: TabId; label: string; icon: string }[] = [
   { id: 'agents', label: 'Agents', icon: '🤖' },
   { id: 'worker', label: 'Worker', icon: '⚙️' },
   { id: 'ingest', label: 'Ingest', icon: '📥' },
   { id: 'system', label: 'System', icon: '🖥️' },
+  { id: 'export', label: 'Export', icon: '📤' },
   { id: 'accessibility', label: 'Accessibility', icon: '♿' },
 ]
 
@@ -74,6 +75,8 @@ export default function Settings() {
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<TabId>('agents')
+  const [exportStatus, setExportStatus] = useState<{ google_drive: { configured: boolean } } | null>(null)
+  const [driveFolderId, setDriveFolderId] = useState(() => localStorage.getItem('cardigan_drive_folder_id') || '')
 
   // Track unsaved changes
   const [pendingPhaseModels, setPendingPhaseModels] = useState<Record<string, string> | null>(null)
@@ -145,6 +148,23 @@ export default function Settings() {
     const interval = setInterval(fetchSystemStatus, 5000)
     return () => clearInterval(interval)
   }, [activeTab, fetchSystemStatus])
+
+  useEffect(() => {
+    if (activeTab === 'export') {
+      fetch('/api/export/status')
+        .then(res => res.json())
+        .then(setExportStatus)
+        .catch(() => {})
+    }
+  }, [activeTab])
+
+  useEffect(() => {
+    if (driveFolderId) {
+      localStorage.setItem('cardigan_drive_folder_id', driveFolderId)
+    } else {
+      localStorage.removeItem('cardigan_drive_folder_id')
+    }
+  }, [driveFolderId])
 
   const handleRefreshModels = async () => {
     try {
@@ -810,6 +830,65 @@ export default function Settings() {
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* EXPORT TAB */}
+        {activeTab === 'export' && (
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold text-white mb-4">Export Settings</h2>
+
+              <div className="bg-gray-800 rounded-lg border border-gray-700 p-4 space-y-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-medium text-white">Google Drive</h3>
+                  {exportStatus ? (
+                    <span className={`px-2 py-1 rounded text-xs font-medium ${
+                      exportStatus.google_drive.configured
+                        ? 'bg-green-900/50 text-green-400 border border-green-800'
+                        : 'bg-gray-700 text-gray-400'
+                    }`}>
+                      {exportStatus.google_drive.configured ? 'Connected' : 'Not Configured'}
+                    </span>
+                  ) : (
+                    <span className="text-gray-500 text-sm">Loading...</span>
+                  )}
+                </div>
+
+                {exportStatus?.google_drive.configured ? (
+                  <div className="space-y-3">
+                    <p className="text-sm text-gray-400">
+                      Google Drive export is active. Output files can be uploaded directly from job detail pages.
+                    </p>
+                    <div>
+                      <label htmlFor="drive-folder-id" className="block text-sm text-gray-300 mb-1">
+                        Default folder ID <span className="text-gray-500">(optional)</span>
+                      </label>
+                      <input
+                        id="drive-folder-id"
+                        type="text"
+                        value={driveFolderId}
+                        onChange={(e) => setDriveFolderId(e.target.value)}
+                        placeholder="e.g., 1a2b3c4d5e6f..."
+                        className="w-full bg-gray-900 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
+                      />
+                      <p className="mt-1 text-xs text-gray-500">
+                        Find this in the Drive folder URL after /folders/. Leave empty to upload to the service account's root.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <p className="text-sm text-gray-400">
+                      To enable Google Drive export, add a service account credentials JSON file as the <code className="text-blue-300 bg-gray-900 px-1 rounded text-xs">GOOGLE_DRIVE_CREDENTIALS</code> secret.
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      See the project documentation for setup instructions.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Stacked on #150 (Sprint 5 rebased). Final sprint in the v4.1 chain. Will cascade-retarget as earlier sprints land.

Pure increment patch applied cleanly with no conflicts.

## What's new (over Sprint 5)

- **ProseContainer** — shared markdown rendering component (headings, code blocks, tables, lists) for output/artifact viewer modals
- **Download polish** — files prefixed with project name (e.g., \`Wisconsin-Life-2WLI1209HD-analyst_output.md\`)
- **Google Drive export** — service account upload integration: backend service, API router (\`/api/export/status\`, \`/api/export/google-drive/{job_id}/{filename}\`), upload buttons on output cards, Export tab in Settings, Docker secrets support, graceful degradation
- **UX consistency** — validation badges standardized to Unicode, cost breakdown contrast improved, output grid responsive tweaks

## Diff

+1781 / -18 across 15 files (1202 lines are the implementation plan doc; real code is ~580 lines).

## ⚠️ Pre-merge gate

Per the original PR #109 description and saved memory \`project_v41_sprint_prs\`, this sprint requires **visual review with \`/impeccable\` tools against a running test container** (tracked as issue #112). The gate still applies — do not merge until visual review is complete. The test container needs:

- Seeded database with completed jobs (multiple phases, validation results, previous runs)
- API + web services running
- Google Drive credentials optional (review both configured and unconfigured states)

## Replaces

Closes #109.

## Test plan

- [x] 420 tests pass (up from Sprint 5's 405 — 15 new tests across test_download_filename, test_google_drive, test_export_router)
- [x] Python compile clean
- [ ] \`cd web && npx tsc --noEmit\` — no type errors
- [ ] \`cd web && npm run build\` — production build succeeds
- [ ] Visual review with \`/impeccable\` against running test container (per #112)
- [ ] Manual: output viewer modal renders headings, tables, code blocks correctly
- [ ] Manual: download produces project-prefixed filename
- [ ] Manual: Export tab in Settings — verify "Not Configured" + "Connected" states
- [ ] Manual: Drive upload button appears/hides based on configuration
- [ ] Manual: validation badges render consistently

## Stack — complete v4.1 chain

| Sprint | PR | Base | Status |
|---|---|---|---|
| 2 | #147 | \`main\` | rebased |
| 3 | #148 | #147 | rebased |
| 4 | #149 | #148 | rebased |
| 5 | #150 | #149 | rebased |
| 6 | this | #150 | rebased |

🤖 Generated with [Claude Code](https://claude.com/claude-code)