### PR TITLE
fix(ingest-scanner): defend against recursive directory loops on mmingest

### DIFF
--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -423,11 +423,7 @@ class IngestScanner:
         if depth < self.MAX_SCAN_DEPTH:
             # Lowercase ancestor segments for case-insensitive loop detection.
             # Mirrors how `ignore_directories` is normalized at init.
-            ancestor_segments = {
-                segment.lower()
-                for segment in directory_path.strip("/").split("/")
-                if segment
-            }
+            ancestor_segments = {segment.lower() for segment in directory_path.strip("/").split("/") if segment}
 
             for subdir_name, subdir_url in subdirs:
                 subdir_path = f"{directory_path.rstrip('/')}/{subdir_name}/"
@@ -450,9 +446,7 @@ class IngestScanner:
                     continue
 
                 try:
-                    sub_files = await self._scan_directory(
-                        subdir_url, subdir_path, depth + 1, visited_urls
-                    )
+                    sub_files = await self._scan_directory(subdir_url, subdir_path, depth + 1, visited_urls)
                     files.extend(sub_files)
                 except Exception as e:
                     logger.warning(f"Failed to scan subdirectory {subdir_path}: {e}")

--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -392,7 +392,6 @@ class IngestScanner:
         if canonical_url in visited_urls:
             logger.debug(f"Skipping already-visited URL: {url}")
             return []
-        visited_urls.add(canonical_url)
 
         files: List[RemoteFile] = []
 
@@ -404,6 +403,11 @@ class IngestScanner:
 
             response = await client.get(url, auth=auth)
             response.raise_for_status()
