### PR TITLE
Feedback bundle 2026-05-21: docker reliability + LLM output hygiene + date hallucination fix

### DIFF
--- a/.claude/agents/formatter.md
+++ b/.claude/agents/formatter.md
@@ -73,6 +73,8 @@ You produce a formatted transcript saved as:
 OUTPUT/{project}/formatter_output.md
 ```
 
+> ⚠️ **CRITICAL OUTPUT FORMAT**: Return your response as raw markdown content. Do NOT wrap your entire response in ` ```markdown ... ``` ` (or any other) code fences — the surrounding fences in the structure example below are documentation, not part of the output. Do NOT include a conversational preamble such as "I'll now format the transcript..." or "Here is the formatted transcript:". Your response MUST begin directly with the `# Formatted Transcript` heading.
+
 ## Formatted Transcript Structure
 
 > ⚠️ **CRITICAL**: The header fields below use `{placeholders}`. You MUST replace these with ACTUAL VALUES from the project you're processing. NEVER copy placeholder values from the analyst's output or use example values like `2WLI1234HD` or `2024-01-15`. Use the real project name from the manifest/filename you received.

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ data/judge_archive/findings.md
 .vscode/
 *.swp
 
+# Superpowers brainstorm session runtime state (server.pid, server.log, server-stopped)
+.superpowers/
+
 # Node
 node_modules/
 web/dist/

--- a/api/services/chunking.py
+++ b/api/services/chunking.py
@@ -329,7 +329,7 @@ def merge_formatter_chunks(chunks: List[str]) -> str:
         # remains intact.
         fence_open = re.match(r"^```(?:markdown|md)?\s*\n", chunk)
         if fence_open:
-            chunk = chunk[fence_open.end():]
+            chunk = chunk[fence_open.end() :]
             chunk = re.sub(r"\n```\s*\Z", "", chunk.rstrip()) + "\n"
 
         # Strip LLM-generated model/creator attribution lines (appear at end of chunk responses)

--- a/api/services/chunking.py
+++ b/api/services/chunking.py
@@ -309,6 +309,29 @@ def merge_formatter_chunks(chunks: List[str]) -> str:
         # Strip provenance HTML comment from top (<!-- model: ... -->)
         chunk = re.sub(r"^<!--\s*model:.*?-->\s*\n?", "", chunk.strip())
 
