### PR TITLE
feat(web): PBS-tinted palette migration + WCAG AA surface-400 fix

### DIFF
--- a/web/src/components/IngestPanel.tsx
+++ b/web/src/components/IngestPanel.tsx
@@ -229,8 +229,8 @@ export default function IngestPanel() {
 
       {/* Error Message */}
       {error && (
-        <div role="alert" aria-live="assertive" className="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
-          <p className="text-red-400">{error}</p>
+        <div role="alert" aria-live="assertive" className="bg-status-failed/15 border border-status-failed/30 rounded-lg p-4">
+          <p className="text-status-failed">{error}</p>
         </div>
       )}
 
@@ -243,7 +243,7 @@ export default function IngestPanel() {
             </span>
             <button
               onClick={handleQueueSelected}
-              className="px-3 py-1.5 text-sm bg-green-600 hover:bg-green-500 text-white rounded-md transition-colors"
+              className="px-3 py-1.5 text-sm bg-pbs-500 hover:bg-pbs-400 text-white rounded-md transition-colors"
               aria-label={`Queue ${selectedFileIds.size} selected files`}
             >
               Queue Selected
@@ -318,7 +318,7 @@ export default function IngestPanel() {
                   )}
 
                   {!file.sst_record && file.media_id && (
-                    <div className="text-xs text-yellow-500 mt-0.5">
+                    <div className="text-xs text-status-pending mt-0.5">
                       No SST record found
                     </div>
                   )}
@@ -328,7 +328,7 @@ export default function IngestPanel() {
               <div className="flex items-center space-x-2 ml-4">
                 <button
                   onClick={() => handleQueueFile(file.id)}
-                  className="px-3 py-1 text-sm bg-green-600 hover:bg-green-500 text-white rounded transition-colors"
+                  className="px-3 py-1 text-sm bg-pbs-500 hover:bg-pbs-400 text-white rounded transition-colors"
                   aria-label={`Queue ${file.media_id || file.filename} for processing`}
                 >
                   Queue

--- a/web/src/components/IngestPanel.tsx
+++ b/web/src/components/IngestPanel.tsx
@@ -201,25 +201,25 @@ export default function IngestPanel() {
   }
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-6 space-y-4">
+    <div className="bg-surface-800 rounded-lg border border-surface-700 p-6 space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold text-white">Ready to Queue</h2>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-surface-400">
             {totalNew} transcript{totalNew !== 1 ? 's' : ''} ready for processing
           </p>
         </div>
         <div className="flex items-center space-x-3">
           {lastScanAt && (
-            <span className="text-sm text-gray-400" title={new Date(lastScanAt + 'Z').toLocaleString()}>
+            <span className="text-sm text-surface-400" title={new Date(lastScanAt + 'Z').toLocaleString()}>
               Last scan: {formatRelativeTime(lastScanAt + 'Z')}
             </span>
           )}
           <button
             onClick={handleScan}
             disabled={scanning}
-            className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-md transition-colors"
+            className="px-3 py-1.5 text-sm bg-surface-700 hover:bg-surface-600 disabled:opacity-50 text-white rounded-md transition-colors"
             aria-label="Scan for new transcript files"
           >
             {scanning ? 'Checking...' : 'Check Now'}
@@ -236,9 +236,9 @@ export default function IngestPanel() {
 
       {/* Bulk Actions */}
       {selectedFileIds.size > 0 && (
-        <div className="bg-blue-900/20 border border-blue-500/30 rounded-lg p-4">
+        <div className="bg-pbs-900/20 border border-pbs-500/30 rounded-lg p-4">
           <div className="flex items-center justify-between">
-            <span className="text-blue-400 text-sm">
+            <span className="text-pbs-400 text-sm">
               {selectedFileIds.size} file{selectedFileIds.size !== 1 ? 's' : ''} selected
             </span>
             <button
@@ -255,27 +255,27 @@ export default function IngestPanel() {
       {/* File List */}
       {loading ? (
         <div className="py-8 text-center">
-          <p className="text-gray-400 animate-pulse">Loading available files...</p>
+          <p className="text-surface-400 animate-pulse">Loading available files...</p>
         </div>
       ) : files.length === 0 ? (
         <div className="py-8 text-center">
-          <p className="text-gray-400">No new transcript files available</p>
-          <p className="text-sm text-gray-500 mt-1">Click "Check Now" to scan for new files</p>
+          <p className="text-surface-400">No new transcript files available</p>
+          <p className="text-sm text-surface-400 mt-1">Click "Check Now" to scan for new files</p>
         </div>
       ) : (
         <div className="space-y-2">
           {/* Select All */}
           {files.length > 1 && (
-            <div className="flex items-center px-3 py-2 bg-gray-900 rounded-lg">
+            <div className="flex items-center px-3 py-2 bg-surface-900 rounded-lg">
               <label className="flex items-center space-x-3 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={selectedFileIds.size === files.length}
                   onChange={toggleSelectAll}
-                  className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-800"
+                  className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-pbs-500 focus:ring-pbs-400 focus:ring-offset-surface-800"
                   aria-label="Select all files"
                 />
-                <span className="text-sm text-gray-400 font-medium">Select All</span>
+                <span className="text-sm text-surface-400 font-medium">Select All</span>
               </label>
             </div>
           )}
@@ -284,7 +284,7 @@ export default function IngestPanel() {
           {files.map((file) => (
             <div
               key={file.id}
-              className="flex items-center justify-between p-3 bg-gray-900 rounded-lg hover:bg-gray-850 transition-colors"
+              className="flex items-center justify-between p-3 bg-surface-900 rounded-lg hover:bg-surface-850 transition-colors"
             >
               <div className="flex items-center space-x-3 flex-1 min-w-0">
                 <label className="flex items-center cursor-pointer">
@@ -292,7 +292,7 @@ export default function IngestPanel() {
                     type="checkbox"
                     checked={selectedFileIds.has(file.id)}
                     onChange={() => toggleFileSelection(file.id)}
-                    className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-800"
+                    className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-pbs-500 focus:ring-pbs-400 focus:ring-offset-surface-800"
                     aria-label={`Select ${file.media_id || file.filename}`}
                   />
                 </label>
@@ -302,17 +302,17 @@ export default function IngestPanel() {
                     {file.media_id ? (
                       <span className="font-medium text-white font-mono">{file.media_id}</span>
                     ) : (
-                      <span className="font-medium text-gray-400">{file.filename}</span>
+                      <span className="font-medium text-surface-400">{file.filename}</span>
                     )}
                   </div>
 
                   {file.sst_record && (
-                    <div className="text-sm text-gray-400 mt-0.5">
+                    <div className="text-sm text-surface-400 mt-0.5">
                       {file.sst_record.title && (
                         <span className="mr-2">{file.sst_record.title}</span>
                       )}
                       {file.sst_record.project && (
-                        <span className="text-gray-500">• {file.sst_record.project}</span>
+                        <span className="text-surface-400">• {file.sst_record.project}</span>
                       )}
                     </div>
                   )}
@@ -335,7 +335,7 @@ export default function IngestPanel() {
                 </button>
                 <button
                   onClick={() => handleIgnoreFile(file.id)}
-                  className="px-3 py-1 text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors"
+                  className="px-3 py-1 text-sm bg-surface-700 hover:bg-surface-600 text-surface-300 rounded transition-colors"
                   aria-label={`Ignore ${file.media_id || file.filename}`}
                 >
                   Ignore

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Outlet, NavLink } from 'react-router-dom'
+import { Outlet, NavLink, useLocation } from 'react-router-dom'
 import StatusBar from './StatusBar'
 import { useKeyboardShortcuts, getKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { useFocusTrap } from '../hooks/useFocusTrap'
@@ -9,8 +9,15 @@ export default function Layout() {
   useKeyboardShortcuts()
   const { preferences } = usePreferences()
   const [showHelp, setShowHelp] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const helpModalRef = useFocusTrap(showHelp)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const location = useLocation()
+
+  // Close mobile menu on navigation
+  useEffect(() => {
+    setMobileMenuOpen(false)
+  }, [location.pathname])
 
   // Apply preferences to document root
   useEffect(() => {
@@ -66,10 +73,17 @@ export default function Layout() {
   }
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-    `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    `px-3 py-2 text-sm font-medium transition-colors relative ${
       isActive
-        ? 'bg-surface-700 text-white'
-        : 'text-surface-300 hover:bg-surface-700 hover:text-white'
+        ? 'text-white after:absolute after:bottom-0 after:left-1 after:right-1 after:h-0.5 after:bg-pbs-400 after:rounded-full'
+        : 'text-surface-300 hover:text-white'
+    }`
+
+  const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `block px-3 py-2 rounded-md text-base font-medium transition-colors ${
+      isActive
+        ? 'text-white bg-surface-800'
+        : 'text-surface-300 hover:text-white hover:bg-surface-800'
     }`
 
   return (
@@ -86,10 +100,11 @@ export default function Layout() {
       <StatusBar />
 
       {/* Navigation */}
-      <nav className="bg-surface-800 border-b border-surface-700" aria-label="Main navigation">
+      <nav className="bg-surface-850 border-b border-surface-700" aria-label="Main navigation">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14">
-            <div className="flex items-center space-x-4">
+            {/* Brand */}
+            <div className="flex items-center space-x-3">
               <img
                 src="https://wisconsinpublictv.s3.us-east-2.amazonaws.com/wp-content/uploads/2023/08/pbs-wisconsin-wblue-rgb-2-412x62.png"
                 alt="PBS Wisconsin"
@@ -100,51 +115,70 @@ export default function Layout() {
               </span>
               <span className="text-xs text-surface-400">v4.0</span>
             </div>
-            <div className="flex items-center space-x-1">
-              <NavLink
-                to="/ready"
-                className={navLinkClass}
-              >
-                Ready for Work
-              </NavLink>
-              <NavLink
-                to="/queue"
-                className={navLinkClass}
-              >
-                Queue
-              </NavLink>
-              <NavLink
-                to="/projects"
-                className={navLinkClass}
-              >
-                Projects
-              </NavLink>
-              <NavLink
-                to="/settings"
-                className={navLinkClass}
-              >
-                Settings
-              </NavLink>
-              <NavLink
-                to="/help"
-                className={navLinkClass}
-              >
-                Help
-              </NavLink>
-              <button
-                ref={triggerRef}
-                onClick={() => setShowHelp(true)}
-                className="px-3 py-2 rounded-md text-sm font-medium transition-colors text-surface-300 hover:bg-surface-700 hover:text-white"
-                aria-label="Show keyboard shortcuts"
-                title="Keyboard shortcuts (?)"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </button>
+
+            {/* Desktop nav — hidden on mobile */}
+            <div className="hidden md:flex items-center">
+              {/* Work items */}
+              <div className="flex items-center space-x-1">
+                <NavLink to="/ready" className={navLinkClass}>Ready for Work</NavLink>
+                <NavLink to="/queue" className={navLinkClass}>Queue</NavLink>
+                <NavLink to="/projects" className={navLinkClass}>Projects</NavLink>
+              </div>
+
+              {/* Separator */}
+              <div className="w-px h-5 bg-surface-700 mx-3" />
+
+              {/* Utility items */}
+              <div className="flex items-center space-x-1">
+                <NavLink to="/settings" className={navLinkClass}>Settings</NavLink>
+                <NavLink to="/help" className={navLinkClass}>Help</NavLink>
+                <button
+                  ref={triggerRef}
+                  onClick={() => setShowHelp(true)}
+                  className="p-2 transition-colors text-surface-300 hover:text-white"
+                  aria-label="Show keyboard shortcuts"
+                  title="Keyboard shortcuts (?)"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </button>
+              </div>
             </div>
+
+            {/* Mobile hamburger — visible on mobile only */}
+            <button
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              className="md:hidden p-2 text-surface-300 hover:text-white transition-colors"
+              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileMenuOpen}
+            >
+              {mobileMenuOpen ? (
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
           </div>
         </div>
+
+        {/* Mobile menu panel */}
+        {mobileMenuOpen && (
+          <div className="md:hidden border-t border-surface-700 bg-surface-850">
+            <div className="px-4 py-3 space-y-1">
+              <NavLink to="/ready" className={mobileNavLinkClass}>Ready for Work</NavLink>
+              <NavLink to="/queue" className={mobileNavLinkClass}>Queue</NavLink>
+              <NavLink to="/projects" className={mobileNavLinkClass}>Projects</NavLink>
+              <div className="border-t border-surface-700 my-2" />
+              <NavLink to="/settings" className={mobileNavLinkClass}>Settings</NavLink>
+              <NavLink to="/help" className={mobileNavLinkClass}>Help</NavLink>
+            </div>
+          </div>
+        )}
       </nav>
 
       {/* Main Content */}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -68,16 +68,16 @@ export default function Layout() {
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
       isActive
-        ? 'bg-gray-700 text-white'
-        : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+        ? 'bg-surface-700 text-white'
+        : 'text-surface-300 hover:bg-surface-700 hover:text-white'
     }`
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100">
+    <div className="min-h-screen bg-surface-900 text-surface-100">
       {/* Skip Navigation Link */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-md focus:shadow-lg"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-pbs-500 focus:text-white focus:rounded-md focus:shadow-lg"
       >
         Skip to main content
       </a>
@@ -86,7 +86,7 @@ export default function Layout() {
       <StatusBar />
 
       {/* Navigation */}
-      <nav className="bg-gray-800 border-b border-gray-700" aria-label="Main navigation">
+      <nav className="bg-surface-800 border-b border-surface-700" aria-label="Main navigation">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14">
             <div className="flex items-center space-x-4">
@@ -98,7 +98,7 @@ export default function Layout() {
               <span className="text-lg font-semibold text-white">
                 Cardigan
               </span>
-              <span className="text-xs text-gray-400">v4.0</span>
+              <span className="text-xs text-surface-400">v4.0</span>
             </div>
             <div className="flex items-center space-x-1">
               <NavLink
@@ -134,7 +134,7 @@ export default function Layout() {
               <button
                 ref={triggerRef}
                 onClick={() => setShowHelp(true)}
-                className="px-3 py-2 rounded-md text-sm font-medium transition-colors text-gray-300 hover:bg-gray-700 hover:text-white"
+                className="px-3 py-2 rounded-md text-sm font-medium transition-colors text-surface-300 hover:bg-surface-700 hover:text-white"
                 aria-label="Show keyboard shortcuts"
                 title="Keyboard shortcuts (?)"
               >
@@ -160,20 +160,20 @@ export default function Layout() {
         >
           <div
             ref={helpModalRef}
-            className="bg-gray-900 rounded-lg border border-gray-700 w-full max-w-md"
+            className="bg-surface-900 rounded-lg border border-surface-700 w-full max-w-md"
             role="dialog"
             aria-modal="true"
             aria-labelledby="shortcuts-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Modal Header */}
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-700">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-surface-700">
               <h3 id="shortcuts-modal-title" className="text-lg font-medium text-white">
                 Keyboard Shortcuts
               </h3>
               <button
                 onClick={closeHelp}
-                className="text-gray-400 hover:text-white text-2xl leading-none"
+                className="text-surface-400 hover:text-white text-2xl leading-none"
                 aria-label="Close shortcuts help"
               >
                 &times;
@@ -184,16 +184,16 @@ export default function Layout() {
               <div className="space-y-3">
                 {getKeyboardShortcuts().map((shortcut, index) => (
                   <div key={index} className="flex items-center justify-between">
-                    <span className="text-gray-300">{shortcut.description}</span>
-                    <kbd className="px-2 py-1 bg-gray-800 border border-gray-600 rounded text-sm font-mono text-gray-300">
+                    <span className="text-surface-300">{shortcut.description}</span>
+                    <kbd className="px-2 py-1 bg-surface-800 border border-surface-600 rounded text-sm font-mono text-surface-300">
                       {shortcut.keys}
                     </kbd>
                   </div>
                 ))}
               </div>
-              <div className="mt-6 pt-4 border-t border-gray-700">
-                <p className="text-xs text-gray-500">
-                  Press <kbd className="px-1 py-0.5 bg-gray-800 border border-gray-600 rounded text-xs font-mono">?</kbd> to open this help anytime
+              <div className="mt-6 pt-4 border-t border-surface-700">
+                <p className="text-xs text-surface-400">
+                  Press <kbd className="px-1 py-0.5 bg-surface-800 border border-surface-600 rounded text-xs font-mono">?</kbd> to open this help anytime
                 </p>
               </div>
             </div>

--- a/web/src/components/ModelStatsWidget.tsx
+++ b/web/src/components/ModelStatsWidget.tsx
@@ -96,13 +96,13 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
   }
 
   return (
-    <div className={`bg-gray-800 rounded-lg border border-gray-700 p-4 ${className}`}>
+    <div className={`bg-surface-800 rounded-lg border border-surface-700 p-4 ${className}`}>
       <div className="flex items-center justify-between mb-3">
         <div>
-          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+          <h3 className="text-sm font-medium text-surface-400 uppercase tracking-wide">
             Actual Model Usage
           </h3>
-          <p className="text-xs text-gray-500 mt-0.5">
+          <p className="text-xs text-surface-400 mt-0.5">
             From Langfuse analytics
           </p>
         </div>
@@ -110,7 +110,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
-            className="bg-gray-700 text-gray-300 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="bg-surface-700 text-surface-300 text-xs rounded px-2 py-1 border border-surface-600 focus:outline-none focus:ring-1 focus:ring-pbs-400"
             aria-label="Time period"
           >
             <option value={7}>Last 7 days</option>
@@ -120,7 +120,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
           <button
             onClick={fetchStats}
             disabled={loading}
-            className="text-xs text-gray-400 hover:text-white disabled:opacity-50"
+            className="text-xs text-surface-400 hover:text-white disabled:opacity-50"
             aria-label="Refresh stats"
           >
             {loading ? '...' : 'Refresh'}
@@ -131,9 +131,9 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
       {/* Loading state */}
       {loading && !stats && (
         <div className="animate-pulse space-y-3">
-          <div className="h-4 bg-gray-700 rounded w-3/4"></div>
-          <div className="h-4 bg-gray-700 rounded w-1/2"></div>
-          <div className="h-4 bg-gray-700 rounded w-2/3"></div>
+          <div className="h-4 bg-surface-700 rounded w-3/4"></div>
+          <div className="h-4 bg-surface-700 rounded w-1/2"></div>
+          <div className="h-4 bg-surface-700 rounded w-2/3"></div>
         </div>
       )}
 
@@ -143,7 +143,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
           <p className="text-red-400 text-sm">{error}</p>
           <button
             onClick={fetchStats}
-            className="mt-2 text-xs text-blue-400 hover:text-blue-300"
+            className="mt-2 text-xs text-pbs-400 hover:text-pbs-300"
           >
             Try again
           </button>
@@ -154,7 +154,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
       {stats && !stats.available && (
         <div className="text-center py-4">
           <p className="text-yellow-400 text-sm">Langfuse not configured</p>
-          <p className="text-xs text-gray-500 mt-1">{stats.error}</p>
+          <p className="text-xs text-surface-400 mt-1">{stats.error}</p>
         </div>
       )}
 
@@ -162,20 +162,20 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
       {stats && stats.available && (
         <>
           {/* Summary row */}
-          <div className="flex justify-between text-sm mb-4 pb-3 border-b border-gray-700">
+          <div className="flex justify-between text-sm mb-4 pb-3 border-b border-surface-700">
             <div>
-              <span className="text-gray-400">Total Requests:</span>{' '}
+              <span className="text-surface-400">Total Requests:</span>{' '}
               <span className="text-white font-medium">{stats.total_requests.toLocaleString()}</span>
             </div>
             <div>
-              <span className="text-gray-400">Total Cost:</span>{' '}
+              <span className="text-surface-400">Total Cost:</span>{' '}
               <span className="text-white font-medium">{formatCost(stats.total_cost)}</span>
             </div>
           </div>
 
           {/* Model list */}
           {stats.models.length === 0 ? (
-            <p className="text-gray-500 text-sm text-center py-4">
+            <p className="text-surface-400 text-sm text-center py-4">
               No model usage data for this period
             </p>
           ) : (
@@ -199,12 +199,12 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
                           {formatModelName(model.model_name)}
                         </span>
                         {model.cost_percentage !== null && model.cost_percentage > 0 && (
-                          <span className="text-xs text-gray-500">
+                          <span className="text-xs text-surface-400">
                             {model.cost_percentage.toFixed(0)}%
                           </span>
                         )}
                       </div>
-                      <div className="flex items-center space-x-3 text-xs text-gray-500 mt-0.5">
+                      <div className="flex items-center space-x-3 text-xs text-surface-400 mt-0.5">
                         <span>{model.request_count} requests</span>
                         <span>{model.total_tokens.toLocaleString()} tokens</span>
                         {model.avg_latency_ms && (
@@ -224,8 +224,8 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
           )}
 
           {/* Footer with link to Langfuse */}
-          <div className="mt-4 pt-3 border-t border-gray-700 flex justify-between items-center">
-            <span className="text-xs text-gray-600">
+          <div className="mt-4 pt-3 border-t border-surface-700 flex justify-between items-center">
+            <span className="text-xs text-surface-600">
               Data from {stats.period_start ? new Date(stats.period_start).toLocaleDateString() : 'N/A'}
               {' - '}
               {stats.period_end ? new Date(stats.period_end).toLocaleDateString() : 'now'}
@@ -234,7 +234,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
               href="https://cloud.langfuse.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-blue-400 hover:text-blue-300 flex items-center space-x-1"
+              className="text-xs text-pbs-400 hover:text-pbs-300 flex items-center space-x-1"
             >
               <span>Open Langfuse</span>
               <span>&#8599;</span>

--- a/web/src/components/ModelStatsWidget.tsx
+++ b/web/src/components/ModelStatsWidget.tsx
@@ -85,14 +85,14 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
     const lowerName = name.toLowerCase()
     // Premium models
     if (lowerName.includes('opus') || lowerName.includes('gpt-4') || lowerName.includes('pro')) {
-      return 'bg-purple-500'
+      return 'bg-pbs-300'
     }
     // Free tier
     if (lowerName.includes('free') || lowerName.includes(':free')) {
-      return 'bg-green-500'
+      return 'bg-pbs-500'
     }
     // Default/balanced
-    return 'bg-cyan-500'
+    return 'bg-pbs-500'
   }
 
   return (
@@ -140,7 +140,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
       {/* Error state */}
       {error && !loading && (
         <div className="text-center py-4">
-          <p className="text-red-400 text-sm">{error}</p>
+          <p className="text-status-failed text-sm">{error}</p>
           <button
             onClick={fetchStats}
             className="mt-2 text-xs text-pbs-400 hover:text-pbs-300"
@@ -153,7 +153,7 @@ export default function ModelStatsWidget({ className = '' }: ModelStatsWidgetPro
       {/* Langfuse not available */}
       {stats && !stats.available && (
         <div className="text-center py-4">
-          <p className="text-yellow-400 text-sm">Langfuse not configured</p>
+          <p className="text-status-pending text-sm">Langfuse not configured</p>
           <p className="text-xs text-surface-400 mt-1">{stats.error}</p>
         </div>
       )}

--- a/web/src/components/PhaseStatsWidget.tsx
+++ b/web/src/components/PhaseStatsWidget.tsx
@@ -78,17 +78,17 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
   }, [days])
 
   const getSuccessColor = (rate: number) => {
-    if (rate >= 99) return 'text-green-400'
-    if (rate >= 95) return 'text-yellow-400'
-    if (rate >= 90) return 'text-orange-400'
-    return 'text-red-400'
+    if (rate >= 99) return 'text-status-completed'
+    if (rate >= 95) return 'text-status-pending'
+    if (rate >= 90) return 'text-status-paused'
+    return 'text-status-failed'
   }
 
   const getBarColor = (rate: number) => {
-    if (rate >= 99) return 'bg-green-500'
-    if (rate >= 95) return 'bg-yellow-500'
-    if (rate >= 90) return 'bg-orange-500'
-    return 'bg-red-500'
+    if (rate >= 99) return 'bg-status-completed'
+    if (rate >= 95) return 'bg-status-pending'
+    if (rate >= 90) return 'bg-status-paused'
+    return 'bg-status-failed'
   }
 
   const formatCost = (cost: number) => {
@@ -147,7 +147,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
       {/* Error state */}
       {error && !loading && (
         <div className="text-center py-4">
-          <p className="text-red-400 text-sm">{error}</p>
+          <p className="text-status-failed text-sm">{error}</p>
           <button
             onClick={fetchStats}
             className="mt-2 text-xs text-pbs-400 hover:text-pbs-300"
@@ -168,7 +168,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                 {stats.total_completions.toLocaleString()} jobs
               </span>
               {stats.total_failures > 0 && (
-                <span className="text-red-400 text-xs ml-2">
+                <span className="text-status-failed text-xs ml-2">
                   ({stats.total_failures} failed)
                 </span>
               )}
@@ -270,8 +270,8 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
 
                         {/* Insights for problematic phases */}
                         {phase.success_rate < 95 && (
-                          <div className="mt-3 p-2 bg-yellow-900/20 border border-yellow-500/30 rounded text-xs">
-                            <p className="text-yellow-400">
+                          <div className="mt-3 p-2 bg-status-pending/20 border border-status-pending/30 rounded text-xs">
+                            <p className="text-status-pending">
                               Low success rate — consider using a more capable base model
                             </p>
                           </div>

--- a/web/src/components/PhaseStatsWidget.tsx
+++ b/web/src/components/PhaseStatsWidget.tsx
@@ -102,13 +102,13 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
   }
 
   return (
-    <div className={`bg-gray-800 rounded-lg border border-gray-700 p-4 ${className}`}>
+    <div className={`bg-surface-800 rounded-lg border border-surface-700 p-4 ${className}`}>
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+          <h3 className="text-sm font-medium text-surface-400 uppercase tracking-wide">
             Agent Performance
           </h3>
-          <p className="text-xs text-gray-500 mt-0.5">
+          <p className="text-xs text-surface-400 mt-0.5">
             Model usage &amp; success rates by phase
           </p>
         </div>
@@ -116,7 +116,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
           <select
             value={days}
             onChange={(e) => setDays(Number(e.target.value))}
-            className="bg-gray-700 text-gray-300 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="bg-surface-700 text-surface-300 text-xs rounded px-2 py-1 border border-surface-600 focus:outline-none focus:ring-1 focus:ring-pbs-400"
             aria-label="Time period"
           >
             <option value={7}>Last 7 days</option>
@@ -127,7 +127,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
           <button
             onClick={fetchStats}
             disabled={loading}
-            className="text-xs text-gray-400 hover:text-white disabled:opacity-50"
+            className="text-xs text-surface-400 hover:text-white disabled:opacity-50"
             aria-label="Refresh stats"
           >
             {loading ? '...' : 'Refresh'}
@@ -138,9 +138,9 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
       {/* Loading state */}
       {loading && !stats && (
         <div className="animate-pulse space-y-3">
-          <div className="h-12 bg-gray-700 rounded"></div>
-          <div className="h-12 bg-gray-700 rounded"></div>
-          <div className="h-12 bg-gray-700 rounded"></div>
+          <div className="h-12 bg-surface-700 rounded"></div>
+          <div className="h-12 bg-surface-700 rounded"></div>
+          <div className="h-12 bg-surface-700 rounded"></div>
         </div>
       )}
 
@@ -150,7 +150,7 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
           <p className="text-red-400 text-sm">{error}</p>
           <button
             onClick={fetchStats}
-            className="mt-2 text-xs text-blue-400 hover:text-blue-300"
+            className="mt-2 text-xs text-pbs-400 hover:text-pbs-300"
           >
             Try again
           </button>
@@ -161,9 +161,9 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
       {stats && !error && (
         <>
           {/* Summary bar */}
-          <div className="flex justify-between text-sm mb-4 pb-3 border-b border-gray-700">
+          <div className="flex justify-between text-sm mb-4 pb-3 border-b border-surface-700">
             <div>
-              <span className="text-gray-400">Total:</span>{' '}
+              <span className="text-surface-400">Total:</span>{' '}
               <span className="text-white font-medium">
                 {stats.total_completions.toLocaleString()} jobs
               </span>
@@ -174,14 +174,14 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
               )}
             </div>
             <div>
-              <span className="text-gray-400">Cost:</span>{' '}
+              <span className="text-surface-400">Cost:</span>{' '}
               <span className="text-white font-medium">{formatCost(stats.total_cost)}</span>
             </div>
           </div>
 
           {/* Phase list */}
           {stats.phases.length === 0 ? (
-            <p className="text-gray-500 text-sm text-center py-4">
+            <p className="text-surface-400 text-sm text-center py-4">
               No phase data for this period
             </p>
           ) : (
@@ -191,24 +191,24 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                 const isExpanded = expandedPhase === phase.phase
 
                 return (
-                  <div key={phase.phase} className="bg-gray-900 rounded-lg overflow-hidden">
+                  <div key={phase.phase} className="bg-surface-900 rounded-lg overflow-hidden">
                     {/* Main row - clickable */}
                     <button
                       onClick={() => setExpandedPhase(isExpanded ? null : phase.phase)}
-                      className="w-full p-3 flex items-center justify-between hover:bg-gray-800/50 transition-colors"
+                      className="w-full p-3 flex items-center justify-between hover:bg-surface-800/50 transition-colors"
                     >
                       <div className="flex items-center space-x-3">
                         <span className="text-lg">{info.icon}</span>
                         <div className="text-left">
                           <div className="flex items-center space-x-2">
                             <span className="text-white font-medium">{info.name}</span>
-                            <span className="text-xs text-gray-500">
+                            <span className="text-xs text-surface-400">
                               {phase.total_completions} runs
                             </span>
                           </div>
                           {/* Progress bar */}
                           <div className="flex items-center space-x-2 mt-1">
-                            <div className="w-32 h-1.5 bg-gray-700 rounded-full overflow-hidden">
+                            <div className="w-32 h-1.5 bg-surface-700 rounded-full overflow-hidden">
                               <div
                                 className={`h-full ${getBarColor(phase.success_rate)} transition-all`}
                                 style={{ width: `${phase.success_rate}%` }}
@@ -224,13 +224,13 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
                       <div className="flex items-center space-x-4 text-right">
                         {/* Cost */}
                         <div>
-                          <div className="text-xs text-gray-500">Cost</div>
+                          <div className="text-xs text-surface-400">Cost</div>
                           <div className="text-sm font-mono text-white">
                             {formatCost(phase.total_cost)}
                           </div>
                         </div>
                         {/* Expand indicator */}
-                        <span className={`text-gray-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                        <span className={`text-surface-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
                           ▼
                         </span>
                       </div>
@@ -238,29 +238,29 @@ export default function PhaseStatsWidget({ className = '' }: PhaseStatsWidgetPro
 
                     {/* Expanded details */}
                     {isExpanded && (
-                      <div className="px-3 pb-3 border-t border-gray-800">
+                      <div className="px-3 pb-3 border-t border-surface-800">
                         <div className="mt-3 space-y-2">
-                          <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">
+                          <div className="text-xs text-surface-400 uppercase tracking-wide mb-2">
                             Model Breakdown
                           </div>
                           {phase.models.map((model, idx) => (
                             <div
                               key={idx}
-                              className="flex items-center justify-between text-xs py-1.5 px-2 bg-gray-800 rounded"
+                              className="flex items-center justify-between text-xs py-1.5 px-2 bg-surface-800 rounded"
                             >
                               <div className="flex items-center space-x-2">
-                                <span className="text-gray-300 font-mono truncate max-w-[200px]" title={model.model}>
+                                <span className="text-surface-300 font-mono truncate max-w-[200px]" title={model.model}>
                                   {model.model}
                                 </span>
                               </div>
                               <div className="flex items-center space-x-4">
-                                <span className="text-gray-500">
+                                <span className="text-surface-400">
                                   {model.completions} runs
                                 </span>
                                 <span className={getSuccessColor(model.success_rate)}>
                                   {model.success_rate}%
                                 </span>
-                                <span className="text-gray-400 font-mono">
+                                <span className="text-surface-400 font-mono">
                                   {formatCost(model.total_cost)}
                                 </span>
                               </div>

--- a/web/src/components/ScreengrabPanel.tsx
+++ b/web/src/components/ScreengrabPanel.tsx
@@ -176,8 +176,8 @@ export default function ScreengrabPanel() {
 
   if (loading && screengrabs.length === 0) {
     return (
-      <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-        <div className="text-gray-300 animate-pulse">Loading screengrabs...</div>
+      <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+        <div className="text-surface-300 animate-pulse">Loading screengrabs...</div>
       </div>
     )
   }
@@ -191,7 +191,7 @@ export default function ScreengrabPanel() {
           <button
             onClick={handleAttachAll}
             disabled={batchAttaching || attaching !== null}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg text-sm transition-colors"
+            className="px-4 py-2 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded-lg text-sm transition-colors"
             aria-label={`Attach all ${pendingCount} pending screengrabs`}
           >
             {batchAttaching ? 'Attaching...' : `Attach All (${pendingCount})`}
@@ -212,7 +212,7 @@ export default function ScreengrabPanel() {
       )}
 
       {/* Filter Tabs */}
-      <div className="border-b border-gray-700">
+      <div className="border-b border-surface-700">
         <nav className="flex space-x-1" role="tablist" aria-label="Screengrab filters">
           <button
             role="tab"
@@ -221,8 +221,8 @@ export default function ScreengrabPanel() {
             onClick={() => setActiveFilter('pending')}
             className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${
               activeFilter === 'pending'
-                ? 'bg-gray-700 text-white'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800/50'
+                ? 'bg-surface-700 text-white'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
             }`}
           >
             Pending {counts.new > 0 && <span className="ml-1">({counts.new})</span>}
@@ -234,8 +234,8 @@ export default function ScreengrabPanel() {
             onClick={() => setActiveFilter('no_match')}
             className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${
               activeFilter === 'no_match'
-                ? 'bg-gray-700 text-white'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800/50'
+                ? 'bg-surface-700 text-white'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
             }`}
           >
             No Match {counts.no_match > 0 && <span className="ml-1">({counts.no_match})</span>}
@@ -247,8 +247,8 @@ export default function ScreengrabPanel() {
             onClick={() => setActiveFilter('all')}
             className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors ${
               activeFilter === 'all'
-                ? 'bg-gray-700 text-white'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800/50'
+                ? 'bg-surface-700 text-white'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
             }`}
           >
             All
@@ -263,7 +263,7 @@ export default function ScreengrabPanel() {
             <span className="text-yellow-400 text-xl">⚠️</span>
             <div>
               <h3 className="text-sm font-medium text-yellow-400">No SST Match Found</h3>
-              <p className="text-xs text-gray-300 mt-1">
+              <p className="text-xs text-surface-300 mt-1">
                 These screengrabs could not be automatically matched to a Media ID in the SST.
                 The filename pattern does not match expected formats (e.g., &quot;2WLI...&quot; or &quot;NOLA...&quot;).
                 You may need to manually attach these files or verify the filename.
@@ -278,12 +278,12 @@ export default function ScreengrabPanel() {
         role="tabpanel"
         id={`panel-${activeFilter}`}
         aria-labelledby={activeFilter}
-        className="bg-gray-800 rounded-lg border border-gray-700 p-6"
+        className="bg-surface-800 rounded-lg border border-surface-700 p-6"
       >
         {filteredScreengrabs.length === 0 ? (
           <div className="text-center py-8">
-            <p className="text-gray-300">No {activeFilter === 'pending' ? 'pending' : activeFilter === 'no_match' ? 'unmatched' : ''} screengrabs found.</p>
-            <p className="text-gray-400 text-sm mt-2">
+            <p className="text-surface-300">No {activeFilter === 'pending' ? 'pending' : activeFilter === 'no_match' ? 'unmatched' : ''} screengrabs found.</p>
+            <p className="text-surface-400 text-sm mt-2">
               {activeFilter === 'pending' && 'New screengrabs will appear here when detected.'}
               {activeFilter === 'no_match' && 'Files that cannot be matched to Media IDs will appear here.'}
               {activeFilter === 'all' && 'No screengrabs have been processed yet.'}
@@ -294,14 +294,14 @@ export default function ScreengrabPanel() {
             {filteredScreengrabs.map((screengrab) => (
               <div
                 key={screengrab.id}
-                className="bg-gray-900 rounded-lg p-3 flex items-center gap-4"
+                className="bg-surface-900 rounded-lg p-3 flex items-center gap-4"
               >
                 {/* Thumbnail */}
                 <div className="flex-shrink-0">
                   <img
                     src={screengrab.remote_url}
                     alt={`Thumbnail for ${screengrab.filename}`}
-                    className="w-16 h-12 object-cover rounded border border-gray-700"
+                    className="w-16 h-12 object-cover rounded border border-surface-700"
                     loading="lazy"
                   />
                 </div>
@@ -314,7 +314,7 @@ export default function ScreengrabPanel() {
                         {screengrab.filename}
                       </div>
                       {screengrab.media_id && (
-                        <div className="text-gray-400 text-xs font-mono">
+                        <div className="text-surface-400 text-xs font-mono">
                           Media ID: {screengrab.media_id}
                         </div>
                       )}
@@ -338,7 +338,7 @@ export default function ScreengrabPanel() {
                         </span>
                       )}
                       {screengrab.status === 'ignored' && (
-                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-gray-700/30 text-gray-400 border border-gray-600/30">
+                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-surface-700/30 text-surface-400 border border-surface-600/30">
                           Ignored
                         </span>
                       )}
@@ -347,12 +347,12 @@ export default function ScreengrabPanel() {
 
                   {/* Timestamp */}
                   {screengrab.attached_at && (
-                    <div className="text-gray-500 text-xs mt-1">
+                    <div className="text-surface-400 text-xs mt-1">
                       Attached: {new Date(screengrab.attached_at).toLocaleString()}
                     </div>
                   )}
                   {!screengrab.attached_at && screengrab.first_seen_at && (
-                    <div className="text-gray-500 text-xs mt-1">
+                    <div className="text-surface-400 text-xs mt-1">
                       Detected: {new Date(screengrab.first_seen_at).toLocaleString()}
                     </div>
                   )}
@@ -364,7 +364,7 @@ export default function ScreengrabPanel() {
                     <button
                       onClick={() => handleAttach(screengrab.id)}
                       disabled={attaching === screengrab.id || batchAttaching}
-                      className="px-3 py-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-sm rounded transition-colors"
+                      className="px-3 py-1 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white text-sm rounded transition-colors"
                       aria-label={`Attach ${screengrab.filename}`}
                     >
                       {attaching === screengrab.id ? 'Attaching...' : 'Attach'}
@@ -372,7 +372,7 @@ export default function ScreengrabPanel() {
                     <button
                       onClick={() => handleIgnore(screengrab.id)}
                       disabled={attaching === screengrab.id || batchAttaching}
-                      className="px-3 py-1 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-gray-300 text-sm rounded transition-colors"
+                      className="px-3 py-1 bg-surface-700 hover:bg-surface-600 disabled:opacity-50 text-surface-300 text-sm rounded transition-colors"
                       aria-label={`Ignore ${screengrab.filename}`}
                     >
                       Ignore
@@ -386,7 +386,7 @@ export default function ScreengrabPanel() {
       </div>
 
       {/* Summary Footer */}
-      <div className="flex items-center justify-between text-sm text-gray-400 px-2">
+      <div className="flex items-center justify-between text-sm text-surface-400 px-2">
         <div>
           Total: {counts.new + counts.attached + counts.no_match} screengrabs
         </div>

--- a/web/src/components/ScreengrabPanel.tsx
+++ b/web/src/components/ScreengrabPanel.tsx
@@ -201,13 +201,13 @@ export default function ScreengrabPanel() {
 
       {/* Status Messages */}
       {error && (
-        <div role="alert" aria-live="assertive" className="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
-          <p className="text-red-400 text-sm">{error}</p>
+        <div role="alert" aria-live="assertive" className="bg-status-failed/15 border border-status-failed/30 rounded-lg p-4">
+          <p className="text-status-failed text-sm">{error}</p>
         </div>
       )}
       {success && (
-        <div role="status" aria-live="polite" className="bg-green-900/20 border border-green-500/30 rounded-lg p-4">
-          <p className="text-green-400 text-sm">{success}</p>
+        <div role="status" aria-live="polite" className="bg-status-completed/15 border border-status-completed/30 rounded-lg p-4">
+          <p className="text-status-completed text-sm">{success}</p>
         </div>
       )}
 
@@ -258,11 +258,11 @@ export default function ScreengrabPanel() {
 
       {/* No Match Explanation */}
       {activeFilter === 'no_match' && counts.no_match > 0 && (
-        <div className="bg-yellow-900/20 border border-yellow-500/30 rounded-lg p-4">
+        <div className="bg-status-pending/15 border border-status-pending/30 rounded-lg p-4">
           <div className="flex items-start space-x-3">
-            <span className="text-yellow-400 text-xl">⚠️</span>
+            <span className="text-status-pending text-xl">⚠️</span>
             <div>
-              <h3 className="text-sm font-medium text-yellow-400">No SST Match Found</h3>
+              <h3 className="text-sm font-medium text-status-pending">No SST Match Found</h3>
               <p className="text-xs text-surface-300 mt-1">
                 These screengrabs could not be automatically matched to a Media ID in the SST.
                 The filename pattern does not match expected formats (e.g., &quot;2WLI...&quot; or &quot;NOLA...&quot;).
@@ -319,7 +319,7 @@ export default function ScreengrabPanel() {
                         </div>
                       )}
                       {screengrab.sst_record_id && (
-                        <div className="text-green-400 text-xs">
+                        <div className="text-status-completed text-xs">
                           SST Match Found
                         </div>
                       )}
@@ -328,12 +328,12 @@ export default function ScreengrabPanel() {
                     {/* Status Badge */}
                     <div>
                       {screengrab.status === 'attached' && (
-                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-green-900/30 text-green-400 border border-green-500/30">
+                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-status-completed/15 text-status-completed border border-status-completed/30">
                           Attached
                         </span>
                       )}
                       {screengrab.status === 'no_match' && (
-                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-yellow-900/30 text-yellow-400 border border-yellow-500/30">
+                        <span className="inline-flex items-center px-2 py-1 rounded text-xs bg-status-pending/15 text-status-pending border border-status-pending/30">
                           No Match
                         </span>
                       )}

--- a/web/src/components/ScreengrabSlideout.tsx
+++ b/web/src/components/ScreengrabSlideout.tsx
@@ -179,7 +179,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
           <button
             onClick={handleAttachAll}
             disabled={batchAttaching}
-            className="w-full px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
+            className="w-full px-4 py-2 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
           >
             {batchAttaching ? 'Attaching...' : `Attach All (${pendingCount})`}
           </button>
@@ -235,8 +235,8 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
         )}
 
         {error && (
-          <div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
-            <p className="text-red-400 text-sm">{error}</p>
+          <div className="mb-4 p-3 bg-status-failed/15 border border-status-failed/30 rounded-lg">
+            <p className="text-status-failed text-sm">{error}</p>
           </div>
         )}
 
@@ -272,7 +272,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
 
                   {/* Status Badge */}
                   {screengrab.status === 'attached' && (
-                    <div className="absolute top-2 right-2 px-2 py-1 bg-green-600 text-white text-xs rounded">
+                    <div className="absolute top-2 right-2 px-2 py-1 bg-status-completed text-white text-xs rounded">
                       Attached
                     </div>
                   )}
@@ -293,7 +293,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
                       <button
                         onClick={() => handleAttach(screengrab.id)}
                         disabled={attaching === screengrab.id}
-                        className="flex-1 px-3 py-1.5 text-sm bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded transition-colors"
+                        className="flex-1 px-3 py-1.5 text-sm bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded transition-colors"
                       >
                         {attaching === screengrab.id ? 'Attaching...' : 'Attach'}
                       </button>

--- a/web/src/components/ScreengrabSlideout.tsx
+++ b/web/src/components/ScreengrabSlideout.tsx
@@ -157,16 +157,16 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
         <div>
           <h3 className="text-lg font-semibold text-white">Screengrabs</h3>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-surface-400">
             {pendingCount} available for {mediaId}
           </p>
         </div>
         <button
           onClick={onClose}
-          className="text-gray-400 hover:text-white text-2xl leading-none px-2"
+          className="text-surface-400 hover:text-white text-2xl leading-none px-2"
           aria-label="Close screengrab panel"
         >
           &times;
@@ -175,7 +175,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
 
       {/* Attach All Button */}
       {pendingCount > 1 && (
-        <div className="px-4 py-3 border-b border-gray-700">
+        <div className="px-4 py-3 border-b border-surface-700">
           <button
             onClick={handleAttachAll}
             disabled={batchAttaching}
@@ -190,13 +190,13 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
       <div className="flex-1 overflow-y-auto p-4">
         {/* Existing Attachments Banner */}
         {existingAttachments !== null && existingAttachments > 0 && (
-          <div className="mb-4 p-3 bg-blue-900/20 border border-blue-500/30 rounded-lg">
+          <div className="mb-4 p-3 bg-pbs-900/20 border border-pbs-500/30 rounded-lg">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2">
-                <svg className="w-5 h-5 text-blue-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-pbs-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <p className="text-blue-300 text-sm">
+                <p className="text-pbs-300 text-sm">
                   <span className="font-medium">{existingAttachments}</span> image{existingAttachments !== 1 ? 's' : ''} already attached
                 </p>
               </div>
@@ -205,7 +205,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
                   href={`https://airtable.com/${AIRTABLE_BASE_ID}/${AIRTABLE_SST_TABLE_ID}/${sstRecordId}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-400 hover:text-blue-300 text-sm flex items-center space-x-1"
+                  className="text-pbs-400 hover:text-pbs-300 text-sm flex items-center space-x-1"
                 >
                   <span>View in Airtable</span>
                   <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -224,7 +224,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
               href={`https://airtable.com/${AIRTABLE_BASE_ID}/${AIRTABLE_SST_TABLE_ID}/${sstRecordId}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-400 hover:text-gray-300 text-sm flex items-center space-x-1"
+              className="text-surface-400 hover:text-surface-300 text-sm flex items-center space-x-1"
             >
               <span>View SST record in Airtable</span>
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -242,12 +242,12 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
 
         {loading ? (
           <div className="py-8 text-center">
-            <p className="text-gray-400 animate-pulse">Loading screengrabs...</p>
+            <p className="text-surface-400 animate-pulse">Loading screengrabs...</p>
           </div>
         ) : screengrabs.length === 0 ? (
           <div className="py-8 text-center">
-            <p className="text-gray-400">No screengrabs available for this project</p>
-            <p className="text-sm text-gray-500 mt-1">
+            <p className="text-surface-400">No screengrabs available for this project</p>
+            <p className="text-sm text-surface-400 mt-1">
               Screengrabs may have already been attached or none were found on the ingest server.
             </p>
           </div>
@@ -256,10 +256,10 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
             {screengrabs.map((screengrab) => (
               <div
                 key={screengrab.id}
-                className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden"
+                className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden"
               >
                 {/* Thumbnail */}
-                <div className="aspect-video bg-gray-900 relative">
+                <div className="aspect-video bg-surface-900 relative">
                   <img
                     src={screengrab.remote_url}
                     alt={screengrab.filename}
@@ -280,10 +280,10 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
 
                 {/* Info */}
                 <div className="p-3">
-                  <p className="text-sm text-gray-300 truncate" title={screengrab.filename}>
+                  <p className="text-sm text-surface-300 truncate" title={screengrab.filename}>
                     {screengrab.filename}
                   </p>
-                  <p className="text-xs text-gray-500 mt-1">
+                  <p className="text-xs text-surface-400 mt-1">
                     {formatRelativeTime(screengrab.first_seen_at + 'Z')}
                   </p>
 
@@ -299,7 +299,7 @@ export default function ScreengrabSlideout({ mediaId, onClose }: ScreengrabSlide
                       </button>
                       <button
                         onClick={() => handleIgnore(screengrab.id)}
-                        className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors"
+                        className="px-3 py-1.5 text-sm bg-surface-700 hover:bg-surface-600 text-surface-300 rounded transition-colors"
                       >
                         Ignore
                       </button>

--- a/web/src/components/ScreengrabsBox.tsx
+++ b/web/src/components/ScreengrabsBox.tsx
@@ -136,12 +136,12 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
         <div className="flex items-center space-x-2">
-          <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-pbs-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
           <h3 className="text-sm font-medium text-white">Screen Grabs</h3>
           {pendingCount > 0 && (
-            <span className="px-2 py-0.5 text-xs bg-purple-600 text-white rounded-full">
+            <span className="px-2 py-0.5 text-xs bg-pbs-500 text-white rounded-full">
               {pendingCount} available
             </span>
           )}
@@ -171,7 +171,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
         )}
 
         {error && (
-          <div className="mb-3 p-2 bg-red-900/20 border border-red-500/30 rounded text-red-400 text-sm">
+          <div className="mb-3 p-2 bg-status-failed/15 border border-status-failed/30 rounded text-status-failed text-sm">
             {error}
           </div>
         )}
@@ -231,7 +231,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
                       <button
                         onClick={() => handleAttach(screengrab.id)}
                         disabled={attaching === screengrab.id}
-                        className="flex-1 px-2 py-1 text-xs bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded transition-colors"
+                        className="flex-1 px-2 py-1 text-xs bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded transition-colors"
                       >
                         {attaching === screengrab.id ? '...' : 'Attach'}
                       </button>

--- a/web/src/components/ScreengrabsBox.tsx
+++ b/web/src/components/ScreengrabsBox.tsx
@@ -132,9 +132,9 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
   }
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700">
+    <div className="bg-surface-800 rounded-lg border border-surface-700">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
         <div className="flex items-center space-x-2">
           <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -151,7 +151,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
             href={buildAirtableSstUrl(sstRecordId)}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-400 hover:text-gray-300 text-xs flex items-center space-x-1"
+            className="text-surface-400 hover:text-surface-300 text-xs flex items-center space-x-1"
           >
             <span>View in Airtable</span>
             <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -165,7 +165,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
       <div className="p-4">
         {/* Existing attachments info */}
         {existingAttachments !== null && existingAttachments > 0 && (
-          <div className="mb-3 text-sm text-gray-400">
+          <div className="mb-3 text-sm text-surface-400">
             {existingAttachments} image{existingAttachments !== 1 ? 's' : ''} already attached in Airtable
           </div>
         )}
@@ -178,21 +178,21 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
 
         {loading ? (
           <div className="py-4 text-center">
-            <p className="text-gray-400 text-sm animate-pulse">Loading...</p>
+            <p className="text-surface-400 text-sm animate-pulse">Loading...</p>
           </div>
         ) : screengrabs.length === 0 ? (
           <div className="py-2 text-center">
-            <p className="text-gray-500 text-sm">All screengrabs have been processed</p>
+            <p className="text-surface-400 text-sm">All screengrabs have been processed</p>
           </div>
         ) : (
           <div className="grid grid-cols-2 gap-3">
             {screengrabs.map((screengrab) => (
               <div
                 key={screengrab.id}
-                className="bg-gray-900 rounded-lg overflow-hidden border border-gray-700"
+                className="bg-surface-900 rounded-lg overflow-hidden border border-surface-700"
               >
                 {/* Thumbnail */}
-                <div className="aspect-video bg-gray-950 relative">
+                <div className="aspect-video bg-surface-950 relative">
                   <a
                     href={screengrab.remote_url}
                     target="_blank"
@@ -222,7 +222,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
 
                 {/* Info & Actions */}
                 <div className="p-2">
-                  <p className="text-xs text-gray-400 truncate mb-2" title={screengrab.filename}>
+                  <p className="text-xs text-surface-400 truncate mb-2" title={screengrab.filename}>
                     {screengrab.filename}
                   </p>
 
@@ -237,7 +237,7 @@ export default function ScreengrabsBox({ mediaId }: ScreengrabsBoxProps) {
                       </button>
                       <button
                         onClick={() => handleIgnore(screengrab.id)}
-                        className="px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition-colors"
+                        className="px-2 py-1 text-xs bg-surface-700 hover:bg-surface-600 text-surface-300 rounded transition-colors"
                       >
                         Ignore
                       </button>

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -49,10 +49,10 @@ export default function StatusBar() {
         >
           <div
             className={`w-1.5 h-1.5 rounded-full ${
-              error ? 'bg-red-500 animate-pulse' : 'bg-green-500'
+              error ? 'bg-status-failed animate-pulse' : 'bg-status-completed'
             }`}
           />
-          <span className={error ? 'text-red-400' : 'text-surface-300'}>
+          <span className={error ? 'text-status-failed' : 'text-surface-300'}>
             {error ? 'Offline' : 'Connected'}
           </span>
         </Link>
@@ -64,10 +64,10 @@ export default function StatusBar() {
             className="flex items-center space-x-1.5 text-surface-400 hover:bg-surface-800 px-2 py-1 rounded transition-colors"
             title={`${health.queue.pending} pending, ${health.queue.in_progress} processing`}
           >
-            <span className="text-yellow-400 font-medium">{queueTotal}</span>
+            <span className="text-status-pending font-medium">{queueTotal}</span>
             <span>in queue</span>
             {health.queue.in_progress > 0 && (
-              <span className="text-pbs-400 animate-pulse">●</span>
+              <span className="text-status-processing animate-pulse">●</span>
             )}
           </Link>
         )}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -37,12 +37,12 @@ export default function StatusBar() {
     : 0
 
   return (
-    <div className="bg-gray-950 border-b border-gray-800 px-4 py-1.5">
+    <div className="bg-surface-950 border-b border-surface-800 px-4 py-1.5">
       <div className="max-w-7xl mx-auto flex items-center justify-between text-xs">
         {/* Left: Connection Status */}
         <Link
           to="/settings"
-          className="flex items-center space-x-2 hover:bg-gray-800 px-2 py-1 rounded transition-colors"
+          className="flex items-center space-x-2 hover:bg-surface-800 px-2 py-1 rounded transition-colors"
           title="View system settings"
           role="status"
           aria-live="polite"
@@ -52,7 +52,7 @@ export default function StatusBar() {
               error ? 'bg-red-500 animate-pulse' : 'bg-green-500'
             }`}
           />
-          <span className={error ? 'text-red-400' : 'text-gray-400'}>
+          <span className={error ? 'text-red-400' : 'text-surface-300'}>
             {error ? 'Offline' : 'Connected'}
           </span>
         </Link>
@@ -61,13 +61,13 @@ export default function StatusBar() {
         {health?.queue && queueTotal > 0 && (
           <Link
             to="/queue"
-            className="flex items-center space-x-1.5 text-gray-400 hover:bg-gray-800 px-2 py-1 rounded transition-colors"
+            className="flex items-center space-x-1.5 text-surface-400 hover:bg-surface-800 px-2 py-1 rounded transition-colors"
             title={`${health.queue.pending} pending, ${health.queue.in_progress} processing`}
           >
             <span className="text-yellow-400 font-medium">{queueTotal}</span>
             <span>in queue</span>
             {health.queue.in_progress > 0 && (
-              <span className="text-blue-400 animate-pulse">●</span>
+              <span className="text-pbs-400 animate-pulse">●</span>
             )}
           </Link>
         )}

--- a/web/src/components/TranscriptUploader.tsx
+++ b/web/src/components/TranscriptUploader.tsx
@@ -194,7 +194,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
 
   const getStatusIcon = (status: UploadStatus) => {
     if (status.uploading) {
-      return <span className="text-blue-400 animate-spin">⟳</span>
+      return <span className="text-pbs-400 animate-spin">⟳</span>
     }
     if (status.success) {
       return <span className="text-green-400">✓</span>
@@ -203,13 +203,13 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
   }
 
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-6 space-y-4">
+    <div className="bg-surface-800 rounded-lg border border-surface-700 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-white">Upload Transcripts</h3>
         {files.length > 0 && !isUploading && (
           <button
             onClick={clearAll}
-            className="text-sm text-gray-400 hover:text-white transition-colors"
+            className="text-sm text-surface-400 hover:text-white transition-colors"
           >
             Clear all
           </button>
@@ -224,13 +224,13 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
         className={`
           border-2 border-dashed rounded-lg p-8 text-center transition-colors
           ${isDragging
-            ? 'border-blue-500 bg-blue-500/10'
-            : 'border-gray-600 hover:border-gray-500 bg-gray-900/50'
+            ? 'border-pbs-500 bg-pbs-400/10'
+            : 'border-surface-600 hover:border-surface-400 bg-surface-900/50'
           }
         `}
       >
         <div className="space-y-2">
-          <p className="text-gray-300">
+          <p className="text-surface-300">
             Drag and drop transcript files here, or
           </p>
           <label className="inline-block">
@@ -242,11 +242,11 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
               className="hidden"
               disabled={isUploading}
             />
-            <span className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg cursor-pointer transition-colors inline-block">
+            <span className="px-4 py-2 bg-pbs-500 hover:bg-pbs-400 text-white rounded-lg cursor-pointer transition-colors inline-block">
               Browse files
             </span>
           </label>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-surface-400">
             .txt or .srt files, up to {MAX_FILE_SIZE / 1024 / 1024}MB each, max {MAX_BATCH_SIZE} files
           </p>
         </div>
@@ -255,7 +255,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
       {/* File List */}
       {files.length > 0 && (
         <div className="space-y-2">
-          <h4 className="text-sm font-medium text-gray-300">
+          <h4 className="text-sm font-medium text-surface-300">
             {files.length} file{files.length !== 1 ? 's' : ''} ready to upload
           </h4>
           <div className="space-y-1 max-h-64 overflow-y-auto">
@@ -264,12 +264,12 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
               return (
                 <div
                   key={idx}
-                  className="flex items-center justify-between bg-gray-900 rounded px-3 py-2 text-sm"
+                  className="flex items-center justify-between bg-surface-900 rounded px-3 py-2 text-sm"
                 >
                   <div className="flex items-center space-x-2 flex-1 min-w-0">
                     {status && getStatusIcon(status)}
-                    <span className="text-gray-300 truncate">{file.name}</span>
-                    <span className="text-gray-500 text-xs whitespace-nowrap">
+                    <span className="text-surface-300 truncate">{file.name}</span>
+                    <span className="text-surface-400 text-xs whitespace-nowrap">
                       ({(file.size / 1024).toFixed(1)} KB)
                     </span>
                   </div>
@@ -277,7 +277,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
                     {status?.success && status.job_id && (
                       <a
                         href={`/jobs/${status.job_id}`}
-                        className="text-blue-400 hover:text-blue-300 text-xs whitespace-nowrap"
+                        className="text-pbs-400 hover:text-pbs-300 text-xs whitespace-nowrap"
                       >
                         Job #{status.job_id}
                       </a>
@@ -290,7 +290,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
                     {!isUploading && !status && (
                       <button
                         onClick={() => removeFile(idx)}
-                        className="text-gray-500 hover:text-red-400 transition-colors"
+                        className="text-surface-400 hover:text-red-400 transition-colors"
                         aria-label="Remove file"
                       >
                         ✕
@@ -308,9 +308,9 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
       {files.length > 0 && (
         <>
           {estimatedCost !== null && (
-            <p className="text-sm text-gray-400 text-center">
+            <p className="text-sm text-surface-400 text-center">
               Estimated cost: <span className="text-green-400 font-mono">~${estimatedCost.toFixed(2)}</span>
-              <span className="text-gray-500 ml-1">(based on file size)</span>
+              <span className="text-surface-500 ml-1">(based on file size)</span>
             </p>
           )}
           <button
@@ -319,7 +319,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
             className={`
               w-full py-2 px-4 rounded-lg font-medium transition-colors
               ${isUploading
-                ? 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                ? 'bg-surface-700 text-surface-400 cursor-not-allowed'
                 : 'bg-green-600 hover:bg-green-500 text-white'
               }
             `}

--- a/web/src/components/TranscriptUploader.tsx
+++ b/web/src/components/TranscriptUploader.tsx
@@ -197,9 +197,9 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
       return <span className="text-pbs-400 animate-spin">⟳</span>
     }
     if (status.success) {
-      return <span className="text-green-400">✓</span>
+      return <span className="text-status-completed">✓</span>
     }
-    return <span className="text-red-400">✗</span>
+    return <span className="text-status-failed">✗</span>
   }
 
   return (
@@ -283,14 +283,14 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
                       </a>
                     )}
                     {status?.error && (
-                      <span className="text-red-400 text-xs max-w-xs truncate" title={status.error}>
+                      <span className="text-status-failed text-xs max-w-xs truncate" title={status.error}>
                         {status.error}
                       </span>
                     )}
                     {!isUploading && !status && (
                       <button
                         onClick={() => removeFile(idx)}
-                        className="text-surface-400 hover:text-red-400 transition-colors"
+                        className="text-surface-400 hover:text-status-failed transition-colors"
                         aria-label="Remove file"
                       >
                         ✕
@@ -309,7 +309,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
         <>
           {estimatedCost !== null && (
             <p className="text-sm text-surface-400 text-center">
-              Estimated cost: <span className="text-green-400 font-mono">~${estimatedCost.toFixed(2)}</span>
+              Estimated cost: <span className="text-status-completed font-mono">~${estimatedCost.toFixed(2)}</span>
               <span className="text-surface-500 ml-1">(based on file size)</span>
             </p>
           )}
@@ -320,7 +320,7 @@ export default function TranscriptUploader({ onUploadComplete }: TranscriptUploa
               w-full py-2 px-4 rounded-lg font-medium transition-colors
               ${isUploading
                 ? 'bg-surface-700 text-surface-400 cursor-not-allowed'
-                : 'bg-green-600 hover:bg-green-500 text-white'
+                : 'bg-pbs-500 hover:bg-pbs-400 text-white'
               }
             `}
           >

--- a/web/src/components/ui/Breadcrumb.tsx
+++ b/web/src/components/ui/Breadcrumb.tsx
@@ -19,7 +19,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
           return (
             <li key={index} className="flex items-center">
               {index > 0 && (
-                <span className="text-gray-500 mx-2" aria-hidden="true">
+                <span className="text-surface-400 mx-2" aria-hidden="true">
                   /
                 </span>
               )}
@@ -33,7 +33,7 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
               ) : (
                 <Link
                   to={item.href || '#'}
-                  className="text-gray-400 hover:text-white transition-colors"
+                  className="text-surface-400 hover:text-white transition-colors"
                 >
                   {item.label}
                 </Link>

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -63,15 +63,15 @@ export default function ConfirmDialog({
   const variantStyles: Record<DialogVariant, { icon: string; iconBg: string; iconColor: string; confirmBg: string }> = {
     danger: {
       icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-      iconBg: 'bg-red-900/50',
-      iconColor: 'text-red-400',
-      confirmBg: 'bg-red-600 hover:bg-red-500',
+      iconBg: 'bg-status-failed/20',
+      iconColor: 'text-status-failed',
+      confirmBg: 'bg-status-failed hover:bg-status-failed/80',
     },
     warning: {
       icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-      iconBg: 'bg-yellow-900/50',
-      iconColor: 'text-yellow-400',
-      confirmBg: 'bg-yellow-600 hover:bg-yellow-500',
+      iconBg: 'bg-status-pending/20',
+      iconColor: 'text-status-pending',
+      confirmBg: 'bg-status-pending hover:bg-status-pending/80',
     },
     info: {
       icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -75,9 +75,9 @@ export default function ConfirmDialog({
     },
     info: {
       icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-      iconBg: 'bg-blue-900/50',
-      iconColor: 'text-blue-400',
-      confirmBg: 'bg-blue-600 hover:bg-blue-500',
+      iconBg: 'bg-pbs-900/50',
+      iconColor: 'text-pbs-400',
+      confirmBg: 'bg-pbs-500 hover:bg-pbs-400',
     },
   }
 
@@ -101,7 +101,7 @@ export default function ConfirmDialog({
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"
         aria-describedby="confirm-dialog-description"
-        className="relative bg-gray-800 rounded-lg border border-gray-700 shadow-xl max-w-md w-full p-6 motion-reduce:transition-none transform transition-all duration-200"
+        className="relative bg-surface-800 rounded-lg border border-surface-700 shadow-xl max-w-md w-full p-6 motion-reduce:transition-none transform transition-all duration-200"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-4">
@@ -123,7 +123,7 @@ export default function ConfirmDialog({
             <h2 id="confirm-dialog-title" className="text-lg font-semibold text-white">
               {title}
             </h2>
-            <div id="confirm-dialog-description" className="mt-2 text-sm text-gray-300">
+            <div id="confirm-dialog-description" className="mt-2 text-sm text-surface-300">
               {message}
             </div>
           </div>
@@ -134,13 +134,13 @@ export default function ConfirmDialog({
           <button
             ref={cancelButtonRef}
             onClick={onCancel}
-            className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-gray-800"
+            className="px-4 py-2 text-sm font-medium text-surface-300 bg-surface-700 hover:bg-surface-600 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-surface-400 focus:ring-offset-2 focus:ring-offset-surface-800"
           >
             {cancelText}
           </button>
           <button
             onClick={onConfirm}
-            className={`px-4 py-2 text-sm font-medium text-white ${styles.confirmBg} rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800`}
+            className={`px-4 py-2 text-sm font-medium text-white ${styles.confirmBg} rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-surface-800`}
           >
             {confirmText}
           </button>

--- a/web/src/components/ui/LoadingSpinner.tsx
+++ b/web/src/components/ui/LoadingSpinner.tsx
@@ -18,7 +18,7 @@ export default function LoadingSpinner({
   return (
     <div className={`inline-flex items-center gap-2 ${className}`} role="status" aria-live="polite">
       <svg
-        className={`animate-spin text-gray-400 motion-reduce:animate-none ${sizeClasses[size]}`}
+        className={`animate-spin text-surface-400 motion-reduce:animate-none ${sizeClasses[size]}`}
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -8,7 +8,7 @@ interface SkeletonProps {
 export function Skeleton({ className = '' }: SkeletonProps) {
   return (
     <div
-      className={`animate-pulse bg-gray-700 rounded ${className}`}
+      className={`animate-pulse bg-surface-700 rounded ${className}`}
       aria-hidden="true"
     />
   )
@@ -19,7 +19,7 @@ export function Skeleton({ className = '' }: SkeletonProps) {
  */
 export function SkeletonCard() {
   return (
-    <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+    <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
       <Skeleton className="h-4 w-20 mb-2" />
       <Skeleton className="h-8 w-16" />
     </div>
@@ -31,7 +31,7 @@ export function SkeletonCard() {
  */
 export function SkeletonTableRow() {
   return (
-    <tr className="border-b border-gray-700">
+    <tr className="border-b border-surface-700">
       <td className="px-4 py-3"><Skeleton className="h-4 w-8" /></td>
       <td className="px-4 py-3"><Skeleton className="h-4 w-48" /></td>
       <td className="px-4 py-3"><Skeleton className="h-5 w-20 rounded-full" /></td>
@@ -48,7 +48,7 @@ export function SkeletonTableRow() {
  */
 export function SkeletonListItem() {
   return (
-    <div className="p-4 bg-gray-800 border border-gray-700 rounded-lg">
+    <div className="p-4 bg-surface-800 border border-surface-700 rounded-lg">
       <div className="flex items-center justify-between">
         <div className="flex-1">
           <Skeleton className="h-5 w-48 mb-2" />
@@ -80,12 +80,12 @@ export function SkeletonDashboard() {
       </div>
 
       {/* Recent Jobs */}
-      <div className="bg-gray-800 rounded-lg border border-gray-700">
-        <div className="px-4 py-3 border-b border-gray-700 flex items-center justify-between">
+      <div className="bg-surface-800 rounded-lg border border-surface-700">
+        <div className="px-4 py-3 border-b border-surface-700 flex items-center justify-between">
           <Skeleton className="h-5 w-32" />
           <Skeleton className="h-4 w-16" />
         </div>
-        <div className="divide-y divide-gray-700">
+        <div className="divide-y divide-surface-700">
           {[1, 2, 3, 4, 5].map((i) => (
             <div key={i} className="px-4 py-3">
               <div className="flex items-center justify-between">
@@ -118,9 +118,9 @@ export function SkeletonQueue() {
 
       <Skeleton className="h-10 w-96" />
 
-      <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+      <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
         <table className="w-full">
-          <thead className="bg-gray-850 border-b border-gray-700">
+          <thead className="bg-surface-850 border-b border-surface-700">
             <tr>
               <th className="px-4 py-3"><Skeleton className="h-4 w-8" /></th>
               <th className="px-4 py-3"><Skeleton className="h-4 w-20" /></th>

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -99,21 +99,21 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
 
   const variantStyles: Record<ToastVariant, { bg: string; border: string; text: string; icon: string }> = {
     success: {
-      bg: 'bg-green-900/90',
-      border: 'border-status-completed/40',
-      text: 'text-green-100',
+      bg: 'bg-status-completed/90',
+      border: 'border-status-completed/50',
+      text: 'text-white',
       icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
     },
     error: {
-      bg: 'bg-red-900/90',
-      border: 'border-status-failed/40',
-      text: 'text-red-100',
+      bg: 'bg-status-failed/90',
+      border: 'border-status-failed/50',
+      text: 'text-white',
       icon: 'M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z',
     },
     warning: {
-      bg: 'bg-amber-900/90',
-      border: 'border-status-pending/40',
-      text: 'text-amber-100',
+      bg: 'bg-status-pending/90',
+      border: 'border-status-pending/50',
+      text: 'text-white',
       icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
     },
     info: {

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -117,9 +117,9 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
       icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
     },
     info: {
-      bg: 'bg-blue-900/90',
-      border: 'border-blue-500/50',
-      text: 'text-blue-100',
+      bg: 'bg-pbs-900/90',
+      border: 'border-pbs-500/50',
+      text: 'text-pbs-100',
       icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
     },
   }

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -100,20 +100,20 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
   const variantStyles: Record<ToastVariant, { bg: string; border: string; text: string; icon: string }> = {
     success: {
       bg: 'bg-green-900/90',
-      border: 'border-green-500/50',
+      border: 'border-status-completed/40',
       text: 'text-green-100',
       icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
     },
     error: {
       bg: 'bg-red-900/90',
-      border: 'border-red-500/50',
+      border: 'border-status-failed/40',
       text: 'text-red-100',
       icon: 'M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z',
     },
     warning: {
-      bg: 'bg-yellow-900/90',
-      border: 'border-yellow-500/50',
-      text: 'text-yellow-100',
+      bg: 'bg-amber-900/90',
+      border: 'border-status-pending/40',
+      text: 'text-amber-100',
       icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
     },
     info: {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -30,7 +30,7 @@ body {
 
 /* Focus-visible styles for keyboard navigation */
 *:focus-visible {
-  outline: 2px solid #3b82f6; /* blue-500 */
+  outline: 2px solid #5283d6; /* pbs-400 */
   outline-offset: 2px;
 }
 

--- a/web/src/pages/Help.tsx
+++ b/web/src/pages/Help.tsx
@@ -64,7 +64,41 @@ export default function Help() {
   }
 
   return (
-    <div className="flex gap-8">
+    <div className="lg:flex lg:gap-8">
+      {/* Mobile TOC — collapsible, shown below lg: */}
+      <details className="lg:hidden mb-6">
+        <summary className="flex items-center justify-between px-4 py-3 bg-surface-800 rounded-lg border border-surface-700 cursor-pointer text-sm font-display font-semibold text-surface-300 select-none">
+          <span>Contents</span>
+          <svg className="w-4 h-4 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <nav className="mt-2 px-4 py-3 bg-surface-800 rounded-lg border border-surface-700" aria-label="Table of contents">
+          <ul className="space-y-1">
+            {toc.filter(e => e.level <= 2).map((entry) => (
+              <li key={entry.id}>
+                <button
+                  onClick={() => {
+                    scrollTo(entry.id)
+                    const details = document.querySelector('details.lg\\:hidden') as HTMLDetailsElement
+                    if (details) details.open = false
+                  }}
+                  className={`block w-full text-left text-sm px-2 py-1 rounded transition-colors ${
+                    entry.level === 2 ? 'pl-4' : ''
+                  } ${
+                    activeSection === entry.id
+                      ? 'text-pbs-400 bg-surface-700'
+                      : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
+                  }`}
+                >
+                  {entry.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </details>
+
       {/* Table of Contents Sidebar */}
       <nav
         className="hidden lg:block w-56 flex-shrink-0 sticky top-20 self-start max-h-[calc(100vh-6rem)] overflow-y-auto"
@@ -95,8 +129,8 @@ export default function Help() {
 
       {/* Main Content */}
       <article className="flex-1 min-w-0">
-        <div className="bg-surface-800 rounded-lg border border-surface-700 p-8">
-          <div className="prose prose-invert prose-gray max-w-none
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 sm:p-6 lg:p-8">
+          <div className="prose prose-invert max-w-none
             prose-headings:scroll-mt-20
             prose-h1:text-2xl prose-h1:font-bold prose-h1:text-white prose-h1:border-b prose-h1:border-surface-700 prose-h1:pb-3 prose-h1:mb-6
             prose-h2:text-xl prose-h2:font-semibold prose-h2:text-white prose-h2:mt-10 prose-h2:mb-4

--- a/web/src/pages/Help.tsx
+++ b/web/src/pages/Help.tsx
@@ -70,7 +70,7 @@ export default function Help() {
         className="hidden lg:block w-56 flex-shrink-0 sticky top-20 self-start max-h-[calc(100vh-6rem)] overflow-y-auto"
         aria-label="Table of contents"
       >
-        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+        <h2 className="text-sm font-semibold text-surface-400 uppercase tracking-wider mb-3">
           Contents
         </h2>
         <ul className="space-y-1">
@@ -82,8 +82,8 @@ export default function Help() {
                   entry.level === 2 ? 'pl-4' : ''
                 } ${
                   activeSection === entry.id
-                    ? 'text-blue-400 bg-gray-800'
-                    : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+                    ? 'text-pbs-400 bg-surface-800'
+                    : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
                 }`}
               >
                 {entry.text}
@@ -95,21 +95,21 @@ export default function Help() {
 
       {/* Main Content */}
       <article className="flex-1 min-w-0">
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-8">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-8">
           <div className="prose prose-invert prose-gray max-w-none
             prose-headings:scroll-mt-20
-            prose-h1:text-2xl prose-h1:font-bold prose-h1:text-white prose-h1:border-b prose-h1:border-gray-700 prose-h1:pb-3 prose-h1:mb-6
+            prose-h1:text-2xl prose-h1:font-bold prose-h1:text-white prose-h1:border-b prose-h1:border-surface-700 prose-h1:pb-3 prose-h1:mb-6
             prose-h2:text-xl prose-h2:font-semibold prose-h2:text-white prose-h2:mt-10 prose-h2:mb-4
-            prose-h3:text-lg prose-h3:font-medium prose-h3:text-gray-200
-            prose-p:text-gray-300 prose-p:leading-relaxed
-            prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
+            prose-h3:text-lg prose-h3:font-medium prose-h3:text-surface-200
+            prose-p:text-surface-300 prose-p:leading-relaxed
+            prose-a:text-pbs-400 prose-a:no-underline hover:prose-a:underline
             prose-strong:text-white
-            prose-code:text-blue-300 prose-code:bg-gray-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+            prose-code:text-pbs-300 prose-code:bg-surface-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
             prose-table:border-collapse
-            prose-th:bg-gray-900 prose-th:text-gray-200 prose-th:text-left prose-th:px-3 prose-th:py-2 prose-th:border prose-th:border-gray-700 prose-th:text-sm
-            prose-td:px-3 prose-td:py-2 prose-td:border prose-td:border-gray-700 prose-td:text-sm prose-td:text-gray-300
-            prose-li:text-gray-300
-            prose-hr:border-gray-700
+            prose-th:bg-surface-900 prose-th:text-surface-200 prose-th:text-left prose-th:px-3 prose-th:py-2 prose-th:border prose-th:border-surface-700 prose-th:text-sm
+            prose-td:px-3 prose-td:py-2 prose-td:border prose-td:border-surface-700 prose-td:text-sm prose-td:text-surface-300
+            prose-li:text-surface-300
+            prose-hr:border-surface-700
           ">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -704,7 +704,7 @@ export default function JobDetail() {
                       href={sstMetadata.media_manager_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-green-400 hover:text-green-300 text-sm inline-flex items-center"
+                      className="text-pbs-400 hover:text-pbs-300 text-sm inline-flex items-center"
                     >
                       View
                       <svg className="ml-1 w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -777,8 +777,8 @@ export default function JobDetail() {
                     {job.validation_result?.phase_results?.[phase.name] && (
                       <span className={`ml-2 px-2 py-0.5 rounded text-xs font-medium ${
                         job.validation_result.phase_results[phase.name].status === 'pass'
-                          ? 'bg-green-900/30 text-green-400'
-                          : 'bg-red-900/30 text-red-400'
+                          ? 'bg-status-completed/20 text-status-completed'
+                          : 'bg-status-failed/20 text-status-failed'
                       }`}>
                         {job.validation_result.phase_results[phase.name].status === 'pass' ? '\u2713 Pass' : '\u2717 Fail'}
                       </span>
@@ -789,13 +789,13 @@ export default function JobDetail() {
                       </span>
                     )}
                     {phase.attempts && phase.attempts > 1 && (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-orange-900/50 text-orange-300">
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-status-paused/15 text-status-paused">
                         {phase.attempts} attempts
                       </span>
                     )}
                     {phase.retry_count > 0 && (
                       <span
-                        className="text-xs px-2 py-0.5 rounded-full bg-amber-900/50 text-amber-300"
+                        className="text-xs px-2 py-0.5 rounded-full bg-status-pending/15 text-status-pending"
                         title={`Retried ${phase.retry_count} time${phase.retry_count > 1 ? 's' : ''}`}
                       >
                         &#8635; {phase.retry_count}
@@ -887,7 +887,7 @@ export default function JobDetail() {
                   <button
                     onClick={() => openRetryModal(key, label)}
                     disabled={isRetrying || retryingPhase !== null}
-                    className={`px-2 py-2 bg-surface-600 hover:bg-orange-600 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-surface-300 hover:text-white transition-colors disabled:opacity-50`}
+                    className={`px-2 py-2 bg-surface-600 hover:bg-pbs-400 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-surface-300 hover:text-white transition-colors disabled:opacity-50`}
                     aria-label={`Retry ${label}`}
                     title={`Retry this phase`}
                   >

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -469,13 +469,13 @@ export default function JobDetail() {
       case 'completed':
         return <span className="text-green-400">&#10003;</span>
       case 'in_progress':
-        return <span className="text-blue-400 animate-pulse">&#9679;</span>
+        return <span className="text-pbs-400 animate-pulse">&#9679;</span>
       case 'failed':
         return <span className="text-red-400">&#10007;</span>
       case 'skipped':
-        return <span className="text-gray-400">&#8212;</span>
+        return <span className="text-surface-400">&#8212;</span>
       default:
-        return <span className="text-gray-400">&#9675;</span>
+        return <span className="text-surface-400">&#9675;</span>
     }
   }
 
@@ -484,7 +484,7 @@ export default function JobDetail() {
       <div className="space-y-6" aria-label="Loading job details" role="status">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-5 w-96" />
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <Skeleton className="h-6 w-48 mb-4" />
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
@@ -505,7 +505,7 @@ export default function JobDetail() {
         <div role="alert" aria-live="assertive" className="text-red-400 mb-4">{error || 'Job not found'}</div>
         <button
           onClick={() => navigate(-1)}
-          className="text-blue-400 hover:text-blue-300"
+          className="text-pbs-400 hover:text-pbs-300"
         >
           Go back
         </button>
@@ -520,7 +520,7 @@ export default function JobDetail() {
         <div>
           <button
             onClick={() => navigate(-1)}
-            className="text-sm text-gray-400 hover:text-white mb-2 inline-block transition-colors"
+            className="text-sm text-surface-400 hover:text-white mb-2 inline-block transition-colors"
             aria-label="Go back to previous page"
           >
             &#8592; Back
@@ -549,10 +549,10 @@ export default function JobDetail() {
               </span>
             )}
           </div>
-          <p className="text-gray-400">
+          <p className="text-surface-400">
             Job #{job.id}
             {job.current_phase && job.status === 'in_progress' && (
-              <span className="ml-2 text-blue-400 animate-pulse">
+              <span className="ml-2 text-pbs-400 animate-pulse">
                 • Processing {job.current_phase}...
               </span>
             )}
@@ -572,7 +572,7 @@ export default function JobDetail() {
           {job.status === 'paused' && !job.error_message?.includes('TRUNCATION') && (
             <button
               onClick={() => handleAction('resume')}
-              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded-md text-sm"
+              className="px-3 py-1.5 bg-pbs-500 hover:bg-pbs-400 text-white rounded-md text-sm"
             >
               Resume
             </button>
@@ -610,7 +610,7 @@ export default function JobDetail() {
 
       {/* AirTable Metadata Panel */}
       {(job.airtable_url || job.media_id || sstMetadata) && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-medium text-white">AirTable Metadata</h2>
             {job.airtable_url && (
@@ -618,7 +618,7 @@ export default function JobDetail() {
                 href={job.airtable_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors"
+                className="inline-flex items-center text-sm text-pbs-400 hover:text-pbs-300 transition-colors"
               >
                 <span>Open in AirTable</span>
                 <svg
@@ -639,13 +639,13 @@ export default function JobDetail() {
           </div>
 
           {sstLoading ? (
-            <div className="text-gray-400 text-sm">Loading metadata...</div>
+            <div className="text-surface-400 text-sm">Loading metadata...</div>
           ) : (
             <div className="space-y-4">
               {/* Release Title */}
               {sstMetadata?.release_title && (
                 <div>
-                  <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                  <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                     Release Title
                   </div>
                   <div className="text-white">{sstMetadata.release_title}</div>
@@ -655,9 +655,9 @@ export default function JobDetail() {
               {/* Short Description */}
               {sstMetadata?.short_description && (
                 <div>
-                  <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                  <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                     Short Description
-                    <span className="ml-2 text-gray-500">
+                    <span className="ml-2 text-surface-400">
                       ({sstMetadata.short_description.length}/90 chars)
                     </span>
                   </div>
@@ -666,10 +666,10 @@ export default function JobDetail() {
               )}
 
               {/* Media ID & Links Row */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2 border-t border-gray-700">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2 border-t border-surface-700">
                 {job.media_id && (
                   <div>
-                    <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                       Media ID
                     </div>
                     <div className="text-white font-mono text-sm">{job.media_id}</div>
@@ -678,7 +678,7 @@ export default function JobDetail() {
 
                 {sstMetadata?.youtube_url && (
                   <div>
-                    <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                       YouTube
                     </div>
                     <a
@@ -697,7 +697,7 @@ export default function JobDetail() {
 
                 {sstMetadata?.media_manager_url && (
                   <div>
-                    <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                       Website
                     </div>
                     <a
@@ -716,10 +716,10 @@ export default function JobDetail() {
 
                 {job.airtable_record_id && (
                   <div>
-                    <div className="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    <div className="text-xs text-surface-400 uppercase tracking-wide mb-1">
                       Record ID
                     </div>
-                    <div className="text-gray-500 font-mono text-xs truncate" title={job.airtable_record_id}>
+                    <div className="text-surface-400 font-mono text-xs truncate" title={job.airtable_record_id}>
                       {job.airtable_record_id}
                     </div>
                   </div>
@@ -732,16 +732,16 @@ export default function JobDetail() {
 
       {/* Progress Bar for in_progress jobs */}
       {job.status === 'in_progress' && job.phases && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm text-gray-400">Processing Progress</span>
+            <span className="text-sm text-surface-400">Processing Progress</span>
             <span className="text-sm text-white">
               {job.phases.filter(p => p.status === 'completed').length} / {job.phases.length} phases
             </span>
           </div>
-          <div className="w-full bg-gray-700 rounded-full h-2.5">
+          <div className="w-full bg-surface-700 rounded-full h-2.5">
             <div
-              className="bg-blue-500 h-2.5 rounded-full transition-all duration-500"
+              className="bg-pbs-400 h-2.5 rounded-full transition-all duration-500"
               style={{
                 width: `${(job.phases.filter(p => p.status === 'completed').length / job.phases.length) * 100}%`
               }}
@@ -760,7 +760,7 @@ export default function JobDetail() {
 
       {/* Phases */}
       {job.phases && job.phases.length > 0 && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <h2 className="text-lg font-medium text-white mb-4">
             Processing Phases
           </h2>
@@ -768,7 +768,7 @@ export default function JobDetail() {
             {job.phases.map((phase, idx) => (
               <div
                 key={idx}
-                className="py-3 border-b border-gray-700 last:border-0"
+                className="py-3 border-b border-surface-700 last:border-0"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-3">
@@ -784,7 +784,7 @@ export default function JobDetail() {
                       </span>
                     )}
                     {phase.model && (
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-gray-700 text-gray-300 font-mono">
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-surface-700 text-surface-300 font-mono">
                         {phase.model}
                       </span>
                     )}
@@ -802,7 +802,7 @@ export default function JobDetail() {
                       </span>
                     )}
                   </div>
-                  <div className="flex items-center space-x-4 text-sm text-gray-400">
+                  <div className="flex items-center space-x-4 text-sm text-surface-400">
                     {phase.cost !== undefined && (
                       <span>${phase.cost.toFixed(4)}</span>
                     )}
@@ -812,12 +812,12 @@ export default function JobDetail() {
                   </div>
                 </div>
                 {phase.previous_runs && phase.previous_runs.length > 0 && (
-                  <div className="mt-1.5 ml-8 text-xs text-gray-500">
-                    <div className="text-gray-600 mb-1">Previous runs:</div>
+                  <div className="mt-1.5 ml-8 text-xs text-surface-400">
+                    <div className="text-surface-600 mb-1">Previous runs:</div>
                     {phase.previous_runs.map((run, i) => (
-                      <div key={i} className="flex items-center gap-2 text-gray-500 ml-2">
-                        <span className="text-gray-600">#{i + 1}</span>
-                        {run.model && <span className="font-mono text-gray-400">{run.model}</span>}
+                      <div key={i} className="flex items-center gap-2 text-surface-400 ml-2">
+                        <span className="text-surface-600">#{i + 1}</span>
+                        {run.model && <span className="font-mono text-surface-400">{run.model}</span>}
                         <span>${(run.cost || 0).toFixed(4)}</span>
                       </div>
                     ))}
@@ -847,7 +847,7 @@ export default function JobDetail() {
 
       {/* Outputs */}
       {job.outputs && Object.keys(job.outputs).length > 0 && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <h2 className="text-lg font-medium text-white mb-4">
             Output Files
           </h2>
@@ -867,7 +867,7 @@ export default function JobDetail() {
                   <button
                     onClick={(e) => handleViewOutput(key, actualFilename, e)}
                     disabled={loadingOutput}
-                    className="flex-1 flex items-center justify-center px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-l-md text-sm text-white transition-colors disabled:opacity-50"
+                    className="flex-1 flex items-center justify-center px-3 py-2 bg-surface-700 hover:bg-surface-600 rounded-l-md text-sm text-white transition-colors disabled:opacity-50"
                     aria-label={`View ${label}`}
                   >
                     <span className="mr-2">&#128196;</span>
@@ -876,7 +876,7 @@ export default function JobDetail() {
                   <a
                     href={`/api/jobs/${id}/outputs/${actualFilename}?download=true`}
                     download={actualFilename}
-                    className="px-2 py-2 bg-gray-600 hover:bg-blue-600 text-gray-300 hover:text-white transition-colors"
+                    className="px-2 py-2 bg-surface-600 hover:bg-pbs-500 text-surface-300 hover:text-white transition-colors"
                     aria-label={`Download ${label}`}
                     title={`Download ${label}`}
                   >
@@ -887,7 +887,7 @@ export default function JobDetail() {
                   <button
                     onClick={() => openRetryModal(key, label)}
                     disabled={isRetrying || retryingPhase !== null}
-                    className={`px-2 py-2 bg-gray-600 hover:bg-orange-600 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50`}
+                    className={`px-2 py-2 bg-surface-600 hover:bg-orange-600 ${driveConfigured ? '' : 'rounded-r-md'} text-sm text-surface-300 hover:text-white transition-colors disabled:opacity-50`}
                     aria-label={`Retry ${label}`}
                     title={`Retry this phase`}
                   >
@@ -923,9 +923,9 @@ export default function JobDetail() {
 
       {/* Keyword Report Upload — shown when reports exist or job is completed */}
       {(keywordReports.length > 0 || job.status === 'completed') && (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium text-gray-400">SEMRush Keyword Report</h2>
+            <h2 className="text-sm font-medium text-surface-400">SEMRush Keyword Report</h2>
             <div className="flex items-center gap-2">
               <input
                 ref={keywordInputRef}
@@ -940,7 +940,7 @@ export default function JobDetail() {
               />
               <label
                 htmlFor="keyword-report-input"
-                className={`px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-md text-sm cursor-pointer transition-colors ${keywordUploading ? 'opacity-50 pointer-events-none' : ''}`}
+                className={`px-3 py-1.5 bg-surface-700 hover:bg-surface-600 text-surface-300 rounded-md text-sm cursor-pointer transition-colors ${keywordUploading ? 'opacity-50 pointer-events-none' : ''}`}
               >
                 {keywordUploading ? 'Uploading...' : 'Upload'}
               </label>
@@ -950,9 +950,9 @@ export default function JobDetail() {
             <ul className="mt-2 space-y-1">
               {keywordReports.map((report) => (
                 <li key={report.filename} className="flex items-center justify-between text-sm">
-                  <span className="text-gray-300 font-mono">{report.filename}</span>
+                  <span className="text-surface-300 font-mono">{report.filename}</span>
                   {report.uploaded_at && (
-                    <span className="text-gray-500 text-xs">{report.uploaded_at}</span>
+                    <span className="text-surface-500 text-xs">{report.uploaded_at}</span>
                   )}
                 </li>
               ))}
@@ -1008,18 +1008,18 @@ export default function JobDetail() {
       )}
 
       {/* Timestamps */}
-      <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+      <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
         <h2 className="text-lg font-medium text-white mb-4">Timeline</h2>
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
-            <span className="text-gray-400">Queued:</span>
+            <span className="text-surface-400">Queued:</span>
             <span className="ml-2 text-white" title={formatTimestamp(job.queued_at)}>
               {formatRelativeTime(job.queued_at)}
             </span>
           </div>
           {job.started_at && (
             <div>
-              <span className="text-gray-400">Started:</span>
+              <span className="text-surface-400">Started:</span>
               <span className="ml-2 text-white" title={formatTimestamp(job.started_at)}>
                 {formatRelativeTime(job.started_at)}
               </span>
@@ -1027,7 +1027,7 @@ export default function JobDetail() {
           )}
           {job.completed_at && (
             <div>
-              <span className="text-gray-400">Completed:</span>
+              <span className="text-surface-400">Completed:</span>
               <span className="ml-2 text-white" title={formatTimestamp(job.completed_at)}>
                 {formatRelativeTime(job.completed_at)}
               </span>
@@ -1035,7 +1035,7 @@ export default function JobDetail() {
           )}
           {job.started_at && job.completed_at && (
             <div>
-              <span className="text-gray-400">Duration:</span>
+              <span className="text-surface-400">Duration:</span>
               <span className="ml-2 text-white">
                 {formatDuration(job.started_at, job.completed_at)}
               </span>
@@ -1043,7 +1043,7 @@ export default function JobDetail() {
           )}
           {job.last_heartbeat && job.status === 'in_progress' && (
             <div>
-              <span className="text-gray-400">Last heartbeat:</span>
+              <span className="text-surface-400">Last heartbeat:</span>
               <span className="ml-2 text-white" title={formatTimestamp(job.last_heartbeat)}>
                 {formatRelativeTime(job.last_heartbeat)}
               </span>
@@ -1054,7 +1054,7 @@ export default function JobDetail() {
             const totalRetries = retriedPhases.reduce((sum, p) => sum + (p.retry_count || 0), 0);
             return (
               <div>
-                <span className="text-gray-400">Retries:</span>
+                <span className="text-surface-400">Retries:</span>
                 <span className="ml-2 text-white">
                   {totalRetries === 0
                     ? 'None'
@@ -1073,19 +1073,19 @@ export default function JobDetail() {
           onClick={() => setRetryModal(null)}
         >
           <div
-            className="bg-gray-900 rounded-lg border border-gray-700 w-full max-w-md"
+            className="bg-surface-900 rounded-lg border border-surface-700 w-full max-w-md"
             role="dialog"
             aria-modal="true"
             aria-labelledby="retry-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
               <h3 id="retry-modal-title" className="text-base font-medium text-white">
                 Retry: {retryModal.label}
               </h3>
               <button
                 onClick={() => setRetryModal(null)}
-                className="text-gray-400 hover:text-white text-2xl leading-none"
+                className="text-surface-400 hover:text-white text-2xl leading-none"
                 aria-label="Close retry dialog"
               >
                 &times;
@@ -1093,14 +1093,14 @@ export default function JobDetail() {
             </div>
             <div className="p-4 space-y-4">
               <div>
-                <label htmlFor="retry-model" className="block text-sm text-gray-300 mb-1">
+                <label htmlFor="retry-model" className="block text-sm text-surface-300 mb-1">
                   Model
                 </label>
                 <select
                   id="retry-model"
                   value={retryModel}
                   onChange={(e) => setRetryModel(e.target.value)}
-                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 pr-8 text-sm text-white focus:outline-none focus:border-blue-500"
+                  className="w-full bg-surface-800 border border-surface-600 rounded px-3 py-2 pr-8 text-sm text-white focus:outline-none focus:border-pbs-500"
                 >
                   <option value="">Phase default</option>
                   {availableModels.map(m => (
@@ -1122,8 +1122,8 @@ export default function JobDetail() {
                 )
               })()}
               <div>
-                <label htmlFor="retry-feedback" className="block text-sm text-gray-300 mb-1">
-                  Editorial feedback <span className="text-gray-500">(optional)</span>
+                <label htmlFor="retry-feedback" className="block text-sm text-surface-300 mb-1">
+                  Editorial feedback <span className="text-surface-400">(optional)</span>
                 </label>
                 <textarea
                   id="retry-feedback"
@@ -1131,13 +1131,13 @@ export default function JobDetail() {
                   onChange={(e) => setRetryFeedback(e.target.value)}
                   placeholder="Optional: describe what to change..."
                   rows={4}
-                  className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-y"
+                  className="w-full bg-surface-800 border border-surface-600 rounded px-3 py-2 text-sm text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500 resize-y"
                 />
               </div>
               <div className="flex gap-3 justify-end pt-1">
                 <button
                   onClick={() => setRetryModal(null)}
-                  className="px-4 py-2 text-sm text-gray-300 hover:text-white transition-colors"
+                  className="px-4 py-2 text-sm text-surface-300 hover:text-white transition-colors"
                 >
                   Cancel
                 </button>
@@ -1161,20 +1161,20 @@ export default function JobDetail() {
         >
           <div
             ref={modalRef}
-            className="bg-gray-900 rounded-lg border border-gray-700 w-full max-w-4xl max-h-[90vh] flex flex-col"
+            className="bg-surface-900 rounded-lg border border-surface-700 w-full max-w-4xl max-h-[90vh] flex flex-col"
             role="dialog"
             aria-modal="true"
             aria-labelledby="output-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Modal Header */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
               <h3 id="output-modal-title" className="text-lg font-medium text-white">
                 {viewingOutput.label}
               </h3>
               <button
                 onClick={closeModal}
-                className="text-gray-400 hover:text-white text-2xl leading-none"
+                className="text-surface-400 hover:text-white text-2xl leading-none"
                 aria-label="Close output viewer"
               >
                 &times;
@@ -1183,7 +1183,7 @@ export default function JobDetail() {
             {/* Modal Content */}
             <div className="flex-1 overflow-auto p-4">
               {viewingOutput.isJson ? (
-                <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+                <pre className="text-sm text-surface-300 whitespace-pre-wrap font-mono">
                   {viewingOutput.content}
                 </pre>
               ) : (
@@ -1196,7 +1196,7 @@ export default function JobDetail() {
 
       {/* Screengrab Slideout */}
       {showScreengrabs && job?.media_id && (
-        <div className="fixed right-0 top-0 h-full w-1/3 min-w-[350px] bg-gray-900 border-l border-gray-700 z-40 shadow-xl">
+        <div className="fixed right-0 top-0 h-full w-1/3 min-w-[350px] bg-surface-900 border-l border-surface-700 z-40 shadow-xl">
           <ScreengrabSlideout
             mediaId={job.media_id}
             onClose={() => setShowScreengrabs(false)}
@@ -1222,16 +1222,16 @@ function CopyEditorHandoff({ projectName }: { projectName: string }) {
   }
 
   return (
-    <div className="flex items-center justify-between py-3 px-4 bg-gray-800 rounded-lg border border-gray-700">
+    <div className="flex items-center justify-between py-3 px-4 bg-surface-800 rounded-lg border border-surface-700">
       <div className="flex items-center gap-3 min-w-0">
-        <span className="text-sm text-gray-400">Copy editing prompt:</span>
+        <span className="text-sm text-surface-400">Copy editing prompt:</span>
         <code className="text-sm text-white select-all cursor-text truncate">
           {promptText}
         </code>
       </div>
       <button
         onClick={handleCopy}
-        className="ml-4 flex-shrink-0 px-3 py-1 text-sm text-gray-300 hover:text-white bg-gray-700 hover:bg-gray-600 rounded transition-colors"
+        className="ml-4 flex-shrink-0 px-3 py-1 text-sm text-surface-300 hover:text-white bg-surface-700 hover:bg-surface-600 rounded transition-colors"
         aria-label="Copy prompt to clipboard"
       >
         {copied ? 'Copied' : 'Copy'}

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -1196,7 +1196,7 @@ export default function JobDetail() {
 
       {/* Screengrab Slideout */}
       {showScreengrabs && job?.media_id && (
-        <div className="fixed right-0 top-0 h-full w-1/3 min-w-[350px] bg-surface-900 border-l border-surface-700 z-40 shadow-xl">
+        <div className="fixed right-0 top-0 h-full w-full sm:w-1/2 md:w-1/3 md:min-w-[350px] bg-surface-900 border-l border-surface-700 z-40 shadow-xl">
           <ScreengrabSlideout
             mediaId={job.media_id}
             onClose={() => setShowScreengrabs(false)}

--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -467,11 +467,11 @@ export default function JobDetail() {
   const phaseStatusIcon = (status: string) => {
     switch (status) {
       case 'completed':
-        return <span className="text-green-400">&#10003;</span>
+        return <span className="text-status-completed">&#10003;</span>
       case 'in_progress':
-        return <span className="text-pbs-400 animate-pulse">&#9679;</span>
+        return <span className="text-status-processing animate-pulse">&#9679;</span>
       case 'failed':
-        return <span className="text-red-400">&#10007;</span>
+        return <span className="text-status-failed">&#10007;</span>
       case 'skipped':
         return <span className="text-surface-400">&#8212;</span>
       default:
@@ -502,7 +502,7 @@ export default function JobDetail() {
   if (error || !job) {
     return (
       <div className="text-center py-12">
-        <div role="alert" aria-live="assertive" className="text-red-400 mb-4">{error || 'Job not found'}</div>
+        <div role="alert" aria-live="assertive" className="text-status-failed mb-4">{error || 'Job not found'}</div>
         <button
           onClick={() => navigate(-1)}
           className="text-pbs-400 hover:text-pbs-300"
@@ -999,9 +999,9 @@ export default function JobDetail() {
 
       {/* Error Message (non-truncation errors) */}
       {job.error_message && !job.error_message.includes('TRUNCATION') && (
-        <div role="alert" aria-live="assertive" className="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
-          <h3 className="text-red-400 font-medium mb-2">Error</h3>
-          <pre className="text-sm text-red-300 whitespace-pre-wrap">
+        <div role="alert" aria-live="assertive" className="bg-status-failed/15 border border-status-failed/30 rounded-lg p-4">
+          <h3 className="text-status-failed font-medium mb-2">Error</h3>
+          <pre className="text-sm text-status-failed/70 whitespace-pre-wrap">
             {job.error_message}
           </pre>
         </div>

--- a/web/src/pages/Projects.tsx
+++ b/web/src/pages/Projects.tsx
@@ -233,15 +233,15 @@ export default function Projects() {
     switch (status) {
       case 'completed': return <span className="text-green-400">✓</span>
       case 'failed': return <span className="text-red-400">✗</span>
-      case 'in_progress': return <span className="text-blue-400 animate-pulse">●</span>
-      default: return <span className="text-gray-400">○</span>
+      case 'in_progress': return <span className="text-pbs-400 animate-pulse">●</span>
+      default: return <span className="text-surface-400">○</span>
     }
   }
 
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-gray-300">Loading projects...</div>
+        <div className="text-surface-300">Loading projects...</div>
       </div>
     )
   }
@@ -252,7 +252,7 @@ export default function Projects() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Completed Projects</h1>
-          <span className="text-gray-400 text-sm">
+          <span className="text-surface-400 text-sm">
             {total} project{total !== 1 ? 's' : ''}
             {search && ` matching "${search}"`}
           </span>
@@ -268,14 +268,14 @@ export default function Projects() {
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search by filename..."
-              className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:border-blue-500 w-64"
+              className="bg-surface-800 border border-surface-700 rounded-lg px-4 py-2 text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500 w-64"
               aria-describedby="projects-search-desc"
             />
             {search && (
               <button
                 type="button"
                 onClick={clearSearch}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-surface-400 hover:text-white"
                 aria-label="Clear search"
               >
                 ✕
@@ -287,7 +287,7 @@ export default function Projects() {
           </div>
           <button
             type="submit"
-            className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg transition-colors"
+            className="bg-pbs-500 hover:bg-pbs-400 text-white px-4 py-2 rounded-lg transition-colors"
           >
             Search
           </button>
@@ -295,9 +295,9 @@ export default function Projects() {
       </div>
 
       {jobs.length === 0 ? (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-8 text-center">
-          <p className="text-gray-300">No completed projects yet.</p>
-          <p className="text-gray-400 text-sm mt-2">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-8 text-center">
+          <p className="text-surface-300">No completed projects yet.</p>
+          <p className="text-surface-400 text-sm mt-2">
             Projects will appear here once jobs finish processing.
           </p>
         </div>
@@ -305,7 +305,7 @@ export default function Projects() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Project List */}
           <div className="space-y-3">
-            <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+            <h2 className="text-sm font-medium text-surface-400 uppercase tracking-wide">
               Projects
             </h2>
             <div className="space-y-2">
@@ -315,15 +315,15 @@ export default function Projects() {
                   onClick={() => selectProject(job)}
                   className={`w-full text-left p-4 rounded-lg border transition-colors ${
                     selectedProject?.id === job.id
-                      ? 'bg-blue-900/30 border-blue-500/50'
-                      : 'bg-gray-800 border-gray-700 hover:border-gray-600'
+                      ? 'bg-pbs-900/30 border-pbs-500/50'
+                      : 'bg-surface-800 border-surface-700 hover:border-surface-600'
                   }`}
                 >
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-medium text-white">{job.project_name}</div>
                       <div
-                        className="text-sm text-gray-400"
+                        className="text-sm text-surface-400"
                         title={job.completed_at ? formatTimestamp(job.completed_at) : undefined}
                       >
                         {job.completed_at ? formatRelativeTime(job.completed_at) : 'Processing...'}
@@ -333,7 +333,7 @@ export default function Projects() {
                       <div className="text-green-400 font-mono text-sm">
                         {formatCost(job.actual_cost || 0)}
                       </div>
-                      <div className="text-xs text-gray-400">total cost</div>
+                      <div className="text-xs text-surface-400">total cost</div>
                     </div>
                   </div>
                 </button>
@@ -346,12 +346,12 @@ export default function Projects() {
             {selectedProject ? (
               <>
                 <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+                  <h2 className="text-sm font-medium text-surface-400 uppercase tracking-wide">
                     Project Details
                   </h2>
                   <Link
                     to={`/jobs/${selectedProject.id}`}
-                    className="text-sm text-blue-400 hover:text-blue-300"
+                    className="text-sm text-pbs-400 hover:text-pbs-300"
                   >
                     View full job →
                   </Link>
@@ -359,11 +359,11 @@ export default function Projects() {
 
                 {/* SST Context from Airtable */}
                 {loadingSst ? (
-                  <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-                    <div className="text-gray-400 text-sm">Loading metadata...</div>
+                  <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+                    <div className="text-surface-400 text-sm">Loading metadata...</div>
                   </div>
                 ) : sstMetadata && (
-                  <div className="bg-gray-800 rounded-lg border border-gray-700 p-4 space-y-3">
+                  <div className="bg-surface-800 rounded-lg border border-surface-700 p-4 space-y-3">
                     {/* Title Row */}
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex-1 min-w-0">
@@ -373,7 +373,7 @@ export default function Projects() {
                           </h3>
                         )}
                         {sstMetadata.media_id && (
-                          <span className="text-xs text-gray-400 font-mono">
+                          <span className="text-xs text-surface-400 font-mono">
                             {sstMetadata.media_id}
                           </span>
                         )}
@@ -383,7 +383,7 @@ export default function Projects() {
                           href={sstMetadata.airtable_url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-xs text-blue-400 hover:text-blue-300 whitespace-nowrap"
+                          className="text-xs text-pbs-400 hover:text-pbs-300 whitespace-nowrap"
                         >
                           SST →
                         </a>
@@ -392,7 +392,7 @@ export default function Projects() {
 
                     {/* Description */}
                     {sstMetadata.short_description && (
-                      <p className="text-sm text-gray-300 line-clamp-3">
+                      <p className="text-sm text-surface-300 line-clamp-3">
                         {sstMetadata.short_description}
                       </p>
                     )}
@@ -405,7 +405,7 @@ export default function Projects() {
                             href={sstMetadata.media_manager_url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-blue-400 hover:text-blue-300"
+                            className="text-pbs-400 hover:text-pbs-300"
                           >
                             PBS Website
                           </a>
@@ -426,15 +426,15 @@ export default function Projects() {
                 )}
 
                 {/* Phase Stats */}
-                <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-                  <h3 className="text-sm font-medium text-gray-400 mb-3">
+                <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+                  <h3 className="text-sm font-medium text-surface-400 mb-3">
                     Agent Phases
                   </h3>
                   <div className="space-y-2">
                     {selectedProject.phases?.map((phase, idx) => (
                       <div
                         key={idx}
-                        className="flex items-center justify-between py-2 border-b border-gray-700 last:border-0"
+                        className="flex items-center justify-between py-2 border-b border-surface-700 last:border-0"
                       >
                         <div className="flex items-center space-x-3">
                           {getPhaseIcon(phase.status)}
@@ -444,7 +444,7 @@ export default function Projects() {
                           <span className="text-green-400 font-mono">
                             {formatCost(phase.cost || 0)}
                           </span>
-                          <span className="text-gray-400">
+                          <span className="text-surface-400">
                             {(phase.tokens || 0).toLocaleString()} tokens
                           </span>
                         </div>
@@ -454,21 +454,21 @@ export default function Projects() {
                 </div>
 
                 {/* Artifacts */}
-                <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-                  <h3 className="text-sm font-medium text-gray-400 mb-3">
+                <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+                  <h3 className="text-sm font-medium text-surface-400 mb-3">
                     Artifacts
                   </h3>
                   {artifacts.length === 0 ? (
-                    <div className="text-gray-300 text-sm">No artifacts found</div>
+                    <div className="text-surface-300 text-sm">No artifacts found</div>
                   ) : (
                     <div className="space-y-1">
                       {artifacts.map((artifact, idx) => (
                         <div
                           key={idx}
-                          className="flex items-center justify-between py-2 px-3 rounded hover:bg-gray-700/50"
+                          className="flex items-center justify-between py-2 px-3 rounded hover:bg-surface-700/50"
                         >
                           <div className="flex items-center space-x-3">
-                            <span className="text-gray-400">
+                            <span className="text-surface-400">
                               {artifact.type === 'directory' ? '📁' : '📄'}
                             </span>
                             <span className="text-white text-sm">
@@ -478,7 +478,7 @@ export default function Projects() {
                           <button
                             onClick={(e) => handleViewArtifact(artifact, e)}
                             disabled={loadingArtifact}
-                            className="text-blue-400 hover:text-blue-300 text-sm disabled:opacity-50"
+                            className="text-pbs-400 hover:text-pbs-300 text-sm disabled:opacity-50"
                             aria-label={`View ${artifact.label}`}
                           >
                             {loadingArtifact ? 'Loading...' : 'View →'}
@@ -495,8 +495,8 @@ export default function Projects() {
                 )}
 
                 {/* Project Path */}
-                <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
-                  <h3 className="text-sm font-medium text-gray-400 mb-2">
+                <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
+                  <h3 className="text-sm font-medium text-surface-400 mb-2">
                     Output Location
                   </h3>
                   <code className="text-sm text-emerald-400 font-mono break-all">
@@ -505,8 +505,8 @@ export default function Projects() {
                 </div>
               </>
             ) : (
-              <div className="bg-gray-800 rounded-lg border border-gray-700 p-8 text-center">
-                <p className="text-gray-300">
+              <div className="bg-surface-800 rounded-lg border border-surface-700 p-8 text-center">
+                <p className="text-surface-300">
                   Select a project to view details and artifacts
                 </p>
               </div>
@@ -521,17 +521,17 @@ export default function Projects() {
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700 transition-colors"
+            className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-700 transition-colors"
           >
             ← Previous
           </button>
-          <span className="text-gray-400">
+          <span className="text-surface-400">
             Page {page} of {totalPages}
           </span>
           <button
             onClick={() => setPage(p => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
-            className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700 transition-colors"
+            className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-700 transition-colors"
           >
             Next →
           </button>
@@ -546,23 +546,23 @@ export default function Projects() {
         >
           <div
             ref={modalRef}
-            className="bg-gray-900 rounded-lg border border-gray-700 w-full max-w-4xl max-h-[90vh] flex flex-col"
+            className="bg-surface-900 rounded-lg border border-surface-700 w-full max-w-4xl max-h-[90vh] flex flex-col"
             role="dialog"
             aria-modal="true"
             aria-labelledby="artifact-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Modal Header */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700">
               <h3 id="artifact-modal-title" className="text-lg font-medium text-white">
                 {viewingArtifact.label}
-                <span className="ml-2 text-sm text-gray-400 font-mono font-normal">
+                <span className="ml-2 text-sm text-surface-400 font-mono font-normal">
                   {viewingArtifact.name}
                 </span>
               </h3>
               <button
                 onClick={closeModal}
-                className="text-gray-400 hover:text-white text-2xl leading-none"
+                className="text-surface-400 hover:text-white text-2xl leading-none"
                 aria-label="Close artifact viewer"
               >
                 &times;
@@ -571,7 +571,7 @@ export default function Projects() {
             {/* Modal Content */}
             <div className="flex-1 overflow-auto p-4">
               {viewingArtifact.isJson ? (
-                <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+                <pre className="text-sm text-surface-300 whitespace-pre-wrap font-mono">
                   {JSON.stringify(JSON.parse(viewingArtifact.content), null, 2)}
                 </pre>
               ) : (

--- a/web/src/pages/Queue.tsx
+++ b/web/src/pages/Queue.tsx
@@ -274,7 +274,7 @@ export default function Queue() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Job Queue</h1>
-          <span className="text-gray-400 text-sm">
+          <span className="text-surface-400 text-sm">
             {total} job{total !== 1 ? 's' : ''}
             {filter !== 'all' && ` (${filter.replace('_', ' ')})`}
             {debouncedSearch && ` matching "${debouncedSearch}"`}
@@ -286,7 +286,7 @@ export default function Queue() {
           {/* Upload Button */}
           <button
             onClick={() => setShowUploader(!showUploader)}
-            className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded-md transition-colors"
+            className="px-3 py-1.5 text-sm bg-pbs-500 hover:bg-pbs-400 text-white rounded-md transition-colors"
             title="Upload transcript files"
           >
             {showUploader ? 'Hide Upload' : '+ Upload'}
@@ -310,14 +310,14 @@ export default function Queue() {
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search by filename..."
-              className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-400 focus:outline-none focus:border-blue-500 w-64 pr-8"
+              className="bg-surface-800 border border-surface-700 rounded-lg px-4 py-2 text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500 w-64 pr-8"
               aria-describedby="queue-search-desc"
             />
             {searchInput && (
               <button
                 type="button"
                 onClick={clearSearch}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-surface-400 hover:text-white"
                 aria-label="Clear search"
               >
                 ✕
@@ -336,7 +336,7 @@ export default function Queue() {
       )}
 
       {/* Filter Tabs */}
-      <div className="flex items-center space-x-1 bg-gray-800 rounded-lg p-1 w-fit">
+      <div className="flex items-center space-x-1 bg-surface-800 rounded-lg p-1 w-fit">
         {['all', 'pending', 'in_progress', 'completed', 'failed', 'cancelled'].map((status) => {
           const count = stats
             ? status === 'all'
@@ -350,8 +350,8 @@ export default function Queue() {
               onClick={() => handleFilterChange(status)}
               className={`px-3 py-1.5 text-sm rounded-md transition-colors flex items-center space-x-1.5 ${
                 filter === status
-                  ? 'bg-gray-700 text-white'
-                  : 'text-gray-400 hover:text-white'
+                  ? 'bg-surface-700 text-white'
+                  : 'text-surface-400 hover:text-white'
               }`}
             >
               <span>{status === 'all' ? 'All' : status.replace('_', ' ')}</span>
@@ -359,8 +359,8 @@ export default function Queue() {
                 <span
                   className={`px-1.5 py-0.5 text-xs rounded-full ${
                     filter === status
-                      ? 'bg-gray-600 text-gray-200'
-                      : 'bg-gray-700 text-gray-400'
+                      ? 'bg-surface-600 text-surface-200'
+                      : 'bg-surface-700 text-surface-400'
                   }`}
                 >
                   {count}
@@ -375,15 +375,15 @@ export default function Queue() {
       {loading ? (
         <SkeletonQueue />
       ) : (
-        <div className="bg-gray-800 rounded-lg border border-gray-700 overflow-hidden">
+        <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">
         {jobs.length === 0 ? (
-          <div className="px-4 py-8 text-center text-gray-300">
+          <div className="px-4 py-8 text-center text-surface-300">
             No jobs found
           </div>
         ) : (
           <table className="w-full">
-            <thead className="bg-gray-850 border-b border-gray-700">
-              <tr className="text-left text-sm text-gray-300">
+            <thead className="bg-surface-850 border-b border-surface-700">
+              <tr className="text-left text-sm text-surface-300">
                 <th className="px-4 py-3 font-medium">ID</th>
                 <th className="px-4 py-3 font-medium">Transcript</th>
                 <th className="px-4 py-3 font-medium">Status</th>
@@ -393,16 +393,16 @@ export default function Queue() {
                 <th className="px-4 py-3 font-medium">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-700">
+            <tbody className="divide-y divide-surface-700">
               {jobs.map((job) => (
                 <tr
                   key={job.id}
-                  className="hover:bg-gray-750 transition-colors"
+                  className="hover:bg-surface-800 transition-colors"
                 >
                   <td className="px-4 py-3">
                     <Link
                       to={`/jobs/${job.id}`}
-                      className="text-blue-400 hover:text-blue-300"
+                      className="text-pbs-400 hover:text-pbs-300"
                     >
                       #{job.id}
                     </Link>
@@ -419,16 +419,16 @@ export default function Queue() {
                       {job.status}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-gray-300 text-sm">
+                  <td className="px-4 py-3 text-surface-300 text-sm">
                     {job.current_phase || '-'}
                   </td>
                   <td
-                    className="px-4 py-3 text-gray-300 text-sm"
+                    className="px-4 py-3 text-surface-300 text-sm"
                     title={formatTimestamp(job.queued_at + 'Z')}
                   >
                     {formatRelativeTime(job.queued_at + 'Z')}
                   </td>
-                  <td className="px-4 py-3 text-gray-300 text-sm">
+                  <td className="px-4 py-3 text-surface-300 text-sm">
                     {job.priority}
                   </td>
                   <td className="px-4 py-3">
@@ -437,7 +437,7 @@ export default function Queue() {
                         <>
                           <button
                             onClick={() => handlePrioritize(job.id)}
-                            className="px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+                            className="px-2 py-1 text-xs bg-pbs-500 hover:bg-pbs-400 text-white rounded transition-colors"
                             title="Move to top of queue"
                           >
                             ↑ Prioritize
@@ -452,12 +452,12 @@ export default function Queue() {
                         </>
                       )}
                       {job.status === 'in_progress' && (
-                        <span className="text-xs text-gray-300">Processing...</span>
+                        <span className="text-xs text-surface-300">Processing...</span>
                       )}
                       {['completed', 'failed', 'cancelled'].includes(job.status) && (
                         <Link
                           to={`/jobs/${job.id}`}
-                          className="text-xs text-gray-300 hover:text-white"
+                          className="text-xs text-surface-300 hover:text-white"
                         >
                           View details
                         </Link>
@@ -478,17 +478,17 @@ export default function Queue() {
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700 transition-colors"
+            className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-700 transition-colors"
           >
             ← Previous
           </button>
-          <span className="text-gray-400">
+          <span className="text-surface-400">
             Page {page} of {totalPages}
           </span>
           <button
             onClick={() => setPage(p => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
-            className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-700 transition-colors"
+            className="px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-700 transition-colors"
           >
             Next →
           </button>

--- a/web/src/pages/Queue.tsx
+++ b/web/src/pages/Queue.tsx
@@ -282,7 +282,7 @@ export default function Queue() {
         </div>
 
         {/* Upload, Clear Button and Search */}
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-3">
           {/* Upload Button */}
           <button
             onClick={() => setShowUploader(!showUploader)}
@@ -310,7 +310,7 @@ export default function Queue() {
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search by filename..."
-              className="bg-surface-800 border border-surface-700 rounded-lg px-4 py-2 text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500 w-64 pr-8"
+              className="bg-surface-800 border border-surface-700 rounded-lg px-4 py-2 text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500 w-full sm:w-64 pr-8"
               aria-describedby="queue-search-desc"
             />
             {searchInput && (

--- a/web/src/pages/ReadyForWork.tsx
+++ b/web/src/pages/ReadyForWork.tsx
@@ -245,20 +245,20 @@ export default function ReadyForWork() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-white">Ready for Work</h1>
-          <p className="text-gray-400 mt-1">
+          <p className="text-surface-400 mt-1">
             Transcripts from the ingest server ready for processing
           </p>
         </div>
         <div className="flex items-center space-x-3">
           {lastScanAt && (
-            <span className="text-sm text-gray-400" title={new Date(lastScanAt + 'Z').toLocaleString()}>
+            <span className="text-sm text-surface-400" title={new Date(lastScanAt + 'Z').toLocaleString()}>
               Last scan: {formatRelativeTime(lastScanAt + 'Z')}
             </span>
           )}
           <button
             onClick={handleScan}
             disabled={scanning}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
+            className="px-4 py-2 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded-lg transition-colors font-medium"
           >
             {scanning ? 'Checking...' : 'Check for New Files'}
           </button>
@@ -275,7 +275,7 @@ export default function ReadyForWork() {
             placeholder="Search by filename or Media ID..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+            className="w-full px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white placeholder-surface-400 focus:outline-none focus:border-pbs-500"
           />
         </div>
         <label htmlFor="days" className="sr-only">Date Range</label>
@@ -283,7 +283,7 @@ export default function ReadyForWork() {
           id="days"
           value={days}
           onChange={(e) => updateFilters(search, parseInt(e.target.value, 10))}
-          className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:border-blue-500"
+          className="px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-white text-sm focus:outline-none focus:border-pbs-500"
         >
           {DATE_RANGE_OPTIONS.map(opt => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -292,7 +292,7 @@ export default function ReadyForWork() {
         {hasActiveFilters && (
           <button
             onClick={clearFilters}
-            className="text-sm text-gray-400 hover:text-white transition-colors"
+            className="text-sm text-surface-400 hover:text-white transition-colors"
           >
             Clear
           </button>
@@ -308,15 +308,15 @@ export default function ReadyForWork() {
 
       {/* Bulk Actions */}
       {selectedFileIds.size > 0 && (
-        <div className="bg-blue-900/20 border border-blue-500/30 rounded-lg p-4">
+        <div className="bg-pbs-900/20 border border-pbs-500/30 rounded-lg p-4">
           <div className="flex items-center justify-between">
-            <span className="text-blue-400">
+            <span className="text-pbs-400">
               {selectedFileIds.size} file{selectedFileIds.size !== 1 ? 's' : ''} selected
             </span>
             <div className="flex items-center space-x-3">
               <button
                 onClick={() => setSelectedFileIds(new Set())}
-                className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+                className="px-3 py-1.5 text-sm text-surface-400 hover:text-white transition-colors"
               >
                 Clear selection
               </button>
@@ -332,9 +332,9 @@ export default function ReadyForWork() {
       )}
 
       {/* Results Card */}
-      <div className="bg-gray-800 rounded-lg border border-gray-700">
+      <div className="bg-surface-800 rounded-lg border border-surface-700">
         {/* Results Header */}
-        <div className="px-6 py-4 border-b border-gray-700">
+        <div className="px-6 py-4 border-b border-surface-700">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-white">
               {loading ? 'Loading...' : `${files.length} transcript${files.length !== 1 ? 's' : ''}`}
@@ -345,24 +345,24 @@ export default function ReadyForWork() {
                   type="checkbox"
                   checked={selectedFileIds.size === files.length && files.length > 0}
                   onChange={toggleSelectAll}
-                  className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500"
+                  className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-pbs-500 focus:ring-pbs-400"
                 />
-                <span className="text-sm text-gray-400">Select all</span>
+                <span className="text-sm text-surface-400">Select all</span>
               </label>
             )}
           </div>
         </div>
 
         {/* File List */}
-        <div className="divide-y divide-gray-700">
+        <div className="divide-y divide-surface-700">
           {loading ? (
             <div className="py-12 text-center">
-              <p className="text-gray-400 animate-pulse">Loading available files...</p>
+              <p className="text-surface-400 animate-pulse">Loading available files...</p>
             </div>
           ) : files.length === 0 ? (
             <div className="py-12 text-center">
-              <p className="text-gray-400">No transcript files match your filters</p>
-              <p className="text-sm text-gray-500 mt-1">
+              <p className="text-surface-400">No transcript files match your filters</p>
+              <p className="text-sm text-surface-400 mt-1">
                 {hasActiveFilters
                   ? 'Try adjusting your search or date range'
                   : 'Click "Check for New Files" to scan for new transcripts'}
@@ -372,14 +372,14 @@ export default function ReadyForWork() {
             files.map((file) => (
               <div
                 key={file.id}
-                className="flex items-center justify-between px-6 py-4 hover:bg-gray-750 transition-colors"
+                className="flex items-center justify-between px-6 py-4 hover:bg-surface-800 transition-colors"
               >
                 <div className="flex items-center space-x-4 flex-1 min-w-0">
                   <input
                     type="checkbox"
                     checked={selectedFileIds.has(file.id)}
                     onChange={() => toggleFileSelection(file.id)}
-                    className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500"
+                    className="w-4 h-4 rounded border-surface-600 bg-surface-700 text-pbs-500 focus:ring-pbs-400"
                   />
 
                   <div className="flex-1 min-w-0">
@@ -387,14 +387,14 @@ export default function ReadyForWork() {
                       {file.media_id ? (
                         <span className="font-medium text-white font-mono">{file.media_id}</span>
                       ) : (
-                        <span className="font-medium text-gray-300 truncate">{file.filename}</span>
+                        <span className="font-medium text-surface-300 truncate">{file.filename}</span>
                       )}
                     </div>
-                    <div className="text-sm text-gray-400 mt-0.5">
+                    <div className="text-sm text-surface-400 mt-0.5">
                       {formatTimestamp(
                         file.remote_modified_at || file.first_seen_at
                       )}
-                      <span className="text-gray-500 ml-2">
+                      <span className="text-surface-400 ml-2">
                         ({formatRelativeTime(
                           file.remote_modified_at || file.first_seen_at
                         )})
@@ -412,7 +412,7 @@ export default function ReadyForWork() {
                   </button>
                   <button
                     onClick={() => handleIgnoreFile(file.id)}
-                    className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-md transition-colors"
+                    className="px-3 py-1.5 text-sm bg-surface-700 hover:bg-surface-600 text-surface-300 rounded-md transition-colors"
                   >
                     Ignore
                   </button>

--- a/web/src/pages/ReadyForWork.tsx
+++ b/web/src/pages/ReadyForWork.tsx
@@ -301,8 +301,8 @@ export default function ReadyForWork() {
 
       {/* Error Message */}
       {error && (
-        <div role="alert" className="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
-          <p className="text-red-400">{error}</p>
+        <div role="alert" className="bg-status-failed/15 border border-status-failed/30 rounded-lg p-4">
+          <p className="text-status-failed">{error}</p>
         </div>
       )}
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -493,7 +493,7 @@ export default function Settings() {
                       <label htmlFor="concurrent-jobs" className="font-medium text-white">Concurrent Jobs</label>
                       <div className="text-sm text-surface-400">Process multiple jobs simultaneously</div>
                     </div>
-                    <span className="text-2xl font-bold text-cyan-400">{getCurrentWorker().max_concurrent_jobs}</span>
+                    <span className="text-2xl font-bold text-pbs-300">{getCurrentWorker().max_concurrent_jobs}</span>
                   </div>
                   <input
                     id="concurrent-jobs"
@@ -621,7 +621,7 @@ export default function Settings() {
                     <div className="font-medium text-white">Server URL</div>
                     <div className="text-sm text-surface-400">Remote file server location</div>
                   </div>
-                  <code className="block p-2 bg-surface-800 rounded text-cyan-400 text-sm">
+                  <code className="block p-2 bg-surface-800 rounded text-pbs-300 text-sm">
                     {getCurrentIngest().server_url || 'Not configured'}
                   </code>
                 </div>
@@ -678,7 +678,11 @@ export default function Settings() {
             {/* Screengrab Info */}
             <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-start space-x-3">
-                <span className="text-purple-400 text-xl">🖼️</span>
+                <div className="flex-shrink-0 w-10 h-10 bg-pbs-500/20 rounded-full flex items-center justify-center">
+                  <svg className="w-5 h-5 text-pbs-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                </div>
                 <div>
                   <h3 className="text-sm font-medium text-white">Screengrab Attachments</h3>
                   <p className="text-xs text-surface-400 mt-1">
@@ -785,19 +789,19 @@ export default function Settings() {
               <div className="space-y-3 text-sm">
                 <div className="flex justify-between p-3 bg-surface-900 rounded">
                   <span className="text-surface-400">Transcripts (input)</span>
-                  <code className="text-cyan-400">/data/transcripts</code>
+                  <code className="text-pbs-300">/data/transcripts</code>
                 </div>
                 <div className="flex justify-between p-3 bg-surface-900 rounded">
                   <span className="text-surface-400">Output (processed)</span>
-                  <code className="text-cyan-400">/data/output</code>
+                  <code className="text-pbs-300">/data/output</code>
                 </div>
                 <div className="flex justify-between p-3 bg-surface-900 rounded">
                   <span className="text-surface-400">Database</span>
-                  <code className="text-cyan-400">/data/db/dashboard.db</code>
+                  <code className="text-pbs-300">/data/db/dashboard.db</code>
                 </div>
                 <div className="flex justify-between p-3 bg-surface-900 rounded">
                   <span className="text-surface-400">Uploads</span>
-                  <code className="text-cyan-400">/data/uploads</code>
+                  <code className="text-pbs-300">/data/uploads</code>
                 </div>
               </div>
             </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -368,13 +368,13 @@ export default function Settings() {
 
       {/* Status Messages */}
       {error && (
-        <div role="alert" aria-live="assertive" className="bg-red-900/20 border border-red-500/30 rounded-lg p-4">
-          <p className="text-red-400">{error}</p>
+        <div role="alert" aria-live="assertive" className="bg-status-failed/15 border border-status-failed/30 rounded-lg p-4">
+          <p className="text-status-failed">{error}</p>
         </div>
       )}
       {success && (
-        <div role="status" aria-live="polite" className="bg-green-900/20 border border-green-500/30 rounded-lg p-4">
-          <p className="text-green-400">{success}</p>
+        <div role="status" aria-live="polite" className="bg-status-completed/15 border border-status-completed/30 rounded-lg p-4">
+          <p className="text-status-completed">{success}</p>
         </div>
       )}
 
@@ -633,8 +633,8 @@ export default function Settings() {
                       <div className="font-medium text-white">Last Scan</div>
                       <span className={`px-2 py-1 rounded text-xs font-medium ${
                         getCurrentIngest().last_scan_success
-                          ? 'bg-green-900/20 text-green-400'
-                          : 'bg-red-900/20 text-red-400'
+                          ? 'bg-status-completed/15 text-status-completed'
+                          : 'bg-status-failed/15 text-status-failed'
                       }`}>
                         {getCurrentIngest().last_scan_success ? 'Success' : 'Failed'}
                       </span>
@@ -720,7 +720,7 @@ export default function Settings() {
                 <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <div className="w-3 h-3 rounded-full bg-green-400" />
+                      <div className="w-3 h-3 rounded-full bg-status-completed" />
                       <div>
                         <div className="font-medium text-white">API Server</div>
                         <div className="text-sm text-surface-400">
@@ -738,7 +738,7 @@ export default function Settings() {
                 <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <div className={`w-3 h-3 rounded-full ${systemStatus?.worker.running ? 'bg-green-400' : 'bg-yellow-400'}`} />
+                      <div className={`w-3 h-3 rounded-full ${systemStatus?.worker.running ? 'bg-status-completed' : 'bg-status-pending'}`} />
                       <div>
                         <div className="font-medium text-white">Worker</div>
                         <div className="text-sm text-surface-400">
@@ -758,7 +758,7 @@ export default function Settings() {
                 <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
-                      <div className={`w-3 h-3 rounded-full ${systemStatus?.watcher.running ? 'bg-green-400' : 'bg-yellow-400'}`} />
+                      <div className={`w-3 h-3 rounded-full ${systemStatus?.watcher.running ? 'bg-status-completed' : 'bg-status-pending'}`} />
                       <div>
                         <div className="font-medium text-white">Transcript Watcher</div>
                         <div className="text-sm text-surface-400">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -315,8 +315,8 @@ export default function Settings() {
     return (
       <div className="space-y-6">
         <h1 className="text-2xl font-bold text-white">Settings</h1>
-        <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
-          <p className="text-gray-400 animate-pulse">Loading configuration...</p>
+        <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+          <p className="text-surface-400 animate-pulse">Loading configuration...</p>
         </div>
       </div>
     )
@@ -330,7 +330,7 @@ export default function Settings() {
       aria-checked={checked}
       aria-label={label}
       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-        checked ? 'bg-blue-600' : 'bg-gray-600'
+        checked ? 'bg-pbs-500' : 'bg-surface-600'
       }`}
     >
       <span
@@ -351,14 +351,14 @@ export default function Settings() {
           <div className="flex items-center space-x-3">
             <button
               onClick={handleReset}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm transition-colors"
+              className="px-4 py-2 bg-surface-700 hover:bg-surface-600 text-white rounded-md text-sm transition-colors"
             >
               Reset
             </button>
             <button
               onClick={handleSave}
               disabled={saving}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-md text-sm transition-colors"
+              className="px-4 py-2 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded-md text-sm transition-colors"
             >
               {saving ? 'Saving...' : 'Save Changes'}
             </button>
@@ -379,7 +379,7 @@ export default function Settings() {
       )}
 
       {/* Tab Navigation */}
-      <div className="border-b border-gray-700">
+      <div className="border-b border-surface-700">
         <nav className="flex space-x-1" role="tablist" aria-label="Settings sections">
           {TABS.map((tab) => (
             <button
@@ -391,8 +391,8 @@ export default function Settings() {
               onClick={() => setActiveTab(tab.id)}
               className={`px-4 py-3 text-sm font-medium rounded-t-lg transition-colors ${
                 activeTab === tab.id
-                  ? 'bg-gray-800 text-white border-b-2 border-blue-500'
-                  : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+                  ? 'bg-surface-800 text-white border-b-2 border-pbs-500'
+                  : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
               }`}
             >
               <span className="mr-2">{tab.icon}</span>
@@ -408,20 +408,20 @@ export default function Settings() {
         {activeTab === 'agents' && (
           <div className="space-y-6">
             {/* Agent Model Assignment */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-semibold text-white">Agent Models</h2>
                 <button
                   onClick={handleRefreshModels}
                   disabled={refreshingModels}
-                  className="text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+                  className="text-xs text-surface-400 hover:text-white transition-colors disabled:opacity-50"
                   title="Fetch latest models from OpenRouter"
                   aria-label="Refresh available models from OpenRouter"
                 >
                   {refreshingModels ? 'Refreshing…' : '↻ Refresh models'}
                 </button>
               </div>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Choose which model runs each agent phase.
               </p>
 
@@ -437,7 +437,7 @@ export default function Settings() {
                   )
 
                   return (
-                    <div key={agent.id} className="p-4 bg-gray-900 rounded-lg space-y-2">
+                    <div key={agent.id} className="p-4 bg-surface-900 rounded-lg space-y-2">
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-3">
                           <span className="text-lg">{agent.icon}</span>
@@ -451,17 +451,17 @@ export default function Settings() {
                           id={`model-${agent.id}`}
                           value={currentModel}
                           onChange={(e) => handlePhaseModelChange(agent.id, e.target.value)}
-                          className="pl-3 pr-8 py-2 rounded-md border text-sm font-medium bg-gray-800 border-gray-600 text-gray-200"
+                          className="pl-3 pr-8 py-2 rounded-md border text-sm font-medium bg-surface-800 border-surface-600 text-surface-200"
                           aria-label={`Select model for ${agent.name} agent`}
                         >
                           {sortedModels.map(m => (
-                            <option key={m.id} value={m.id} className="bg-gray-800 text-white">
+                            <option key={m.id} value={m.id} className="bg-surface-800 text-white">
                               {m.name}
                             </option>
                           ))}
                         </select>
                       </div>
-                      <p className="text-sm text-gray-400 pl-8 max-w-prose">{agent.description}</p>
+                      <p className="text-sm text-surface-400 pl-8 max-w-prose">{agent.description}</p>
                     </div>
                   )
                 })}
@@ -479,19 +479,19 @@ export default function Settings() {
         {/* WORKER TAB */}
         {activeTab === 'worker' && (
           <div className="space-y-6">
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Worker Settings</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Configure job processing concurrency. Changes require worker restart.
               </p>
 
               <div className="space-y-4">
                 {/* Concurrent Jobs */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between mb-2">
                     <div>
                       <label htmlFor="concurrent-jobs" className="font-medium text-white">Concurrent Jobs</label>
-                      <div className="text-sm text-gray-400">Process multiple jobs simultaneously</div>
+                      <div className="text-sm text-surface-400">Process multiple jobs simultaneously</div>
                     </div>
                     <span className="text-2xl font-bold text-cyan-400">{getCurrentWorker().max_concurrent_jobs}</span>
                   </div>
@@ -503,12 +503,12 @@ export default function Settings() {
                     step="1"
                     value={getCurrentWorker().max_concurrent_jobs}
                     onChange={(e) => handleWorkerChange('max_concurrent_jobs', parseInt(e.target.value))}
-                    className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                    className="w-full h-2 bg-surface-700 rounded-lg appearance-none cursor-pointer"
                     aria-valuemin={1}
                     aria-valuemax={5}
                     aria-valuenow={getCurrentWorker().max_concurrent_jobs}
                   />
-                  <div className="flex justify-between text-xs text-gray-400 mt-1">
+                  <div className="flex justify-between text-xs text-surface-400 mt-1">
                     <span>1 (safe)</span>
                     <span>3 (default)</span>
                     <span>5 (max)</span>
@@ -516,13 +516,13 @@ export default function Settings() {
                 </div>
 
                 {/* Poll Interval */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between mb-2">
                     <div>
                       <label htmlFor="poll-interval" className="font-medium text-white">Poll Interval</label>
-                      <div className="text-sm text-gray-400">Seconds between queue checks</div>
+                      <div className="text-sm text-surface-400">Seconds between queue checks</div>
                     </div>
-                    <span className="text-gray-300">{getCurrentWorker().poll_interval_seconds}s</span>
+                    <span className="text-surface-300">{getCurrentWorker().poll_interval_seconds}s</span>
                   </div>
                   <input
                     id="poll-interval"
@@ -532,12 +532,12 @@ export default function Settings() {
                     step="1"
                     value={getCurrentWorker().poll_interval_seconds}
                     onChange={(e) => handleWorkerChange('poll_interval_seconds', parseInt(e.target.value))}
-                    className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                    className="w-full h-2 bg-surface-700 rounded-lg appearance-none cursor-pointer"
                     aria-valuemin={1}
                     aria-valuemax={30}
                     aria-valuenow={getCurrentWorker().poll_interval_seconds}
                   />
-                  <div className="flex justify-between text-xs text-gray-400 mt-1">
+                  <div className="flex justify-between text-xs text-surface-400 mt-1">
                     <span>1s</span>
                     <span>15s</span>
                     <span>30s</span>
@@ -551,18 +551,18 @@ export default function Settings() {
         {/* INGEST TAB */}
         {activeTab === 'ingest' && (
           <div className="space-y-6">
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Ingest Scanner</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Automatically scan network locations for new transcript files and add them to the processing queue.
               </p>
 
               <div className="space-y-4">
                 {/* Enable Toggle */}
-                <div className="flex items-center justify-between p-4 bg-gray-900 rounded-lg">
+                <div className="flex items-center justify-between p-4 bg-surface-900 rounded-lg">
                   <div>
                     <div className="font-medium text-white">Enable Scanner</div>
-                    <div className="text-sm text-gray-400">Automatically discover and ingest new transcripts</div>
+                    <div className="text-sm text-surface-400">Automatically discover and ingest new transcripts</div>
                   </div>
                   <Toggle
                     checked={getCurrentIngest().enabled}
@@ -572,13 +572,13 @@ export default function Settings() {
                 </div>
 
                 {/* Scan Interval */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between mb-2">
                     <div>
                       <label htmlFor="scan-interval" className="font-medium text-white">Scan Interval</label>
-                      <div className="text-sm text-gray-400">Hours between automatic scans</div>
+                      <div className="text-sm text-surface-400">Hours between automatic scans</div>
                     </div>
-                    <span className="text-gray-300">{getCurrentIngest().scan_interval_hours}h</span>
+                    <span className="text-surface-300">{getCurrentIngest().scan_interval_hours}h</span>
                   </div>
                   <input
                     id="scan-interval"
@@ -588,12 +588,12 @@ export default function Settings() {
                     step="1"
                     value={getCurrentIngest().scan_interval_hours}
                     onChange={(e) => handleIngestChange('scan_interval_hours', parseInt(e.target.value))}
-                    className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                    className="w-full h-2 bg-surface-700 rounded-lg appearance-none cursor-pointer"
                     aria-valuemin={1}
                     aria-valuemax={168}
                     aria-valuenow={getCurrentIngest().scan_interval_hours}
                   />
-                  <div className="flex justify-between text-xs text-gray-400 mt-1">
+                  <div className="flex justify-between text-xs text-surface-400 mt-1">
                     <span>1h</span>
                     <span>24h (daily)</span>
                     <span>168h (weekly)</span>
@@ -601,34 +601,34 @@ export default function Settings() {
                 </div>
 
                 {/* Scan Time */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="mb-2">
                     <label htmlFor="scan-time" className="font-medium text-white block">Preferred Scan Time</label>
-                    <div className="text-sm text-gray-400">Daily time to run scheduled scans (24-hour format)</div>
+                    <div className="text-sm text-surface-400">Daily time to run scheduled scans (24-hour format)</div>
                   </div>
                   <input
                     id="scan-time"
                     type="time"
                     value={getCurrentIngest().scan_time}
                     onChange={(e) => handleIngestChange('scan_time', e.target.value)}
-                    className="px-3 py-2 bg-gray-800 border border-gray-600 rounded-md text-white focus:border-blue-500 focus:outline-none"
+                    className="px-3 py-2 bg-surface-800 border border-surface-600 rounded-md text-white focus:border-pbs-500 focus:outline-none"
                   />
                 </div>
 
                 {/* Server URL (read-only) */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="mb-2">
                     <div className="font-medium text-white">Server URL</div>
-                    <div className="text-sm text-gray-400">Remote file server location</div>
+                    <div className="text-sm text-surface-400">Remote file server location</div>
                   </div>
-                  <code className="block p-2 bg-gray-800 rounded text-cyan-400 text-sm">
+                  <code className="block p-2 bg-surface-800 rounded text-cyan-400 text-sm">
                     {getCurrentIngest().server_url || 'Not configured'}
                   </code>
                 </div>
 
                 {/* Last Scan Info */}
                 {getCurrentIngest().last_scan_at && (
-                  <div className="p-4 bg-gray-900 rounded-lg">
+                  <div className="p-4 bg-surface-900 rounded-lg">
                     <div className="flex items-center justify-between mb-2">
                       <div className="font-medium text-white">Last Scan</div>
                       <span className={`px-2 py-1 rounded text-xs font-medium ${
@@ -639,7 +639,7 @@ export default function Settings() {
                         {getCurrentIngest().last_scan_success ? 'Success' : 'Failed'}
                       </span>
                     </div>
-                    <div className="text-sm text-gray-400">
+                    <div className="text-sm text-surface-400">
                       {formatDateTime(getCurrentIngest().last_scan_at)}
                     </div>
                   </div>
@@ -647,9 +647,9 @@ export default function Settings() {
 
                 {/* Next Scheduled Scan */}
                 {getCurrentIngest().next_scan_at && (
-                  <div className="p-4 bg-gray-900 rounded-lg">
+                  <div className="p-4 bg-surface-900 rounded-lg">
                     <div className="font-medium text-white mb-2">Next Scheduled Scan</div>
-                    <div className="text-sm text-gray-400">
+                    <div className="text-sm text-surface-400">
                       {formatDateTime(getCurrentIngest().next_scan_at)}
                     </div>
                   </div>
@@ -658,17 +658,17 @@ export default function Settings() {
             </div>
 
             {/* Link to Ready for Work page */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-center justify-between">
                 <div>
                   <h3 className="text-sm font-medium text-white">Ready for Work</h3>
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className="text-xs text-surface-400 mt-1">
                     View and queue transcripts from the ingest server.
                   </p>
                 </div>
                 <Link
                   to="/ready"
-                  className="text-sm text-blue-400 hover:text-blue-300 transition-colors"
+                  className="text-sm text-pbs-400 hover:text-pbs-300 transition-colors"
                 >
                   Open →
                 </Link>
@@ -676,12 +676,12 @@ export default function Settings() {
             </div>
 
             {/* Screengrab Info */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-start space-x-3">
                 <span className="text-purple-400 text-xl">🖼️</span>
                 <div>
                   <h3 className="text-sm font-medium text-white">Screengrab Attachments</h3>
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className="text-xs text-surface-400 mt-1">
                     Screengrabs are attached from the job detail page. Completed jobs with matching
                     screengrabs show an "Attach Screengrabs" button in the job header.
                   </p>
@@ -690,12 +690,12 @@ export default function Settings() {
             </div>
 
             {/* Configuration Note */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-start space-x-3">
                 <span className="text-yellow-400 text-xl">💡</span>
                 <div>
                   <h3 className="text-sm font-medium text-white">Server Configuration</h3>
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className="text-xs text-surface-400 mt-1">
                     Network paths and credentials are managed in server environment variables.
                     Contact your system administrator to modify the server URL or monitored directories.
                   </p>
@@ -709,66 +709,66 @@ export default function Settings() {
         {activeTab === 'system' && (
           <div className="space-y-6">
             {/* Component Status */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">System Components</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Monitor the containerized services that power The Metadata Neighborhood. Components are managed by Docker Compose.
               </p>
 
               <div className="space-y-4">
                 {/* API Server */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
                       <div className="w-3 h-3 rounded-full bg-green-400" />
                       <div>
                         <div className="font-medium text-white">API Server</div>
-                        <div className="text-sm text-gray-400">
+                        <div className="text-sm text-surface-400">
                           Running - Managed by Docker
                         </div>
                       </div>
                     </div>
-                    <div className="px-3 py-1 text-xs bg-blue-600/20 text-blue-400 border border-blue-500/30 rounded">
+                    <div className="px-3 py-1 text-xs bg-pbs-500/20 text-pbs-400 border border-pbs-500/30 rounded">
                       Container: cardigan-api
                     </div>
                   </div>
                 </div>
 
                 {/* Worker */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
                       <div className={`w-3 h-3 rounded-full ${systemStatus?.worker.running ? 'bg-green-400' : 'bg-yellow-400'}`} />
                       <div>
                         <div className="font-medium text-white">Worker</div>
-                        <div className="text-sm text-gray-400">
+                        <div className="text-sm text-surface-400">
                           {systemStatus?.worker.running
                             ? 'Running - Managed by Docker'
                             : 'Managed by Docker'}
                         </div>
                       </div>
                     </div>
-                    <div className="px-3 py-1 text-xs bg-blue-600/20 text-blue-400 border border-blue-500/30 rounded">
+                    <div className="px-3 py-1 text-xs bg-pbs-500/20 text-pbs-400 border border-pbs-500/30 rounded">
                       Container: cardigan-api
                     </div>
                   </div>
                 </div>
 
                 {/* Watcher */}
-                <div className="p-4 bg-gray-900 rounded-lg">
+                <div className="p-4 bg-surface-900 rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-3">
                       <div className={`w-3 h-3 rounded-full ${systemStatus?.watcher.running ? 'bg-green-400' : 'bg-yellow-400'}`} />
                       <div>
                         <div className="font-medium text-white">Transcript Watcher</div>
-                        <div className="text-sm text-gray-400">
+                        <div className="text-sm text-surface-400">
                           {systemStatus?.watcher.running
                             ? 'Running - Managed by Docker'
                             : 'Managed by Docker'}
                         </div>
                       </div>
                     </div>
-                    <div className="px-3 py-1 text-xs bg-blue-600/20 text-blue-400 border border-blue-500/30 rounded">
+                    <div className="px-3 py-1 text-xs bg-pbs-500/20 text-pbs-400 border border-pbs-500/30 rounded">
                       Container: cardigan-api
                     </div>
                   </div>
@@ -777,55 +777,55 @@ export default function Settings() {
             </div>
 
             {/* Folder Paths */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Docker Volume Mounts</h2>
-              <p className="text-sm text-gray-400 mb-4">
+              <p className="text-sm text-surface-400 mb-4">
                 Persistent data volumes mounted in the container
               </p>
               <div className="space-y-3 text-sm">
-                <div className="flex justify-between p-3 bg-gray-900 rounded">
-                  <span className="text-gray-400">Transcripts (input)</span>
+                <div className="flex justify-between p-3 bg-surface-900 rounded">
+                  <span className="text-surface-400">Transcripts (input)</span>
                   <code className="text-cyan-400">/data/transcripts</code>
                 </div>
-                <div className="flex justify-between p-3 bg-gray-900 rounded">
-                  <span className="text-gray-400">Output (processed)</span>
+                <div className="flex justify-between p-3 bg-surface-900 rounded">
+                  <span className="text-surface-400">Output (processed)</span>
                   <code className="text-cyan-400">/data/output</code>
                 </div>
-                <div className="flex justify-between p-3 bg-gray-900 rounded">
-                  <span className="text-gray-400">Database</span>
+                <div className="flex justify-between p-3 bg-surface-900 rounded">
+                  <span className="text-surface-400">Database</span>
                   <code className="text-cyan-400">/data/db/dashboard.db</code>
                 </div>
-                <div className="flex justify-between p-3 bg-gray-900 rounded">
-                  <span className="text-gray-400">Uploads</span>
+                <div className="flex justify-between p-3 bg-surface-900 rounded">
+                  <span className="text-surface-400">Uploads</span>
                   <code className="text-cyan-400">/data/uploads</code>
                 </div>
               </div>
             </div>
 
             {/* Terminal Commands */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-start space-x-3">
-                <span className="text-blue-400 text-xl">🐳</span>
+                <span className="text-pbs-400 text-xl">🐳</span>
                 <div className="w-full">
                   <h3 className="text-sm font-medium text-white">Docker Commands</h3>
-                  <p className="text-xs text-gray-400 mt-1 mb-3">
+                  <p className="text-xs text-surface-400 mt-1 mb-3">
                     Manage the containerized system via Docker Compose
                   </p>
                   <div className="space-y-2 text-xs">
-                    <div className="p-2 bg-gray-900 rounded">
-                      <div className="text-gray-500 mb-1">Restart all services:</div>
+                    <div className="p-2 bg-surface-900 rounded">
+                      <div className="text-surface-400 mb-1">Restart all services:</div>
                       <code className="text-green-400">docker compose restart</code>
                     </div>
-                    <div className="p-2 bg-gray-900 rounded">
-                      <div className="text-gray-500 mb-1">View logs:</div>
+                    <div className="p-2 bg-surface-900 rounded">
+                      <div className="text-surface-400 mb-1">View logs:</div>
                       <code className="text-green-400">docker compose logs -f</code>
                     </div>
-                    <div className="p-2 bg-gray-900 rounded">
-                      <div className="text-gray-500 mb-1">Stop system:</div>
+                    <div className="p-2 bg-surface-900 rounded">
+                      <div className="text-surface-400 mb-1">Stop system:</div>
                       <code className="text-green-400">docker compose down</code>
                     </div>
-                    <div className="p-2 bg-gray-900 rounded">
-                      <div className="text-gray-500 mb-1">Rebuild and restart:</div>
+                    <div className="p-2 bg-surface-900 rounded">
+                      <div className="text-surface-400 mb-1">Rebuild and restart:</div>
                       <code className="text-green-400">docker compose up --build -d</code>
                     </div>
                   </div>
@@ -898,16 +898,16 @@ export default function Settings() {
         {activeTab === 'accessibility' && (
           <div className="space-y-6">
             {/* Reduce Motion */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Motion Preferences</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Control animations and transitions throughout the dashboard.
               </p>
 
-              <div className="flex items-center justify-between p-4 bg-gray-900 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-surface-900 rounded-lg">
                 <div>
                   <div className="font-medium text-white">Reduce Motion</div>
-                  <div className="text-sm text-gray-400">Minimize or disable animations</div>
+                  <div className="text-sm text-surface-400">Minimize or disable animations</div>
                 </div>
                 <Toggle
                   checked={preferences.reduceMotion}
@@ -918,9 +918,9 @@ export default function Settings() {
             </div>
 
             {/* Text Size */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Text Size</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Adjust the base text size for improved readability.
               </p>
 
@@ -931,24 +931,24 @@ export default function Settings() {
                     onClick={() => updatePreferences({ textSize: size })}
                     className={`w-full p-4 rounded-lg border text-left transition-colors ${
                       preferences.textSize === size
-                        ? 'bg-blue-900/20 border-blue-500/30 text-blue-400'
-                        : 'bg-gray-900 border-gray-700 text-gray-300 hover:bg-gray-800'
+                        ? 'bg-pbs-900/20 border-pbs-500/30 text-pbs-400'
+                        : 'bg-surface-900 border-surface-700 text-surface-300 hover:bg-surface-800'
                     }`}
                   >
                     <div className="flex items-center justify-between">
                       <div>
                         <div className="font-medium capitalize">{size}</div>
-                        <div className="text-sm text-gray-400">
+                        <div className="text-sm text-surface-400">
                           {size === 'default' && 'Standard text size (16px base)'}
                           {size === 'large' && 'Larger text size (18px base)'}
                           {size === 'larger' && 'Largest text size (20px base)'}
                         </div>
                       </div>
                       {preferences.textSize === size && (
-                        <span className="text-blue-400">✓</span>
+                        <span className="text-pbs-400">✓</span>
                       )}
                     </div>
-                    <div className="mt-2 text-gray-400" style={{
+                    <div className="mt-2 text-surface-400" style={{
                       fontSize: size === 'default' ? '16px' : size === 'large' ? '18px' : '20px'
                     }}>
                       Sample preview text
@@ -959,16 +959,16 @@ export default function Settings() {
             </div>
 
             {/* High Contrast */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
               <h2 className="text-lg font-semibold text-white mb-4">Contrast</h2>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-surface-400 mb-6">
                 Increase contrast between text and backgrounds for better visibility.
               </p>
 
-              <div className="flex items-center justify-between p-4 bg-gray-900 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-surface-900 rounded-lg">
                 <div>
                   <div className="font-medium text-white">High Contrast Mode</div>
-                  <div className="text-sm text-gray-400">Enhance text and UI element contrast</div>
+                  <div className="text-sm text-surface-400">Enhance text and UI element contrast</div>
                 </div>
                 <Toggle
                   checked={preferences.highContrast}
@@ -979,12 +979,12 @@ export default function Settings() {
             </div>
 
             {/* Preview Note */}
-            <div className="bg-gray-800 rounded-lg border border-gray-700 p-4">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-4">
               <div className="flex items-start space-x-3">
-                <span className="text-blue-400 text-xl">💡</span>
+                <span className="text-pbs-400 text-xl">💡</span>
                 <div>
                   <h3 className="text-sm font-medium text-white">Live Preview</h3>
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className="text-xs text-surface-400 mt-1">
                     Changes are applied immediately and saved automatically. Navigate to other pages
                     to see how preferences affect the entire dashboard.
                   </p>

--- a/web/src/utils/statusColors.ts
+++ b/web/src/utils/statusColors.ts
@@ -25,21 +25,22 @@ export type JobStatus =
 export function getStatusTextColor(status: string): string {
   switch (status) {
     case 'pending':
-      return 'text-yellow-400'
+      return 'text-status-pending'
     case 'in_progress':
-      return 'text-blue-400'
+      return 'text-status-processing'
     case 'completed':
-      return 'text-green-400'
+      return 'text-status-completed'
     case 'failed':
-      return 'text-red-400'
+      return 'text-status-failed'
     case 'investigating':
-      return 'text-orange-400'
+      // teal-400 — distinct from pbs-blue (in_progress/processing) and amber (pending/paused)
+      return 'text-teal-400'
     case 'paused':
-      return 'text-orange-400'
+      return 'text-status-paused'
     case 'cancelled':
-      return 'text-gray-400'
+      return 'text-status-cancelled'
     default:
-      return 'text-gray-400'
+      return 'text-surface-400'
   }
 }
 
@@ -55,20 +56,21 @@ export function getStatusTextColor(status: string): string {
 export function getStatusBadgeColor(status: string): string {
   switch (status) {
     case 'pending':
-      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+      return 'bg-status-pending/15 text-status-pending border-status-pending/30'
     case 'in_progress':
-      return 'bg-blue-500/20 text-blue-400 border-blue-500/30'
+      return 'bg-status-processing/15 text-status-processing border-status-processing/30'
     case 'completed':
-      return 'bg-green-500/20 text-green-400 border-green-500/30'
+      return 'bg-status-completed/15 text-status-completed border-status-completed/30'
     case 'failed':
-      return 'bg-red-500/20 text-red-400 border-red-500/30'
+      return 'bg-status-failed/15 text-status-failed border-status-failed/30'
     case 'investigating':
-      return 'bg-purple-500/20 text-purple-400 border-purple-500/30'
+      // teal-400 (#2dd4bf) — visually distinct from pbs-blue in_progress/processing and amber pending/paused
+      return 'bg-teal-500/15 text-teal-400 border-teal-500/30'
     case 'paused':
-      return 'bg-orange-500/20 text-orange-400 border-orange-500/30'
+      return 'bg-status-paused/15 text-status-paused border-status-paused/30'
     case 'cancelled':
-      return 'bg-gray-500/20 text-gray-400 border-gray-500/30'
+      return 'bg-status-cancelled/15 text-status-cancelled border-status-cancelled/30'
     default:
-      return 'bg-gray-500/20 text-gray-400 border-gray-500/30'
+      return 'bg-surface-500/15 text-surface-400 border-surface-500/30'
   }
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
           100: '#dfe1e9',
           200: '#c0c4d1',
           300: '#9da2b5',
-          400: '#7a8098',
+          400: '#9da2b5',  // bumped for WCAG AA (was #7a8098, 3.35:1 — failed)
           500: '#5c6380',
           600: '#464d68',
           700: '#343a52',
@@ -50,7 +50,7 @@ export default {
           completed:  '#34a86c',  // warm green
           failed:     '#d64545',  // warm red
           paused:     '#d68a45',  // warm orange
-          cancelled:  '#7a8098',  // neutral-400
+          cancelled:  '#9da2b5',  // bumped for WCAG AA (aligned with surface-400)
         },
       },
       fontFamily: {


### PR DESCRIPTION
## What

Salvages the palette migration work from closed PR #155 onto a clean branch forked from current main (Sprints 2–6 intact).

Six cherry-picks from `worktree-calm-ray-kabm`, filtered to extract palette/color changes only — no feature regressions, no dead routes, no tier/routing/escalation UI that references types not on main.

Plus two P1 fixes applied on top.

## Changes

### Cherry-picks (filtered)

| Commit | What landed | What was dropped |
|--------|-------------|-----------------|
| `91565651` | `surface-*` tokens replace Tailwind grays in all major components | Nothing significant |
| `f1d791fa` | Status colors use `status-*` tokens throughout | — |
| `99961ae` | Responsive nav (hamburger + mobile panel), `Help.tsx` responsive padding | Dead routes (`/system`, `/`) removed; `Button` import not available on main |
| `88946d4` | Toast border tokens (`border-status-*/40`) | — |
| `1f5515a` | `bg-pbs-500` upload button, `IngestPanel` palette | — |
| `3427d9c` | Toast backgrounds → `bg-status-*/90 text-white`; `PhaseStatsWidget` insight alert → `bg-status-pending`; `JobDetail` retry button → `hover:bg-pbs-400`; `Settings` screengrab icon → SVG on `bg-pbs-500/20` | `getEscalationColor`, `tier_label` badges, `escalation_rate` conditions, `tier_reason` — all reference types absent on main |

### P1 fixes

**WCAG AA contrast — `surface-400`**
- Old: `#7a8098` → 3.35:1 vs `surface-800` (**FAIL**)
- New: `#9da2b5` → 5.70:1 vs `surface-800`, 6.80:1 vs `surface-900` (**PASS AA**)
- Also bumped `status.cancelled` (carried the same hex)

**`investigating` status distinct color**
- Maps to `text-teal-400` / `bg-teal-500/15 text-teal-400 border-teal-500/30`
- Teal-400 (`#2dd4bf`): 7.77:1 vs `surface-800` — highly distinct from `pbs-blue` used for `in_progress`

## Validation

```
npm run lint   → ✓ 0 warnings, 0 errors
tsc            → ✓ clean
vite build     → ✓ 311 modules, built in 8.60s
```

## Judgment calls

1. **`validation_result` badge** (JobDetail phase list): HEAD uses `bg-green-900/30 text-green-400` / `bg-red-900/30 text-red-400`. Migrated to `bg-status-completed/20 text-status-completed` / `bg-status-failed/20 text-status-failed` as part of cherry-pick 6 cleanup — consistent with design token intent.

2. **`surface-400 === surface-300`** after the bump (`#9da2b5`): The WCAG fix collapses these two steps of the scale. Worth a future palette pass to re-differentiate surface-300 upward.

3. **`status.cancelled` bump**: Not explicitly requested but carried the same failing hex. Bumped for consistency. Functionally muted/disabled states throughout the UI now pass AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)