+
+            # Mark visited only after a successful fetch. If a transient failure
+            # stamped the URL pre-fetch, a sibling path linking to the same URL
+            # would silently skip it on retry rather than getting a real chance.
+            visited_urls.add(canonical_url)
 
             # Parse HTML into files and subdirectory links
             found_files, subdirs = self._parse_directory_listing(
@@ -433,10 +437,12 @@ class IngestScanner:
                     logger.debug(f"Skipping ignored directory: {subdir_path}")
                     continue
 
-                # Skip subdirs whose name matches an ancestor segment. Catches the
-                # mmingest loop pattern (/Education/.../Education/) where mirrored
-                # directories return identical listings and would otherwise blow the
-                # request timeout budget. See ingest_scanner issue #161.
+                # Skip subdirs whose name reappears in the ancestor path.
+                # Defends against server-side directory mirroring (bind mounts,
+                # Apache Alias directives, symlinks) where /<X>/.../<X>/ returns
+                # the same listing as /<X>/ and the crawl would otherwise walk
+                # mirrored content until the request timeout fires. Originally
+                # surfaced on mmingest under /Education/.
                 if subdir_name.lower() in ancestor_segments:
                     logger.warning(
                         f"Skipping recursive loop: '{subdir_name}' already in ancestor path {directory_path}"

--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -368,6 +368,7 @@ class IngestScanner:
         url: str,
         directory_path: str,
         depth: int = 0,
+        visited_urls: Optional[set] = None,
     ) -> List[RemoteFile]:
         """
         Fetch and parse a directory listing, recursing into subdirectories.
@@ -376,10 +377,23 @@ class IngestScanner:
             url: Full URL to the directory
             directory_path: Path relative to base URL
             depth: Current recursion depth (0 = top-level configured directory)
+            visited_urls: Set of canonical URLs already crawled in THIS scan. Passed
+                through recursion to prevent re-walking the same URL (e.g., when two
+                different parents both link to a shared subdirectory). Initialized to
+                an empty set if None — each top-level caller gets a fresh set.
 
         Returns:
             List of RemoteFile objects (including from subdirectories)
         """
+        if visited_urls is None:
+            visited_urls = set()
+
+        canonical_url = url.rstrip("/")
+        if canonical_url in visited_urls:
+            logger.debug(f"Skipping already-visited URL: {url}")
+            return []
+        visited_urls.add(canonical_url)
+
         files: List[RemoteFile] = []
 
         async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
@@ -403,16 +417,36 @@ class IngestScanner:
 
         # Recurse into subdirectories if within depth limit
         if depth < self.MAX_SCAN_DEPTH:
+            # Lowercase ancestor segments for case-insensitive loop detection.
+            # Mirrors how `ignore_directories` is normalized at init.
+            ancestor_segments = {
+                segment.lower()
+                for segment in directory_path.strip("/").split("/")
+                if segment
+            }
+
             for subdir_name, subdir_url in subdirs:
                 subdir_path = f"{directory_path.rstrip('/')}/{subdir_name}/"
 
-                # Check against ignore list
+                # Skip ignored directories (configured by name)
                 if subdir_name.lower() in self.ignore_directories:
                     logger.debug(f"Skipping ignored directory: {subdir_path}")
                     continue
 
+                # Skip subdirs whose name matches an ancestor segment. Catches the
+                # mmingest loop pattern (/Education/.../Education/) where mirrored
+                # directories return identical listings and would otherwise blow the
+                # request timeout budget. See ingest_scanner issue #161.
+                if subdir_name.lower() in ancestor_segments:
+                    logger.warning(
+                        f"Skipping recursive loop: '{subdir_name}' already in ancestor path {directory_path}"
+                    )
+                    continue
+
                 try:
-                    sub_files = await self._scan_directory(subdir_url, subdir_path, depth + 1)
+                    sub_files = await self._scan_directory(
+                        subdir_url, subdir_path, depth + 1, visited_urls
+                    )
                     files.extend(sub_files)
                 except Exception as e:
                     logger.warning(f"Failed to scan subdirectory {subdir_path}: {e}")

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -1012,3 +1012,107 @@ class TestRecursiveScanning:
         assert result.success is True
         # /shared/ is reachable via /a/ AND /b/, but should only be fetched once.
         assert get_call_counts.get("https://test.com/shared/", 0) == 1
+
+    @pytest.mark.asyncio
+    async def test_ancestor_segment_loop_check_is_case_insensitive(self):
+        """The ancestor-segment guard normalizes case both sides of the compare.
+
+        Pins the lowercase comparison invariant. Mirrors how `ignore_directories`
+        is normalized at __init__ (api/services/ingest_scanner.py line ~99). Both
+        must stay in lockstep — if one drops `.lower()`, the scanner reverts to
+        being vulnerable to the loop on case-mixed servers.
+        """
+        scanner = IngestScanner(base_url="https://test.com", directories=["/"])
+
+        root_html = """
+        <html><body>
+        <a href="Education/">Education/</a>
+        </body></html>
+        """
+        # Ancestor is "Education" (capital E); child is "education" (lowercase).
+        # If the guard didn't lowercase, this would be a fresh descent.
+        education_html = """
+        <html><body>
+        <a href="education/">education/</a>
+        <a href="parent_file.srt">parent_file.srt</a>
+        </body></html>
+        """
+
+        mock_responses = {
+            "https://test.com/": root_html,
+            "https://test.com/Education/": education_html,
+        }
+
+        async def mock_get(url, auth=None):
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch.object(scanner, "_track_files_batch", return_value=(1, 1, 0)):
+                files = await scanner._scan_directory(
+                    "https://test.com/Education/", "/Education/"
+                )
+
+        # The case-mismatched child should still be recognized as the ancestor.
+        # Only the parent's .srt file should come back; no recursion into education/.
+        assert [f.filename for f in files] == ["parent_file.srt"]
+
+    @pytest.mark.asyncio
+    async def test_loop_guard_applies_to_media_id_entry_point(self):
+        """The loop guard fires from `check_ingest_server_for_media_id` too.
+
+        Pins that the per-media-ID search path threads through the same
+        `_scan_directory` defenses. If a future refactor breaks the threading,
+        scheduled `scan()` runs would stay safe while interactive Media-ID
+        lookups silently regress.
+        """
+        scanner = IngestScanner(base_url="https://test.com", directories=["/Education/"])
+
+        education_html = """
+        <html><body>
+        <a href="2WLI1209HD.srt">2WLI1209HD.srt</a>
+        <a href="aka_teacher/">aka_teacher/</a>
+        </body></html>
+        """
+        aka_teacher_html = """
+        <html><body>
+        <a href="Education/">Education/</a>
+        <a href="2WLI1210HD.srt">2WLI1210HD.srt</a>
+        </body></html>
+        """
+
+        mock_responses = {
+            "https://test.com/Education/": education_html,
+            "https://test.com/Education/aka_teacher/": aka_teacher_html,
+        }
+
+        scanned_urls = []
+
+        async def mock_get(url, auth=None):
+            scanned_urls.append(url)
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            files = await scanner.check_ingest_server_for_media_id("2WLI1209HD")
+
+        # The loop URL must not be fetched even from this entry point.
+        assert "https://test.com/Education/aka_teacher/Education/" not in scanned_urls
+        # And the legitimate match for the media ID should still come through.
+        assert any(f.filename == "2WLI1209HD.srt" for f in files)

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -1057,9 +1057,7 @@ class TestRecursiveScanning:
             mock_client.return_value = mock_instance
 
             with patch.object(scanner, "_track_files_batch", return_value=(1, 1, 0)):
-                files = await scanner._scan_directory(
-                    "https://test.com/Education/", "/Education/"
-                )
+                files = await scanner._scan_directory("https://test.com/Education/", "/Education/")
 
         # The case-mismatched child should still be recognized as the ancestor.
         # Only the parent's .srt file should come back; no recursion into education/.

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -887,3 +887,128 @@ class TestRecursiveScanning:
         # Scan should succeed despite broken subdirectory
         assert result.success is True
         assert result.total_files_on_server == 2
+
+    @pytest.mark.asyncio
+    async def test_recursive_scan_skips_ancestor_segment_loop(self):
+        """Don't descend into a subdir whose name matches an ancestor segment.
+
+        Regression for mmingest loop where /Education/aka_teacher/Education/
+        mirrored top-level /Education/ content, causing repeated re-traversal.
+        """
+        scanner = IngestScanner(base_url="https://test.com", directories=["/"])
+
+        root_html = """
+        <html><body>
+        <a href="Education/">Education/</a>
+        <a href="root.srt">root.srt</a>
+        </body></html>
+        """
+        education_html = """
+        <html><body>
+        <a href="aka_teacher/">aka_teacher/</a>
+        <a href="ed_file.srt">ed_file.srt</a>
+        </body></html>
+        """
+        aka_teacher_html = """
+        <html><body>
+        <a href="Education/">Education/</a>
+        <a href="aka_file.srt">aka_file.srt</a>
+        </body></html>
+        """
+
+        mock_responses = {
+            "https://test.com/": root_html,
+            "https://test.com/Education/": education_html,
+            "https://test.com/Education/aka_teacher/": aka_teacher_html,
+        }
+
+        scanned_urls = []
+
+        async def mock_get(url, auth=None):
+            scanned_urls.append(url)
+            if "aka_teacher/Education" in url:
+                raise AssertionError(
+                    "Should not descend into Education/ inside an Education ancestor — "
+                    "this is the mmingest loop pattern"
+                )
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch.object(scanner, "_track_files_batch", return_value=(3, 3, 0)):
+                result = await scanner.scan()
+
+        assert result.success is True
+        assert "https://test.com/Education/aka_teacher/Education/" not in scanned_urls
+
+    @pytest.mark.asyncio
+    async def test_recursive_scan_dedupes_visited_urls(self):
+        """Don't revisit the same URL twice across the crawl.
+
+        Defends against true symlink loops where two distinct paths in the crawl
+        graph resolve to the identical URL.
+        """
+        scanner = IngestScanner(base_url="https://test.com", directories=["/"])
+
+        # Two different parents (a/, b/) each link to the same shared/ URL.
+        root_html = """
+        <html><body>
+        <a href="a/">a/</a>
+        <a href="b/">b/</a>
+        </body></html>
+        """
+        a_html = """
+        <html><body>
+        <a href="https://test.com/shared/">shared/</a>
+        <a href="a_file.srt">a_file.srt</a>
+        </body></html>
+        """
+        b_html = """
+        <html><body>
+        <a href="https://test.com/shared/">shared/</a>
+        <a href="b_file.srt">b_file.srt</a>
+        </body></html>
+        """
+        shared_html = """
+        <html><body>
+        <a href="shared_file.srt">shared_file.srt</a>
+        </body></html>
+        """
+
+        mock_responses = {
+            "https://test.com/": root_html,
+            "https://test.com/a/": a_html,
+            "https://test.com/b/": b_html,
+            "https://test.com/shared/": shared_html,
+        }
+
+        get_call_counts: dict[str, int] = {}
+
+        async def mock_get(url, auth=None):
+            get_call_counts[url] = get_call_counts.get(url, 0) + 1
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch.object(scanner, "_track_files_batch", return_value=(3, 3, 0)):
+                result = await scanner.scan()
+
+        assert result.success is True
+        # /shared/ is reachable via /a/ AND /b/, but should only be fetched once.
+        assert get_call_counts.get("https://test.com/shared/", 0) == 1


### PR DESCRIPTION
## Summary

- Fixes #161 — `POST /api/ingest/scan` was returning HTTP 504 because the scanner followed `Education/`-back-references on every Education subshow folder, blowing the reverse proxy timeout budget
- Adds two guards to `_scan_directory`:
  1. **Ancestor segment guard** — refuses to descend into a subdir whose name matches an ancestor path segment (catches the mmingest mirror pattern)
  2. **Visited URL set** — skips URLs already crawled in this scan (defense in depth for true symlink loops)
- Both guards normalize on lowercase, matching how `ignore_directories` already works

## Verification

Live-server check against `https://mmingest.pbswi.wisc.edu/Education/`:

| Metric | Before | After |
|---|---|---|
| Scan duration | timeout (60s+) | **4.0s** |
| Loop skips | 0 | **21 caught + logged** |
| Distinct dirs scanned | hundreds (huge dupes) | **24** |
| Files found | overcounted | **550** |

Sample log line during the scan:
```
Skipping recursive loop: 'Education' already in ancestor path /Education/aka%20Teacher%20blog/
```

Also caught a bonus pattern: `/Education/WI_Biographies/OLD/WI_Biographies/` — different name, same loop shape.

## Test plan

- [x] Unit test for the ancestor-segment guard: `test_recursive_scan_skips_ancestor_segment_loop`
- [x] Unit test for the visited-URL dedup: `test_recursive_scan_dedupes_visited_urls`
- [x] Full `tests/test_ingest_scanner.py` suite passes (47 passed, 5 xfailed — pre-existing)
- [x] Live scan of `/Education/` against mmingest completes in 4.0s with no regressions
- [ ] (Post-merge) Trigger scheduled scan via the homelab UI; confirm "Failed to scan for new files" banner clears

## Notes

mmingest server-side has back-reference directories that mirror higher-level content on every show folder. Likely a bind mount or symlink configuration error. Worth filing separately with whoever administers the ingest server, but the scanner is now resilient regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)