+        # Strip LLM conversational preamble before any markdown content
+        # (e.g., "I'll now format the complete transcript..." that some models
+        # emit before their actual output). Anything before the first markdown
+        # structure marker (```, #, **, ---, or <!-- HTML comment) is treated
+        # as preamble and removed.
+        preamble_strip = re.sub(
+            r"\A(?:(?!^(?:```|#\s|\*\*|---|<!--))[^\n]*\n)+",
+            "",
+            chunk,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        chunk = preamble_strip.lstrip("\n")
+
+        # Strip wrapping ```markdown ... ``` code fence if the LLM wrapped its
+        # output. We only strip the OUTERMOST fence pair (opening at start,
+        # closing at end), so any legitimate fenced code within the dialogue
+        # remains intact.
+        fence_open = re.match(r"^```(?:markdown|md)?\s*\n", chunk)
+        if fence_open:
+            chunk = chunk[fence_open.end():]
+            chunk = re.sub(r"\n```\s*\Z", "", chunk.rstrip()) + "\n"
+
         # Strip LLM-generated model/creator attribution lines (appear at end of chunk responses)
         chunk = re.sub(
             r"^\*\*(?:Model|Creator|Agent):\*\*.*\n?",

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -1908,12 +1908,28 @@ Please format this transcript section:
                 "cost": 0,
             }
 
-    def _load_agent_prompt(self, phase_name: str) -> str:
-        """Load the system prompt for an agent phase."""
+    def _load_agent_prompt(self, phase_name: str, model: Optional[str] = None) -> str:
+        """Load the system prompt for an agent phase.
+
+        Substitutes runtime values into known placeholders:
+        - `{TODAY'S DATE in YYYY-MM-DD format}` → current UTC date (LLM has no clock).
+        - `{model name you are running as}` / `{the model you are running as}` →
+          the model identifier, if provided. Without this, the LLM would
+          hallucinate (typically a date near its training cutoff and a generic
+          model name).
+        """
         prompt_file = AGENTS_DIR / f"{phase_name}.md"
 
         if prompt_file.exists():
-            return prompt_file.read_text()
+            text = prompt_file.read_text()
+            text = text.replace(
+                "{TODAY'S DATE in YYYY-MM-DD format}",
+                datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            )
+            if model:
+                text = text.replace("{model name you are running as}", model)
+                text = text.replace("{the model you are running as}", model)
+            return text
 
         # Fallback prompts if files don't exist
         fallback_prompts = {

--- a/data/judge_archive/README.md
+++ b/data/judge_archive/README.md
@@ -1,0 +1,112 @@
+# Judge Archive — Inherited from ai-editorial-assistant
+
+This directory holds **legacy data** inherited from `ai-editorial-assistant`,
+the predecessor project that cardigan-v4 superseded. The findings document
+hallucination failure modes observed in production prompts that are
+conceptually similar to (and may overlap with) cardigan-v4's current
+prompts.
+
+> **Treat these findings as starting hypotheses, not confirmed bugs in
+> cardigan-v4.** The agents and prompts have evolved; some failure modes may
+> be fixed, others may persist, others may have new variants. Verify against
+> current cardigan-v4 behavior before acting.
+
+## Provenance
+
+A Langfuse `Hallucination` LLM-as-judge ran for ~3 months (2026-02 →
+2026-05) against an OpenRouter API key shared — inadvertently — across
+crows-nest (a content-capture service in Mark's second-brain monorepo),
+the legacy ai-editorial-assistant pipeline, and briefly cardigan-v4 itself.
+
+The judge scored every model call on a 0.0 (fully grounded) → 1.0 (fully
+fabricated) scale with free-text reasoning. After the unintended forwarding
+was discovered and fixed, the dataset was salvaged and split by source
+project. This is the editorial-assistant slice.
+
+The cardigan-v4 slice itself is empty (0 traces in this 90-day window) —
+either cardigan-v4 wasn't using the leaky key during the window, or its
+output schema didn't match the classifier. If new judge data is generated
+in the future via a properly-scoped key, that data should land here.
+
+## Window and shape
+
+- **Span**: 90 days ending 2026-05-04
+- **Editorial-assistant traces flagged at score ≥ 0.5**: 92
+- **Score distribution**:
+  - score ≥ 0.9 (extreme hallucination): 57
+  - score 0.7–0.9: 31
+  - score 0.5–0.7: 4
+
+## Top failure patterns from the legacy data
+
+### 1. Filename / Media ID missing → fabricated metadata
+
+When transcript-analyst or transcript-formatter agents received a
+transcript without a usable filename or Media ID, they wrote `**Project:**
+UNKNOWN` in the document header but proceeded to generate full
+brainstorming documents / formatted transcripts using **fabricated
+structural context** (program name, date, episode framing). The actual
+transcript content was sometimes real, but the surrounding scaffolding was
+invented to satisfy the agent's output template.
+
+**For cardigan-v4 to verify**: Does the current pipeline accept a
+transcript without metadata? If so, does it elide unknown fields cleanly,
+fail-fast, or paper over the gap with placeholder text?
+
+### 2. Input-echo failures (cross-project pattern)
+
+A non-trivial fraction of flagged traces showed the model returning the
+input **verbatim** instead of producing the requested analysis. The same
+pattern appears in crows-nest's findings (private second-brain repo) —
+suggests something at the OpenRouter integration layer rather than
+per-prompt. Worth checking whether cardigan-v4's OpenRouter calls have any
+defensive validation against this case.
+
+### 3. Judge over-flagging on transformation tasks (caveat, not bug)
+
+Some flagged Transcript Formatter outputs look correct on inspection — they
+ARE faithful, lightly-edited copies of the input transcript, which is the
+formatter's job. The Hallucination evaluator appears to flag structural
+similarity to input as "duplicate of query" in some of these cases.
+**Treat score ≥ 0.5 as evidence to read, not a verdict to act on.** The
+judge's `comment` field is the actual signal — confirm it describes a real
+problem before acting.
+
+## How to access the raw data
+
+The raw JSONL with inputs/outputs/judge reasoning lives in the **private**
+second-brain repo (it contains transcript content from PBS Wisconsin
+production work and shouldn't be committed to a public repo):
+
+```bash
+# From a machine with access to second-brain:
+cd ~/Developer/second-brain
+ls services/crows-nest/data/judge_archive/
+cat services/crows-nest/data/judge_archive/editorial_assistant_findings.jsonl
+```
+
+Each row has: `trace_id`, `timestamp`, `score_value`, `score_comment`
+(judge reasoning), `input_str`, `output_str`, `classifier_evidence`.
+
+## How to regenerate
+
+The export script lives in second-brain:
+
+```bash
+cd ~/Developer/second-brain
+python3 services/crows-nest/scripts/langfuse_export_findings.py \
+  --days 90 --threshold 0.5
+```
+
+Reads Langfuse credentials from macOS Keychain
+(`developer.workspace.LANGFUSE_*`).
+
+## See also
+
+- GitHub issues filed against this dataset on cardigan-v4: search this
+  repo's open issues for label `legacy-data`.
+- Originating canonical README in second-brain:
+  `services/crows-nest/data/judge_archive/README.md`.
+- The API key scoping convention this archive's existence prompted:
+  `~/Developer/the-lodge/conventions/SECRETS_MANAGEMENT.md`,
+  section "Key Scoping and Lifecycle."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       timeout: 5s
       start_period: 10s
       retries: 3
+    restart: unless-stopped
 
   worker:
     build:
@@ -58,6 +59,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    restart: unless-stopped
 
   web:
     build:
@@ -69,6 +71,7 @@ services:
       - CARDIGAN_API_KEY=${CARDIGAN_API_KEY:-}
     depends_on:
       - api
+    restart: unless-stopped
 
   mcp:
     # Shares the api image — same content, different command. Mirrors prod

--- a/tests/api/test_chunking.py
+++ b/tests/api/test_chunking.py
@@ -279,3 +279,67 @@ Second body."""
         # (exact dedup depends on the window size and ratio)
         assert "Start of chunk zero" in result
         assert "End of chunk one" in result
+
+    def test_strips_wrapping_markdown_code_fence(self):
+        """LLM outputs that wrap entire content in ```markdown ... ``` fences should be unwrapped.
+
+        Mirrors the real defect observed on job 171: chunked formatter LLM
+        responses wrapped the full output (header + body) in a single
+        ```markdown ... ``` fence pair, which made the renderer treat the
+        whole chunk as a code block.
+        """
+        chunk0 = """```markdown
+**Project:** Test
+
+---
+
+**Speaker A:** First chunk dialogue.
+```"""
+        chunk1 = """```markdown
+**Speaker B:** Second chunk dialogue.
+```"""
+
+        result = merge_formatter_chunks([chunk0, chunk1])
+        # No code fences should remain (would make renderer treat content as code block)
+        assert "```" not in result
+        # Dialogue content must be preserved verbatim
+        assert "First chunk dialogue" in result
+        assert "Second chunk dialogue" in result
+
+    def test_strips_preamble_then_fence(self):
+        """The exact pathology observed on job 171: preamble + fence-wrapped chunk."""
+        chunk0 = """I'll now format the complete transcript. Let me process all the SRT blocks carefully.
+
+```markdown
+**Project:** Test
+
+---
+
+**Speaker A:** First chunk dialogue.
+```"""
+        chunk1 = """**Speaker B:** Second chunk dialogue (no wrap on this chunk)."""
+
+        result = merge_formatter_chunks([chunk0, chunk1])
+        assert "```" not in result
+        assert "I'll now format" not in result
+        assert "First chunk dialogue" in result
+        assert "Second chunk dialogue" in result
+
+    def test_strips_conversational_preamble(self):
+        """LLM preambles like 'I'll now format...' before markdown content should be stripped."""
+        chunk0 = """I'll now format the complete transcript. Let me process all the SRT blocks carefully.
+
+**Project:** Test
+
+---
+
+**Speaker A:** Dialogue."""
+        chunk1 = """Here is the second chunk:
+
+**Speaker B:** More dialogue."""
+
+        result = merge_formatter_chunks([chunk0, chunk1])
+        assert "I'll now format" not in result
+        assert "Here is the second chunk" not in result
+        assert "Dialogue" in result
+        assert "More dialogue" in result

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -273,6 +273,65 @@ class TestLoadAgentPrompt:
         result = worker._load_agent_prompt("analyst")
         assert "transcript analyst" in result.lower()
 
+    @patch("api.services.worker.get_llm_client")
+    @patch("api.services.worker.AGENTS_DIR")
+    def test_substitutes_today_date_placeholder(self, mock_agents_dir, mock_get_llm, mock_llm_client, tmp_path):
+        """The literal {TODAY'S DATE in YYYY-MM-DD format} placeholder must be replaced
+        with today's actual date so the LLM doesn't hallucinate a date near its
+        training cutoff."""
+        from datetime import datetime, timezone
+
+        mock_get_llm.return_value = mock_llm_client
+        mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
+
+        (tmp_path / "analyst.md").write_text(
+            "**Date Processed:** {TODAY'S DATE in YYYY-MM-DD format}\n"
+        )
+
+        worker = JobWorker()
+        result = worker._load_agent_prompt("analyst")
+        expected_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert expected_date in result
+        assert "{TODAY'S DATE" not in result
+
+    @patch("api.services.worker.get_llm_client")
+    @patch("api.services.worker.AGENTS_DIR")
+    def test_substitutes_model_placeholder_when_provided(
+        self, mock_agents_dir, mock_get_llm, mock_llm_client, tmp_path
+    ):
+        """When a model identifier is provided, both placeholder spellings should be
+        substituted so the artifact header reflects the real model rather than an
+        LLM guess."""
+        mock_get_llm.return_value = mock_llm_client
+        mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
+
+        (tmp_path / "seo.md").write_text(
+            "**Model:** {model name you are running as}\n"
+            "Other line: {the model you are running as}\n"
+        )
+
+        worker = JobWorker()
+        result = worker._load_agent_prompt("seo", model="anthropic/claude-4.5-haiku-20251001")
+        assert "anthropic/claude-4.5-haiku-20251001" in result
+        assert "{model name" not in result
+        assert "{the model" not in result
+
+    @patch("api.services.worker.get_llm_client")
+    @patch("api.services.worker.AGENTS_DIR")
+    def test_leaves_model_placeholder_when_none(self, mock_agents_dir, mock_get_llm, mock_llm_client, tmp_path):
+        """When no model is provided, the model placeholder is left alone (the LLM
+        will then hallucinate, but date substitution still happens)."""
+        mock_get_llm.return_value = mock_llm_client
+        mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
+
+        (tmp_path / "analyst.md").write_text(
+            "**Model:** {model name you are running as}\n"
+        )
+
+        worker = JobWorker()
+        result = worker._load_agent_prompt("analyst")
+        assert "{model name you are running as}" in result
+
 
 class TestBuildPhasePrompt:
     """Tests for _build_phase_prompt method."""

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -284,9 +284,7 @@ class TestLoadAgentPrompt:
         mock_get_llm.return_value = mock_llm_client
         mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
 
-        (tmp_path / "analyst.md").write_text(
-            "**Date Processed:** {TODAY'S DATE in YYYY-MM-DD format}\n"
-        )
+        (tmp_path / "analyst.md").write_text("**Date Processed:** {TODAY'S DATE in YYYY-MM-DD format}\n")
 
         worker = JobWorker()
         result = worker._load_agent_prompt("analyst")
@@ -306,8 +304,7 @@ class TestLoadAgentPrompt:
         mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
 
         (tmp_path / "seo.md").write_text(
-            "**Model:** {model name you are running as}\n"
-            "Other line: {the model you are running as}\n"
+            "**Model:** {model name you are running as}\n" "Other line: {the model you are running as}\n"
         )
 
         worker = JobWorker()
@@ -324,9 +321,7 @@ class TestLoadAgentPrompt:
         mock_get_llm.return_value = mock_llm_client
         mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
 
-        (tmp_path / "analyst.md").write_text(
-            "**Model:** {model name you are running as}\n"
-        )
+        (tmp_path / "analyst.md").write_text("**Model:** {model name you are running as}\n")
 
         worker = JobWorker()
         result = worker._load_agent_prompt("analyst")


### PR DESCRIPTION
Session bundle of fixes discovered during today's troubleshooting and the post-#147 chain cleanup.

## What's in here

### 1. Docker reliability (commit `d507093`)
- `restart: unless-stopped` on api / web / worker.
- Previously only mcp and tunnel had restart policies. The worker silently disappearing after a container stop is what made job 171 sit in `pending` for a week — this prevents the next recurrence.

### 2. Chunked formatter LLM output hygiene (commit `e460534`)
- Chunked formatter responses sometimes wrap their entire output in backtick `markdown` code fences AND/OR include conversational preambles ("I'll now format the transcript..."). When merged, the stray fence makes the rendered transcript display the first chunk inside a code block.
- Fix at two layers:
  - `chunking.py`: in `merge_formatter_chunks`, strip leading preamble and outer code-fence wrapper per chunk before further processing.
  - `.claude/agents/formatter.md`: explicit CRITICAL instruction telling the LLM not to wrap or preamble. Belt + suspenders.
- Three new test cases covering wrap-only, preamble + wrap, and preamble alone. All 23 chunking tests pass.
- Cleaned reference artifact for job 171 is committed to `OUTPUT/` locally (gitignored) so the bug is reproducible.

### 3. Agent prompt date hallucination fix (commit `985bea3`)
- `_load_agent_prompt` previously did a raw `read_text()` with zero template substitution. The agent prompts contain placeholders like `{TODAY'S DATE in YYYY-MM-DD format}` that the LLM interpreted as "fill this in" — and proceeded to invent plausible dates near its training cutoff (typically 2025-01-17) and generic model names ("Claude 3.5 Sonnet").
- Every artifact ever generated has had a wrong `Date Processed` field. Example: job 170 processed 2026-05-14 reports `Date Processed: 2025-01-17`.
- Fix: `_load_agent_prompt` now substitutes the current UTC date into the date placeholder (always) and the actual model identifier into the model placeholder (when provided). Model substitution is wired up but call sites aren't plumbed yet — that's a follow-up. The date fix is load-bearing and works now.

### 4. Carry-forward from the original May-14 bundle (commit `1a0c476`)
- `.gitignore` for `.superpowers/`
- `data/judge_archive/README.md`
- The stale `config/llm-config.json` portion of the original commit was dropped (it referenced the pre-Sprint-2 `manager` phase architecture).

## Test plan

- [x] `pytest tests/api/test_chunking.py::TestMergeFormatterChunks` — 10 passing (7 existing + 3 new)
- [x] `pytest tests/api/test_worker.py::TestLoadAgentPrompt` — 5 passing (2 existing + 3 new)
- [ ] Visual: bring up the stack with `docker compose up -d` and verify the worker container restarts itself if killed manually
- [ ] Process a transcript end-to-end after merge and confirm the rendered formatter artifact has no embedded code block, and the artifact's `Date Processed` field shows today's actual date

🤖 Generated with [Claude Code](https://claude.com/claude-code)