### PR TITLE
feat(mmingest): Sprint 1A — schema migrations 014–017 + FTS parity helper

### DIFF
--- a/alembic/versions/014_extend_available_files_for_mmingest_index.py
+++ b/alembic/versions/014_extend_available_files_for_mmingest_index.py
@@ -23,10 +23,12 @@ populate during HEAD-probe passes:
 The `available_files` table is retained as-is for back-compat during the
 mmingest transition; it is NOT converted into the mmingest_files table.
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision: str = "014"
 down_revision: Union[str, None] = "013"

--- a/alembic/versions/014_extend_available_files_for_mmingest_index.py
+++ b/alembic/versions/014_extend_available_files_for_mmingest_index.py
@@ -1,0 +1,51 @@
+"""Extend available_files table for mmingest index probing.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-06-03
+
+Adds four columns to `available_files` that the mmingest crawler will
+populate during HEAD-probe passes:
+
+  etag          — ETag value from the remote server's Last-Modified/ETag
+                  response headers; used for change-detection without
+                  re-downloading the full body.
+  content_type  — MIME type returned by the server (e.g. video/mp4,
+                  text/plain; charset=utf-8).
+  last_head_at  — Timestamp of the most recent successful HEAD request;
+                  used to schedule re-probes and detect stale entries.
+  probe_status  — Lifecycle flag for the probing workflow:
+                    'unprobed'  default; never been HEAD-checked
+                    'probed'    HEAD completed successfully
+                    'error'     HEAD returned non-200 or connection failed
+                    'skipped'   intentionally excluded from probing
+
+The `available_files` table is retained as-is for back-compat during the
+mmingest transition; it is NOT converted into the mmingest_files table.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "014"
+down_revision: Union[str, None] = "013"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("available_files", sa.Column("etag", sa.Text(), nullable=True))
+    op.add_column("available_files", sa.Column("content_type", sa.Text(), nullable=True))
+    op.add_column("available_files", sa.Column("last_head_at", sa.DateTime(), nullable=True))
+    op.add_column(
+        "available_files",
+        sa.Column("probe_status", sa.Text(), nullable=False, server_default="unprobed"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("available_files", "probe_status")
+    op.drop_column("available_files", "last_head_at")
+    op.drop_column("available_files", "content_type")
+    op.drop_column("available_files", "etag")

--- a/alembic/versions/015_add_mmingest_files_table.py
+++ b/alembic/versions/015_add_mmingest_files_table.py
@@ -28,10 +28,12 @@ superseded_by    Self-referential FK → mmingest_files.id.  Older _REV<YYYYMMDD
                  row within the same (media_id, variant_tag) group.  NULL for
                  current rows.  Population deferred to the indexer sprint.
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision: str = "015"
 down_revision: Union[str, None] = "014"
@@ -42,15 +44,12 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "mmingest_files",
-
         # Primary key
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
-
         # File location
         sa.Column("remote_url", sa.Text(), nullable=False, unique=True),
         sa.Column("directory_path", sa.Text(), nullable=True),
         sa.Column("filename", sa.Text(), nullable=False),
-
         # Parsed metadata — common fields
         sa.Column("media_id", sa.Text(), nullable=True),
         sa.Column("prefix", sa.Text(), nullable=True),
@@ -60,32 +59,23 @@ def upgrade() -> None:
         sa.Column("episode", sa.Text(), nullable=True),
         sa.Column("hd", sa.Integer(), nullable=True),  # boolean: 1=HD, 0=SD
         sa.Column("revision_date", sa.Text(), nullable=True),
-
         # File type and size
         sa.Column("file_type", sa.Text(), nullable=False),  # mp4 | srt | scc | image | other
         sa.Column("file_size_bytes", sa.Integer(), nullable=True),
-
         # Remote server HTTP metadata
         sa.Column("etag", sa.Text(), nullable=True),
         sa.Column("content_type", sa.Text(), nullable=True),
         sa.Column("remote_modified_at", sa.DateTime(), nullable=True),
-
         # Tracking timestamps
-        sa.Column("first_seen_at", sa.DateTime(), nullable=False,
-                  server_default=sa.func.current_timestamp()),
-        sa.Column("last_seen_at", sa.DateTime(), nullable=False,
-                  server_default=sa.func.current_timestamp()),
-
+        sa.Column("first_seen_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=False, server_default=sa.func.current_timestamp()),
         # Workflow status
         sa.Column("status", sa.Text(), nullable=False, server_default="new"),
-
         # Variant / revision lineage
         # variant_tag: true variant suffix from known vocabulary, e.g. 'PLEDGE', 'DS'
         sa.Column("variant_tag", sa.Text(), nullable=True),
         # superseded_by: self-referential FK; older _REV<date> rows point at current row
-        sa.Column("superseded_by", sa.Integer(),
-                  sa.ForeignKey("mmingest_files.id"), nullable=True),
-
+        sa.Column("superseded_by", sa.Integer(), sa.ForeignKey("mmingest_files.id"), nullable=True),
         # Linking
         sa.Column("airtable_record_id", sa.Text(), nullable=True),
     )

--- a/alembic/versions/015_add_mmingest_files_table.py
+++ b/alembic/versions/015_add_mmingest_files_table.py
@@ -1,0 +1,92 @@
+"""Add mmingest_files master asset table.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-06-03
+
+Creates `mmingest_files` — the canonical record for every asset (MP4,
+SRT, SCC, images) discovered on the mmingest server.  This is the
+foundation table for the mmingest search-index feature (Sprint 1A).
+
+The existing `available_files` table is intentionally left in place for
+back-compat during the transition; no data is migrated here.
+
+Column notes
+------------
+prefix_category  enum-like text: 'broadcast' | 'non-broadcast' | 'unknown'
+                 Derived from the URL prefix by the crawler.
+status           workflow states: new | queued | indexed | no_match |
+                 ignored | missing | error
+hd               INTEGER treated as boolean (1=HD, 0=SD, NULL=unknown)
+revision_date    ISO date string extracted from the filename, e.g. "2024-01"
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "015"
+down_revision: Union[str, None] = "014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mmingest_files",
+
+        # Primary key
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+
+        # File location
+        sa.Column("remote_url", sa.Text(), nullable=False, unique=True),
+        sa.Column("directory_path", sa.Text(), nullable=True),
+        sa.Column("filename", sa.Text(), nullable=False),
+
+        # Parsed metadata — common fields
+        sa.Column("media_id", sa.Text(), nullable=True),
+        sa.Column("prefix", sa.Text(), nullable=True),
+        sa.Column("prefix_category", sa.Text(), nullable=False, server_default="unknown"),
+        sa.Column("show_name", sa.Text(), nullable=True),
+        sa.Column("season", sa.Text(), nullable=True),
+        sa.Column("episode", sa.Text(), nullable=True),
+        sa.Column("hd", sa.Integer(), nullable=True),  # boolean: 1=HD, 0=SD
+        sa.Column("revision_date", sa.Text(), nullable=True),
+
+        # File type and size
+        sa.Column("file_type", sa.Text(), nullable=False),  # mp4 | srt | scc | image | other
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+
+        # Remote server HTTP metadata
+        sa.Column("etag", sa.Text(), nullable=True),
+        sa.Column("content_type", sa.Text(), nullable=True),
+        sa.Column("remote_modified_at", sa.DateTime(), nullable=True),
+
+        # Tracking timestamps
+        sa.Column("first_seen_at", sa.DateTime(), nullable=False,
+                  server_default=sa.func.current_timestamp()),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=False,
+                  server_default=sa.func.current_timestamp()),
+
+        # Workflow status
+        sa.Column("status", sa.Text(), nullable=False, server_default="new"),
+
+        # Linking
+        sa.Column("airtable_record_id", sa.Text(), nullable=True),
+    )
+
+    # Indexes for common crawler + search queries
+    op.create_index("idx_mmingest_files_media_id", "mmingest_files", ["media_id"])
+    op.create_index("idx_mmingest_files_file_type", "mmingest_files", ["file_type"])
+    op.create_index("idx_mmingest_files_status", "mmingest_files", ["status"])
+    op.create_index("idx_mmingest_files_prefix", "mmingest_files", ["prefix"])
+    op.create_index("idx_mmingest_files_first_seen", "mmingest_files", ["first_seen_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_mmingest_files_first_seen", table_name="mmingest_files")
+    op.drop_index("idx_mmingest_files_prefix", table_name="mmingest_files")
+    op.drop_index("idx_mmingest_files_status", table_name="mmingest_files")
+    op.drop_index("idx_mmingest_files_file_type", table_name="mmingest_files")
+    op.drop_index("idx_mmingest_files_media_id", table_name="mmingest_files")
+    op.drop_table("mmingest_files")

--- a/alembic/versions/015_add_mmingest_files_table.py
+++ b/alembic/versions/015_add_mmingest_files_table.py
@@ -19,6 +19,14 @@ status           workflow states: new | queued | indexed | no_match |
                  ignored | missing | error
 hd               INTEGER treated as boolean (1=HD, 0=SD, NULL=unknown)
 revision_date    ISO date string extracted from the filename, e.g. "2024-01"
+variant_tag      True variant suffix from a known vocabulary (e.g. 'PLEDGE',
+                 'DS').  Populated when the filename ends in _<UPPERCASE_TAG>.
+                 NULL for primary/non-variant assets.  True variants coexist
+                 with the primary asset; they are NOT superseded.
+superseded_by    Self-referential FK → mmingest_files.id.  Older _REV<YYYYMMDD>
+                 iterations of the same asset point at the current (winning)
+                 row within the same (media_id, variant_tag) group.  NULL for
+                 current rows.  Population deferred to the indexer sprint.
 """
 from typing import Sequence, Union
 
@@ -70,6 +78,13 @@ def upgrade() -> None:
 
         # Workflow status
         sa.Column("status", sa.Text(), nullable=False, server_default="new"),
+
+        # Variant / revision lineage
+        # variant_tag: true variant suffix from known vocabulary, e.g. 'PLEDGE', 'DS'
+        sa.Column("variant_tag", sa.Text(), nullable=True),
+        # superseded_by: self-referential FK; older _REV<date> rows point at current row
+        sa.Column("superseded_by", sa.Integer(),
+                  sa.ForeignKey("mmingest_files.id"), nullable=True),
 
         # Linking
         sa.Column("airtable_record_id", sa.Text(), nullable=True),

--- a/alembic/versions/016_add_mmingest_sidecars_and_fts.py
+++ b/alembic/versions/016_add_mmingest_sidecars_and_fts.py
@@ -10,12 +10,24 @@ Creates two objects:
    linked to a mmingest_files row.
 
 2. `mmingest_sidecars_fts` — FTS5 virtual table in external-content mode
-   (content=mmingest_sidecars).  body_text is stored once in the real
-   table; the FTS shadow tables hold only the inverted index.
+   (content=mmingest_sidecars, content_rowid=id).  Only `body_text` is
+   declared; no UNINDEXED display columns are included.
 
-   Unindexed columns (media_id, prefix, show) are carried alongside
-   ranked hits for display/filtering without joining back to the base
-   table.
+   Why no UNINDEXED columns: In external-content mode FTS5 resolves ALL
+   declared column names against the content table at READ time (not write
+   time).  `media_id`, `prefix`, and `show_name` live on `mmingest_files`,
+   not on `mmingest_sidecars`, so declaring them here would cause:
+       OperationalError: no such column: T.media_id
+   on any query that materialises those columns.  Search consumers must
+   JOIN to retrieve display fields:
+
+       SELECT s.id, s.file_id, mf.media_id, mf.prefix, mf.show_name,
+              rank
+       FROM   mmingest_sidecars_fts
+       JOIN   mmingest_sidecars s  ON s.id  = mmingest_sidecars_fts.rowid
+       JOIN   mmingest_files    mf ON mf.id = s.file_id
+       WHERE  mmingest_sidecars_fts MATCH :query
+       ORDER  BY rank;
 
 FTS5 virtual tables and their sync triggers must go through op.execute()
 because SQLAlchemy/Alembic does not model them.
@@ -73,15 +85,17 @@ def upgrade() -> None:
     # content=mmingest_sidecars means SQLite reads body_text from the real
     # table for snippet/highlight/bm25 — it does NOT duplicate the text in
     # the FTS shadow tables.  content_rowid=id maps FTS rowids to the PK.
+    #
+    # Only body_text is declared.  Do NOT declare media_id/prefix/show_name
+    # here: those columns belong to mmingest_files (not mmingest_sidecars),
+    # so FTS5 would fail at read time trying to resolve them from the content
+    # table.  Search queries JOIN to mmingest_files for display fields.
     op.execute(
         """
         CREATE VIRTUAL TABLE mmingest_sidecars_fts
         USING fts5(
             body_text,
-            media_id   UNINDEXED,
-            prefix     UNINDEXED,
-            show       UNINDEXED,
-            content    = 'mmingest_sidecars',
+            content       = 'mmingest_sidecars',
             content_rowid = 'id'
         )
         """
@@ -93,37 +107,20 @@ def upgrade() -> None:
         """
         CREATE TRIGGER trg_mmingest_sidecars_fts_insert
         AFTER INSERT ON mmingest_sidecars BEGIN
-            INSERT INTO mmingest_sidecars_fts(
-                rowid, body_text, media_id, prefix, show
-            )
-            SELECT
-                new.id,
-                new.body_text,
-                mf.media_id,
-                mf.prefix,
-                mf.show_name
-            FROM mmingest_files mf
-            WHERE mf.id = new.file_id;
+            INSERT INTO mmingest_sidecars_fts(rowid, body_text)
+            VALUES (new.id, new.body_text);
         END
         """
     )
 
     # AFTER DELETE: remove the old row from the FTS index.
-    # FTS5 delete uses a sentinel row where the first column is the integer -1.
+    # FTS5 delete uses the special 'delete' command row.
     op.execute(
         """
         CREATE TRIGGER trg_mmingest_sidecars_fts_delete
         AFTER DELETE ON mmingest_sidecars BEGIN
-            INSERT INTO mmingest_sidecars_fts(
-                mmingest_sidecars_fts, rowid, body_text, media_id, prefix, show
-            ) VALUES (
-                'delete',
-                old.id,
-                old.body_text,
-                (SELECT media_id FROM mmingest_files WHERE id = old.file_id),
-                (SELECT prefix   FROM mmingest_files WHERE id = old.file_id),
-                (SELECT show_name FROM mmingest_files WHERE id = old.file_id)
-            );
+            INSERT INTO mmingest_sidecars_fts(mmingest_sidecars_fts, rowid, body_text)
+            VALUES ('delete', old.id, old.body_text);
         END
         """
     )
@@ -133,27 +130,10 @@ def upgrade() -> None:
         """
         CREATE TRIGGER trg_mmingest_sidecars_fts_update
         AFTER UPDATE ON mmingest_sidecars BEGIN
-            INSERT INTO mmingest_sidecars_fts(
-                mmingest_sidecars_fts, rowid, body_text, media_id, prefix, show
-            ) VALUES (
-                'delete',
-                old.id,
-                old.body_text,
-                (SELECT media_id  FROM mmingest_files WHERE id = old.file_id),
-                (SELECT prefix    FROM mmingest_files WHERE id = old.file_id),
-                (SELECT show_name FROM mmingest_files WHERE id = old.file_id)
-            );
-            INSERT INTO mmingest_sidecars_fts(
-                rowid, body_text, media_id, prefix, show
-            )
-            SELECT
-                new.id,
-                new.body_text,
-                mf.media_id,
-                mf.prefix,
-                mf.show_name
-            FROM mmingest_files mf
-            WHERE mf.id = new.file_id;
+            INSERT INTO mmingest_sidecars_fts(mmingest_sidecars_fts, rowid, body_text)
+            VALUES ('delete', old.id, old.body_text);
+            INSERT INTO mmingest_sidecars_fts(rowid, body_text)
+            VALUES (new.id, new.body_text);
         END
         """
     )

--- a/alembic/versions/016_add_mmingest_sidecars_and_fts.py
+++ b/alembic/versions/016_add_mmingest_sidecars_and_fts.py
@@ -43,10 +43,12 @@ Three AFTER triggers on mmingest_sidecars keep the FTS index in sync:
 
 The downgrade drops triggers, FTS table, and base table in reverse order.
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision: str = "016"
 down_revision: Union[str, None] = "015"
@@ -90,44 +92,37 @@ def upgrade() -> None:
     # here: those columns belong to mmingest_files (not mmingest_sidecars),
     # so FTS5 would fail at read time trying to resolve them from the content
     # table.  Search queries JOIN to mmingest_files for display fields.
-    op.execute(
-        """
+    op.execute("""
         CREATE VIRTUAL TABLE mmingest_sidecars_fts
         USING fts5(
             body_text,
             content       = 'mmingest_sidecars',
             content_rowid = 'id'
         )
-        """
-    )
+        """)
 
     # --- FTS sync triggers ---
     # AFTER INSERT: index the new row
-    op.execute(
-        """
+    op.execute("""
         CREATE TRIGGER trg_mmingest_sidecars_fts_insert
         AFTER INSERT ON mmingest_sidecars BEGIN
             INSERT INTO mmingest_sidecars_fts(rowid, body_text)
             VALUES (new.id, new.body_text);
         END
-        """
-    )
+        """)
 
     # AFTER DELETE: remove the old row from the FTS index.
     # FTS5 delete uses the special 'delete' command row.
-    op.execute(
-        """
+    op.execute("""
         CREATE TRIGGER trg_mmingest_sidecars_fts_delete
         AFTER DELETE ON mmingest_sidecars BEGIN
             INSERT INTO mmingest_sidecars_fts(mmingest_sidecars_fts, rowid, body_text)
             VALUES ('delete', old.id, old.body_text);
         END
-        """
-    )
+        """)
 
     # AFTER UPDATE: delete old entry, insert new entry.
-    op.execute(
-        """
+    op.execute("""
         CREATE TRIGGER trg_mmingest_sidecars_fts_update
         AFTER UPDATE ON mmingest_sidecars BEGIN
             INSERT INTO mmingest_sidecars_fts(mmingest_sidecars_fts, rowid, body_text)
@@ -135,8 +130,7 @@ def upgrade() -> None:
             INSERT INTO mmingest_sidecars_fts(rowid, body_text)
             VALUES (new.id, new.body_text);
         END
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/alembic/versions/016_add_mmingest_sidecars_and_fts.py
+++ b/alembic/versions/016_add_mmingest_sidecars_and_fts.py
@@ -1,0 +1,169 @@
+"""Add mmingest_sidecars table and FTS5 full-text search index.
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-06-03
+
+Creates two objects:
+
+1. `mmingest_sidecars` — stores fetched sidecar content (SRT/SCC bodies)
+   linked to a mmingest_files row.
+
+2. `mmingest_sidecars_fts` — FTS5 virtual table in external-content mode
+   (content=mmingest_sidecars).  body_text is stored once in the real
+   table; the FTS shadow tables hold only the inverted index.
+
+   Unindexed columns (media_id, prefix, show) are carried alongside
+   ranked hits for display/filtering without joining back to the base
+   table.
+
+FTS5 virtual tables and their sync triggers must go through op.execute()
+because SQLAlchemy/Alembic does not model them.
+
+Sync triggers
+-------------
+Three AFTER triggers on mmingest_sidecars keep the FTS index in sync:
+
+  trg_mmingest_sidecars_fts_insert  — on INSERT: insert into FTS
+  trg_mmingest_sidecars_fts_delete  — on DELETE: delete from FTS using
+                                       the special 'delete' command row
+  trg_mmingest_sidecars_fts_update  — on UPDATE: delete old + insert new
+
+The downgrade drops triggers, FTS table, and base table in reverse order.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- mmingest_sidecars base table ---
+    op.create_table(
+        "mmingest_sidecars",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "file_id",
+            sa.Integer(),
+            sa.ForeignKey("mmingest_files.id"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.Text(), nullable=False),  # 'srt' | 'scc'
+        sa.Column("bytes", sa.Integer(), nullable=True),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+        sa.Column("body_text", sa.Text(), nullable=True),
+    )
+
+    op.create_index("idx_mmingest_sidecars_file_id", "mmingest_sidecars", ["file_id"])
+    op.create_index("idx_mmingest_sidecars_kind", "mmingest_sidecars", ["kind"])
+
+    # --- FTS5 virtual table (external-content mode) ---
+    # SQLAlchemy/Alembic cannot model virtual tables; use op.execute() throughout.
+    #
+    # content=mmingest_sidecars means SQLite reads body_text from the real
+    # table for snippet/highlight/bm25 — it does NOT duplicate the text in
+    # the FTS shadow tables.  content_rowid=id maps FTS rowids to the PK.
+    op.execute(
+        """
+        CREATE VIRTUAL TABLE mmingest_sidecars_fts
+        USING fts5(
+            body_text,
+            media_id   UNINDEXED,
+            prefix     UNINDEXED,
+            show       UNINDEXED,
+            content    = 'mmingest_sidecars',
+            content_rowid = 'id'
+        )
+        """
+    )
+
+    # --- FTS sync triggers ---
+    # AFTER INSERT: index the new row
+    op.execute(
+        """
+        CREATE TRIGGER trg_mmingest_sidecars_fts_insert
+        AFTER INSERT ON mmingest_sidecars BEGIN
+            INSERT INTO mmingest_sidecars_fts(
+                rowid, body_text, media_id, prefix, show
+            )
+            SELECT
+                new.id,
+                new.body_text,
+                mf.media_id,
+                mf.prefix,
+                mf.show_name
+            FROM mmingest_files mf
+            WHERE mf.id = new.file_id;
+        END
+        """
+    )
+
+    # AFTER DELETE: remove the old row from the FTS index.
+    # FTS5 delete uses a sentinel row where the first column is the integer -1.
+    op.execute(
+        """
+        CREATE TRIGGER trg_mmingest_sidecars_fts_delete
+        AFTER DELETE ON mmingest_sidecars BEGIN
+            INSERT INTO mmingest_sidecars_fts(
+                mmingest_sidecars_fts, rowid, body_text, media_id, prefix, show
+            ) VALUES (
+                'delete',
+                old.id,
+                old.body_text,
+                (SELECT media_id FROM mmingest_files WHERE id = old.file_id),
+                (SELECT prefix   FROM mmingest_files WHERE id = old.file_id),
+                (SELECT show_name FROM mmingest_files WHERE id = old.file_id)
+            );
+        END
+        """
+    )
+
+    # AFTER UPDATE: delete old entry, insert new entry.
+    op.execute(
+        """
+        CREATE TRIGGER trg_mmingest_sidecars_fts_update
+        AFTER UPDATE ON mmingest_sidecars BEGIN
+            INSERT INTO mmingest_sidecars_fts(
+                mmingest_sidecars_fts, rowid, body_text, media_id, prefix, show
+            ) VALUES (
+                'delete',
+                old.id,
+                old.body_text,
+                (SELECT media_id  FROM mmingest_files WHERE id = old.file_id),
+                (SELECT prefix    FROM mmingest_files WHERE id = old.file_id),
+                (SELECT show_name FROM mmingest_files WHERE id = old.file_id)
+            );
+            INSERT INTO mmingest_sidecars_fts(
+                rowid, body_text, media_id, prefix, show
+            )
+            SELECT
+                new.id,
+                new.body_text,
+                mf.media_id,
+                mf.prefix,
+                mf.show_name
+            FROM mmingest_files mf
+            WHERE mf.id = new.file_id;
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_mmingest_sidecars_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS trg_mmingest_sidecars_fts_delete")
+    op.execute("DROP TRIGGER IF EXISTS trg_mmingest_sidecars_fts_insert")
+    op.execute("DROP TABLE IF EXISTS mmingest_sidecars_fts")
+    op.drop_index("idx_mmingest_sidecars_kind", table_name="mmingest_sidecars")
+    op.drop_index("idx_mmingest_sidecars_file_id", table_name="mmingest_sidecars")
+    op.drop_table("mmingest_sidecars")

--- a/alembic/versions/017_add_consumer_keys.py
+++ b/alembic/versions/017_add_consumer_keys.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
     op.create_table(
         "consumer_keys",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
-        sa.Column("key_hash", sa.Text(), nullable=False, unique=True),
+        sa.Column("key_hash", sa.Text(), nullable=False),
         sa.Column("label", sa.Text(), nullable=False),
         sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
         sa.Column(

--- a/alembic/versions/017_add_consumer_keys.py
+++ b/alembic/versions/017_add_consumer_keys.py
@@ -1,0 +1,54 @@
+"""Add consumer_keys table for API key authentication.
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-06-03
+
+Creates `consumer_keys` — stores hashed API keys and their associated
+scopes for authenticating mmingest search consumers.
+
+Column notes
+------------
+key_hash   SHA-256 hex digest of the raw API key.  The raw key is never
+           stored; consumers present the raw key and the API hashes it
+           for lookup.
+label      Human-readable name for the key (e.g. "search-frontend-prod").
+scopes     CSV of granted scope strings, e.g.
+           "mmingest:read,mmingest:stream".
+created_at Populated at INSERT via server_default.
+last_used_at Updated by the application on each successful auth; nullable
+             until the key has been used at least once.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "017"
+down_revision: Union[str, None] = "016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "consumer_keys",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("key_hash", sa.Text(), nullable=False, unique=True),
+        sa.Column("label", sa.Text(), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+    )
+
+    op.create_index("idx_consumer_keys_key_hash", "consumer_keys", ["key_hash"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_consumer_keys_key_hash", table_name="consumer_keys")
+    op.drop_table("consumer_keys")

--- a/alembic/versions/017_add_consumer_keys.py
+++ b/alembic/versions/017_add_consumer_keys.py
@@ -19,10 +19,12 @@ created_at Populated at INSERT via server_default.
 last_used_at Updated by the application on each successful auth; nullable
              until the key has been used at least once.
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision: str = "017"
 down_revision: Union[str, None] = "016"

--- a/api/services/mmingest/__init__.py
+++ b/api/services/mmingest/__init__.py
@@ -1,0 +1,2 @@
+# mmingest service package — Sprint 1A foundation.
+# Crawler, indexer, and search API will be added in later sprints.

--- a/api/services/mmingest/_db.py
+++ b/api/services/mmingest/_db.py
@@ -53,11 +53,13 @@ async def fts_parity_delta(conn: AsyncConnection) -> int | None:
     # Preflight: check both tables exist in sqlite_master before querying them.
     # Using sqlite_master avoids wrapping OperationalError (which could mask
     # genuine errors such as a corrupt FTS shadow table).
+    # Note: SQLite registers FTS5 shadow tables (e.g. _docsize) with
+    # type='table' — there is no distinct 'shadow' type in sqlite_master.
     exists_row = await conn.execute(
         text(
             """
             SELECT COUNT(*) FROM sqlite_master
-            WHERE type IN ('table', 'shadow')
+            WHERE type = 'table'
               AND name IN ('mmingest_sidecars', 'mmingest_sidecars_fts_docsize')
             """
         )

--- a/api/services/mmingest/_db.py
+++ b/api/services/mmingest/_db.py
@@ -55,30 +55,22 @@ async def fts_parity_delta(conn: AsyncConnection) -> int | None:
     # genuine errors such as a corrupt FTS shadow table).
     # Note: SQLite registers FTS5 shadow tables (e.g. _docsize) with
     # type='table' — there is no distinct 'shadow' type in sqlite_master.
-    exists_row = await conn.execute(
-        text(
-            """
+    exists_row = await conn.execute(text("""
             SELECT COUNT(*) FROM sqlite_master
             WHERE type = 'table'
               AND name IN ('mmingest_sidecars', 'mmingest_sidecars_fts_docsize')
-            """
-        )
-    )
+            """))
     if exists_row.scalar_one() < 2:
         return None
 
-    base_count_row = await conn.execute(
-        text("SELECT COUNT(*) FROM mmingest_sidecars")
-    )
+    base_count_row = await conn.execute(text("SELECT COUNT(*) FROM mmingest_sidecars"))
     base_count: int = base_count_row.scalar_one()
 
     # In FTS5 external-content mode the virtual table does NOT create a
     # _content shadow table (the content lives in mmingest_sidecars itself).
     # The _docsize shadow table has exactly one row per document present in
     # the index, making it the right counter for parity checks.
-    fts_count_row = await conn.execute(
-        text("SELECT COUNT(*) FROM mmingest_sidecars_fts_docsize")
-    )
+    fts_count_row = await conn.execute(text("SELECT COUNT(*) FROM mmingest_sidecars_fts_docsize"))
     fts_count: int = fts_count_row.scalar_one()
 
     return base_count - fts_count

--- a/api/services/mmingest/_db.py
+++ b/api/services/mmingest/_db.py
@@ -4,40 +4,67 @@ Parity check
 ------------
 ``fts_parity_delta`` returns the difference between the row count in the
 ``mmingest_sidecars`` base table and the row count stored in the FTS5
-shadow table ``mmingest_sidecars_fts_content``.
+``_docsize`` shadow table (one row per indexed document).
 
-  * Returns 0   → FTS index is in sync with the base table.
-  * Returns N   → N base rows are missing from the FTS index.
-  * Returns -N  → FTS has N phantom rows not present in the base table
-                  (e.g. after a manual DELETE that bypassed triggers).
+  * Returns 0    → FTS index is in sync with the base table.
+  * Returns N    → N base rows are missing from the FTS index.
+  * Returns -N   → FTS has N phantom rows not present in the base table
+                   (e.g. after a manual DELETE that bypassed triggers).
+  * Returns None → migration 016 has not yet been applied; the tables do
+                   not exist.  Callers should treat None as "not checkable"
+                   rather than "in sync".  This can occur during the deploy
+                   window between app restart and migration completion.
 
 Usage::
 
-    from sqlalchemy import text
     from sqlalchemy.ext.asyncio import AsyncConnection
 
     delta = await fts_parity_delta(conn)
-    if delta != 0:
+    if delta is None:
+        logger.info("FTS tables not yet migrated — skipping parity check")
+    elif delta != 0:
         logger.warning("FTS out of sync by %d rows", delta)
 
 The function is intentionally read-only and side-effect free; it is safe
 to call from health-check endpoints or ops scripts.
 """
 
+from __future__ import annotations
+
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 
-async def fts_parity_delta(conn: AsyncConnection) -> int:
+async def fts_parity_delta(conn: AsyncConnection) -> int | None:
     """Return the row-count delta between mmingest_sidecars and its FTS5 index.
+
+    Preflights sqlite_master to detect the pre-migration state and returns
+    None rather than raising OperationalError when the tables don't exist
+    (e.g. deploy window between app restart and migration 016 completing).
 
     Args:
         conn: An active async SQLAlchemy connection.
 
     Returns:
-        int: ``len(mmingest_sidecars) - len(mmingest_sidecars_fts)``.
-             0 means the FTS index is fully in sync.
+        int:  ``len(mmingest_sidecars) - len(mmingest_sidecars_fts_docsize)``.
+              0 means the FTS index is fully in sync.
+        None: migration 016 has not been applied; tables are absent.
     """
+    # Preflight: check both tables exist in sqlite_master before querying them.
+    # Using sqlite_master avoids wrapping OperationalError (which could mask
+    # genuine errors such as a corrupt FTS shadow table).
+    exists_row = await conn.execute(
+        text(
+            """
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type IN ('table', 'shadow')
+              AND name IN ('mmingest_sidecars', 'mmingest_sidecars_fts_docsize')
+            """
+        )
+    )
+    if exists_row.scalar_one() < 2:
+        return None
+
     base_count_row = await conn.execute(
         text("SELECT COUNT(*) FROM mmingest_sidecars")
     )

--- a/api/services/mmingest/_db.py
+++ b/api/services/mmingest/_db.py
@@ -1,0 +1,55 @@
+"""Database helpers for the mmingest service.
+
+Parity check
+------------
+``fts_parity_delta`` returns the difference between the row count in the
+``mmingest_sidecars`` base table and the row count stored in the FTS5
+shadow table ``mmingest_sidecars_fts_content``.
+
+  * Returns 0   → FTS index is in sync with the base table.
+  * Returns N   → N base rows are missing from the FTS index.
+  * Returns -N  → FTS has N phantom rows not present in the base table
+                  (e.g. after a manual DELETE that bypassed triggers).
+
+Usage::
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import AsyncConnection
+
+    delta = await fts_parity_delta(conn)
+    if delta != 0:
+        logger.warning("FTS out of sync by %d rows", delta)
+
+The function is intentionally read-only and side-effect free; it is safe
+to call from health-check endpoints or ops scripts.
+"""
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+async def fts_parity_delta(conn: AsyncConnection) -> int:
+    """Return the row-count delta between mmingest_sidecars and its FTS5 index.
+
+    Args:
+        conn: An active async SQLAlchemy connection.
+
+    Returns:
+        int: ``len(mmingest_sidecars) - len(mmingest_sidecars_fts)``.
+             0 means the FTS index is fully in sync.
+    """
+    base_count_row = await conn.execute(
+        text("SELECT COUNT(*) FROM mmingest_sidecars")
+    )
+    base_count: int = base_count_row.scalar_one()
+
+    # In FTS5 external-content mode the virtual table does NOT create a
+    # _content shadow table (the content lives in mmingest_sidecars itself).
+    # The _docsize shadow table has exactly one row per document present in
+    # the index, making it the right counter for parity checks.
+    fts_count_row = await conn.execute(
+        text("SELECT COUNT(*) FROM mmingest_sidecars_fts_docsize")
+    )
+    fts_count: int = fts_count_row.scalar_one()
+
+    return base_count - fts_count

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -119,6 +119,26 @@ async def test_mmingest_schema_tables_exist(migrated_engine):
 
 
 @pytest.mark.asyncio
+async def test_mmingest_files_columns(migrated_engine):
+    """Migration 015: mmingest_files has all expected columns including variant lineage."""
+    async with migrated_engine.connect() as conn:
+        cols_row = await conn.execute(text("PRAGMA table_info(mmingest_files)"))
+        col_names = {r[1] for r in cols_row.fetchall()}
+
+    for expected in (
+        "id", "remote_url", "directory_path", "filename",
+        "media_id", "prefix", "prefix_category", "show_name",
+        "season", "episode", "hd", "revision_date",
+        "file_type", "file_size_bytes",
+        "etag", "content_type", "remote_modified_at",
+        "first_seen_at", "last_seen_at", "status",
+        "variant_tag", "superseded_by",
+        "airtable_record_id",
+    ):
+        assert expected in col_names, f"mmingest_files missing column: {expected}"
+
+
+@pytest.mark.asyncio
 async def test_available_files_new_columns_exist(migrated_engine):
     """Migration 014 added four columns to available_files."""
     async with migrated_engine.connect() as conn:

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -38,9 +38,7 @@ async def migrated_engine():
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
     yield engine
@@ -73,27 +71,21 @@ async def test_parity_delta_zero_after_insert(migrated_engine):
 
     async with migrated_engine.begin() as conn:
         # Insert a parent mmingest_files row first (FK constraint)
-        await conn.execute(
-            text(
-                """
+        await conn.execute(text("""
                 INSERT INTO mmingest_files
                     (remote_url, filename, file_type)
                 VALUES
                     ('http://example.com/test.srt', 'test.srt', 'srt')
-                """
-            )
-        )
+                """))
         file_id_row = await conn.execute(text("SELECT last_insert_rowid()"))
         file_id = file_id_row.scalar_one()
 
         # Insert a sidecar — trigger should update FTS
         await conn.execute(
-            text(
-                """
+            text("""
                 INSERT INTO mmingest_sidecars (file_id, kind, body_text)
                 VALUES (:file_id, 'srt', 'This is a test caption body.')
-                """
-            ),
+                """),
             {"file_id": file_id},
         )
 
@@ -106,9 +98,7 @@ async def test_parity_delta_zero_after_insert(migrated_engine):
 async def test_mmingest_schema_tables_exist(migrated_engine):
     """Smoke-test: all four migration targets are present after upgrade head."""
     async with migrated_engine.connect() as conn:
-        tables_row = await conn.execute(
-            text("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        )
+        tables_row = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"))
         tables = {r[0] for r in tables_row.fetchall()}
 
     assert "mmingest_files" in tables
@@ -126,13 +116,28 @@ async def test_mmingest_files_columns(migrated_engine):
         col_names = {r[1] for r in cols_row.fetchall()}
 
     for expected in (
-        "id", "remote_url", "directory_path", "filename",
-        "media_id", "prefix", "prefix_category", "show_name",
-        "season", "episode", "hd", "revision_date",
-        "file_type", "file_size_bytes",
-        "etag", "content_type", "remote_modified_at",
-        "first_seen_at", "last_seen_at", "status",
-        "variant_tag", "superseded_by",
+        "id",
+        "remote_url",
+        "directory_path",
+        "filename",
+        "media_id",
+        "prefix",
+        "prefix_category",
+        "show_name",
+        "season",
+        "episode",
+        "hd",
+        "revision_date",
+        "file_type",
+        "file_size_bytes",
+        "etag",
+        "content_type",
+        "remote_modified_at",
+        "first_seen_at",
+        "last_seen_at",
+        "status",
+        "variant_tag",
+        "superseded_by",
         "airtable_record_id",
     ):
         assert expected in col_names, f"mmingest_files missing column: {expected}"
@@ -174,28 +179,22 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
     """
     async with migrated_engine.begin() as conn:
         # Insert a parent mmingest_files row with known display fields
-        await conn.execute(
-            text(
-                """
+        await conn.execute(text("""
                 INSERT INTO mmingest_files
                     (remote_url, filename, file_type, media_id, prefix, show_name)
                 VALUES
                     ('http://example.com/search_test.srt', 'search_test.srt',
                      'srt', 'WLIA1234', 'wlia', 'Nature Hour')
-                """
-            )
-        )
+                """))
         file_id_row = await conn.execute(text("SELECT last_insert_rowid()"))
         file_id = file_id_row.scalar_one()
 
         await conn.execute(
-            text(
-                """
+            text("""
                 INSERT INTO mmingest_sidecars (file_id, kind, body_text)
                 VALUES (:file_id, 'srt',
                         'The red fox jumped over the lazy brown dog.')
-                """
-            ),
+                """),
             {"file_id": file_id},
         )
 
@@ -203,10 +202,7 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
     # If the FTS5 table still has phantom UNINDEXED columns this raises
     # OperationalError: no such column: T.media_id
     async with migrated_engine.connect() as conn:
-        rows = (
-            await conn.execute(
-                text(
-                    """
+        rows = (await conn.execute(text("""
                     SELECT s.id,
                            s.file_id,
                            mf.media_id,
@@ -218,10 +214,7 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
                     JOIN   mmingest_files        AS mf  ON mf.id = s.file_id
                     WHERE  mmingest_sidecars_fts MATCH 'fox'
                     ORDER  BY fts.rank
-                    """
-                )
-            )
-        ).fetchall()
+                    """))).fetchall()
 
     assert len(rows) == 1, f"Expected 1 FTS hit, got {len(rows)}"
     row = rows[0]
@@ -243,10 +236,7 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
     async with migrated_engine.connect() as conn:
         direct_rows = (
             await conn.execute(
-                text(
-                    "SELECT body_text FROM mmingest_sidecars_fts"
-                    " WHERE mmingest_sidecars_fts MATCH 'fox'"
-                )
+                text("SELECT body_text FROM mmingest_sidecars_fts" " WHERE mmingest_sidecars_fts MATCH 'fox'")
             )
         ).fetchall()
 
@@ -258,6 +248,7 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
 # Downgrade round-trip
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_downgrade_round_trip():
     """upgrade head → downgrade 013 removes mmingest tables; available_files
@@ -266,9 +257,7 @@ async def test_downgrade_round_trip():
     fd, db_path = tempfile.mkstemp(suffix="_downgrade_test.db")
     os.close(fd)
 
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..")
-    )
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
     env = {**os.environ, "DATABASE_PATH": db_path}
 
     def alembic(*args: str) -> None:
@@ -279,9 +268,7 @@ async def test_downgrade_round_trip():
             capture_output=True,
             text=True,
         )
-        assert result.returncode == 0, (
-            f"alembic {' '.join(args)} failed:\n{result.stdout}\n{result.stderr}"
-        )
+        assert result.returncode == 0, f"alembic {' '.join(args)} failed:\n{result.stdout}\n{result.stderr}"
 
     try:
         alembic("upgrade", "head")
@@ -290,9 +277,7 @@ async def test_downgrade_round_trip():
         try:
             # Confirm mmingest tables exist at head
             async with engine.connect() as conn:
-                tables_row = await conn.execute(
-                    text("SELECT name FROM sqlite_master WHERE type='table'")
-                )
+                tables_row = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
                 tables_at_head = {r[0] for r in tables_row.fetchall()}
             assert "mmingest_files" in tables_at_head
             assert "mmingest_sidecars" in tables_at_head
@@ -306,9 +291,7 @@ async def test_downgrade_round_trip():
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
         try:
             async with engine.connect() as conn:
-                tables_row = await conn.execute(
-                    text("SELECT name FROM sqlite_master WHERE type='table'")
-                )
+                tables_row = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
                 tables_at_013 = {r[0] for r in tables_row.fetchall()}
 
                 # mmingest tables must be gone
@@ -320,14 +303,12 @@ async def test_downgrade_round_trip():
                 assert "available_files" in tables_at_013
 
                 # The four columns added by 014 must be gone
-                cols_row = await conn.execute(
-                    text("PRAGMA table_info(available_files)")
-                )
+                cols_row = await conn.execute(text("PRAGMA table_info(available_files)"))
                 col_names_at_013 = {r[1] for r in cols_row.fetchall()}
             for removed_col in ("etag", "content_type", "last_head_at", "probe_status"):
-                assert removed_col not in col_names_at_013, (
-                    f"Column {removed_col!r} should be absent after downgrade to 013"
-                )
+                assert (
+                    removed_col not in col_names_at_013
+                ), f"Column {removed_col!r} should be absent after downgrade to 013"
         finally:
             await engine.dispose()
 
@@ -337,9 +318,7 @@ async def test_downgrade_round_trip():
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
         try:
             async with engine.connect() as conn:
-                tables_row = await conn.execute(
-                    text("SELECT name FROM sqlite_master WHERE type='table'")
-                )
+                tables_row = await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))
                 tables_final = {r[0] for r in tables_row.fetchall()}
             assert "mmingest_files" in tables_final
             assert "mmingest_sidecars" in tables_final
@@ -358,6 +337,7 @@ async def test_downgrade_round_trip():
 # Delete-trigger parity coverage
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_parity_delta_zero_after_delete(migrated_engine):
     """INSERT then DELETE via the normal table path keeps delta at 0.
@@ -368,31 +348,21 @@ async def test_parity_delta_zero_after_delete(migrated_engine):
     from api.services.mmingest._db import fts_parity_delta
 
     async with migrated_engine.begin() as conn:
-        await conn.execute(
-            text(
-                """
+        await conn.execute(text("""
                 INSERT INTO mmingest_files (remote_url, filename, file_type)
                 VALUES ('http://example.com/delete_test.srt',
                         'delete_test.srt', 'srt')
-                """
-            )
-        )
-        file_id = (
-            await conn.execute(text("SELECT last_insert_rowid()"))
-        ).scalar_one()
+                """))
+        file_id = (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
 
         await conn.execute(
-            text(
-                """
+            text("""
                 INSERT INTO mmingest_sidecars (file_id, kind, body_text)
                 VALUES (:fid, 'srt', 'Content that will be deleted.')
-                """
-            ),
+                """),
             {"fid": file_id},
         )
-        sidecar_id = (
-            await conn.execute(text("SELECT last_insert_rowid()"))
-        ).scalar_one()
+        sidecar_id = (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
 
     # Confirm delta is 0 after insert
     async with migrated_engine.connect() as conn:
@@ -422,31 +392,21 @@ async def test_parity_delta_detects_divergence(migrated_engine):
     from api.services.mmingest._db import fts_parity_delta
 
     async with migrated_engine.begin() as conn:
-        await conn.execute(
-            text(
-                """
+        await conn.execute(text("""
                 INSERT INTO mmingest_files (remote_url, filename, file_type)
                 VALUES ('http://example.com/phantom_test.srt',
                         'phantom_test.srt', 'srt')
-                """
-            )
-        )
-        file_id = (
-            await conn.execute(text("SELECT last_insert_rowid()"))
-        ).scalar_one()
+                """))
+        file_id = (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
 
         await conn.execute(
-            text(
-                """
+            text("""
                 INSERT INTO mmingest_sidecars (file_id, kind, body_text)
                 VALUES (:fid, 'srt', 'Phantom row body text.')
-                """
-            ),
+                """),
             {"fid": file_id},
         )
-        sidecar_id = (
-            await conn.execute(text("SELECT last_insert_rowid()"))
-        ).scalar_one()
+        sidecar_id = (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
 
     async with migrated_engine.connect() as conn:
         assert await fts_parity_delta(conn) == 0
@@ -463,9 +423,7 @@ async def test_parity_delta_detects_divergence(migrated_engine):
         # Synthetic phantom: re-insert the _docsize row that the trigger
         # correctly removed, recreating the "FTS ahead of base" condition.
         await conn.execute(
-            text(
-                "INSERT INTO mmingest_sidecars_fts_docsize(id, sz) VALUES (:sid, 4)"
-            ),
+            text("INSERT INTO mmingest_sidecars_fts_docsize(id, sz) VALUES (:sid, 4)"),
             {"sid": sidecar_id},
         )
 
@@ -487,9 +445,7 @@ async def test_parity_delta_returns_none_before_migration_016():
     fd, db_path = tempfile.mkstemp(suffix="_pre016_test.db")
     os.close(fd)
 
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..")
-    )
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
     env = {**os.environ, "DATABASE_PATH": db_path}
     result = subprocess.run(
         [sys.executable, "-m", "alembic", "upgrade", "013"],
@@ -498,17 +454,13 @@ async def test_parity_delta_returns_none_before_migration_016():
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"alembic upgrade 013 failed:\n{result.stdout}\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"alembic upgrade 013 failed:\n{result.stdout}\n{result.stderr}"
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
     try:
         async with engine.connect() as conn:
             result = await fts_parity_delta(conn)
-        assert result is None, (
-            f"Expected None for pre-016 DB, got {result!r}"
-        )
+        assert result is None, f"Expected None for pre-016 DB, got {result!r}"
     finally:
         await engine.dispose()
         try:

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -411,8 +411,13 @@ async def test_parity_delta_zero_after_delete(migrated_engine):
 
 @pytest.mark.asyncio
 async def test_parity_delta_detects_divergence(migrated_engine):
-    """Direct DELETE on the base table that bypasses triggers leaves FTS
-    with a phantom row: delta == -1 (FTS has more rows than base).
+    """Synthetically injected phantom _docsize row produces delta == -1.
+
+    A genuine trigger-bypass (e.g. direct sqlite3 CLI delete) is not
+    cleanly reachable from Python, so this test constructs a numerically
+    identical state: DELETE via the normal trigger path (which cleans FTS
+    correctly), then re-insert the _docsize row to simulate the phantom
+    entry a trigger bypass would have left behind.
     """
     from api.services.mmingest._db import fts_parity_delta
 
@@ -446,17 +451,17 @@ async def test_parity_delta_detects_divergence(migrated_engine):
     async with migrated_engine.connect() as conn:
         assert await fts_parity_delta(conn) == 0
 
-    # Bypass triggers: delete from the _docsize shadow table directly to
-    # simulate the base table being pruned without an FTS delete command.
-    # (Mutating the shadow table is the cleanest way to create the
-    # phantom-row scenario without disabling triggers.)
+    # Delete via the normal trigger path — the AFTER DELETE trigger fires
+    # and removes the _docsize row, leaving delta at 0.  Then synthetically
+    # re-inject the _docsize row to produce the diverged state that a real
+    # trigger bypass (e.g. direct CLI delete without triggers) would leave.
     async with migrated_engine.begin() as conn:
         await conn.execute(
             text("DELETE FROM mmingest_sidecars WHERE id = :sid"),
             {"sid": sidecar_id},
         )
-        # Re-insert the _docsize row to simulate a phantom FTS entry that
-        # the trigger somehow missed (trigger disabled / direct DB edit).
+        # Synthetic phantom: re-insert the _docsize row that the trigger
+        # correctly removed, recreating the "FTS ahead of base" condition.
         await conn.execute(
             text(
                 "INSERT INTO mmingest_sidecars_fts_docsize(id, sz) VALUES (:sid, 4)"

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -140,3 +140,74 @@ async def test_consumer_keys_columns(migrated_engine):
 
     for expected in ("id", "key_hash", "label", "scopes", "created_at", "last_used_at"):
         assert expected in col_names, f"Missing column: {expected}"
+
+
+@pytest.mark.asyncio
+async def test_fts_match_join_returns_display_fields(migrated_engine):
+    """FTS5 MATCH query joined to mmingest_files returns media_id/prefix/show_name.
+
+    This is the read path the search feature uses.  The bug this test guards
+    against: declaring UNINDEXED columns in the FTS5 DDL that don't exist on
+    the content table (mmingest_sidecars) causes OperationalError at read time
+    even though writes succeed.  The fix is to declare only body_text in the
+    FTS5 table and JOIN to mmingest_files for display fields.
+    """
+    async with migrated_engine.begin() as conn:
+        # Insert a parent mmingest_files row with known display fields
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_files
+                    (remote_url, filename, file_type, media_id, prefix, show_name)
+                VALUES
+                    ('http://example.com/search_test.srt', 'search_test.srt',
+                     'srt', 'WLIA1234', 'wlia', 'Nature Hour')
+                """
+            )
+        )
+        file_id_row = await conn.execute(text("SELECT last_insert_rowid()"))
+        file_id = file_id_row.scalar_one()
+
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+                VALUES (:file_id, 'srt',
+                        'The red fox jumped over the lazy brown dog.')
+                """
+            ),
+            {"file_id": file_id},
+        )
+
+    # The actual search query shape the downstream consumer will use.
+    # If the FTS5 table still has phantom UNINDEXED columns this raises
+    # OperationalError: no such column: T.media_id
+    async with migrated_engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    """
+                    SELECT s.id,
+                           s.file_id,
+                           mf.media_id,
+                           mf.prefix,
+                           mf.show_name,
+                           fts.rank
+                    FROM   mmingest_sidecars_fts AS fts
+                    JOIN   mmingest_sidecars     AS s   ON s.id  = fts.rowid
+                    JOIN   mmingest_files        AS mf  ON mf.id = s.file_id
+                    WHERE  mmingest_sidecars_fts MATCH 'fox'
+                    ORDER  BY fts.rank
+                    """
+                )
+            )
+        ).fetchall()
+
+    assert len(rows) == 1, f"Expected 1 FTS hit, got {len(rows)}"
+    row = rows[0]
+    assert row._mapping["media_id"] == "WLIA1234"
+    assert row._mapping["prefix"] == "wlia"
+    assert row._mapping["show_name"] == "Nature Hour"
+    # rank is a negative float (BM25); just assert it's present and numeric
+    assert row._mapping["rank"] is not None
+    assert float(row._mapping["rank"]) < 0

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -252,3 +252,261 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
 
     assert len(direct_rows) == 1
     assert "fox" in direct_rows[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Downgrade round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_downgrade_round_trip():
+    """upgrade head → downgrade 013 removes mmingest tables; available_files
+    loses the four 014 columns; re-upgrade restores everything.
+    """
+    fd, db_path = tempfile.mkstemp(suffix="_downgrade_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    def alembic(*args: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "alembic", *args],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"alembic {' '.join(args)} failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+    try:
+        alembic("upgrade", "head")
+
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+        try:
+            # Confirm mmingest tables exist at head
+            async with engine.connect() as conn:
+                tables_row = await conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                )
+                tables_at_head = {r[0] for r in tables_row.fetchall()}
+            assert "mmingest_files" in tables_at_head
+            assert "mmingest_sidecars" in tables_at_head
+            assert "consumer_keys" in tables_at_head
+        finally:
+            await engine.dispose()
+
+        # Downgrade to 013
+        alembic("downgrade", "013")
+
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+        try:
+            async with engine.connect() as conn:
+                tables_row = await conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                )
+                tables_at_013 = {r[0] for r in tables_row.fetchall()}
+
+                # mmingest tables must be gone
+                assert "mmingest_files" not in tables_at_013
+                assert "mmingest_sidecars" not in tables_at_013
+                assert "consumer_keys" not in tables_at_013
+
+                # available_files must still exist (it predates 014)
+                assert "available_files" in tables_at_013
+
+                # The four columns added by 014 must be gone
+                cols_row = await conn.execute(
+                    text("PRAGMA table_info(available_files)")
+                )
+                col_names_at_013 = {r[1] for r in cols_row.fetchall()}
+            for removed_col in ("etag", "content_type", "last_head_at", "probe_status"):
+                assert removed_col not in col_names_at_013, (
+                    f"Column {removed_col!r} should be absent after downgrade to 013"
+                )
+        finally:
+            await engine.dispose()
+
+        # Re-upgrade: everything must come back
+        alembic("upgrade", "head")
+
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+        try:
+            async with engine.connect() as conn:
+                tables_row = await conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table'")
+                )
+                tables_final = {r[0] for r in tables_row.fetchall()}
+            assert "mmingest_files" in tables_final
+            assert "mmingest_sidecars" in tables_final
+            assert "consumer_keys" in tables_final
+        finally:
+            await engine.dispose()
+
+    finally:
+        try:
+            os.unlink(db_path)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Delete-trigger parity coverage
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_parity_delta_zero_after_delete(migrated_engine):
+    """INSERT then DELETE via the normal table path keeps delta at 0.
+
+    The AFTER DELETE trigger removes the FTS entry, so the index stays
+    in sync with the base table.
+    """
+    from api.services.mmingest._db import fts_parity_delta
+
+    async with migrated_engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_files (remote_url, filename, file_type)
+                VALUES ('http://example.com/delete_test.srt',
+                        'delete_test.srt', 'srt')
+                """
+            )
+        )
+        file_id = (
+            await conn.execute(text("SELECT last_insert_rowid()"))
+        ).scalar_one()
+
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+                VALUES (:fid, 'srt', 'Content that will be deleted.')
+                """
+            ),
+            {"fid": file_id},
+        )
+        sidecar_id = (
+            await conn.execute(text("SELECT last_insert_rowid()"))
+        ).scalar_one()
+
+    # Confirm delta is 0 after insert
+    async with migrated_engine.connect() as conn:
+        assert await fts_parity_delta(conn) == 0
+
+    # Delete via normal path — AFTER DELETE trigger should clean FTS
+    async with migrated_engine.begin() as conn:
+        await conn.execute(
+            text("DELETE FROM mmingest_sidecars WHERE id = :sid"),
+            {"sid": sidecar_id},
+        )
+
+    async with migrated_engine.connect() as conn:
+        assert await fts_parity_delta(conn) == 0
+
+
+@pytest.mark.asyncio
+async def test_parity_delta_detects_divergence(migrated_engine):
+    """Direct DELETE on the base table that bypasses triggers leaves FTS
+    with a phantom row: delta == -1 (FTS has more rows than base).
+    """
+    from api.services.mmingest._db import fts_parity_delta
+
+    async with migrated_engine.begin() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_files (remote_url, filename, file_type)
+                VALUES ('http://example.com/phantom_test.srt',
+                        'phantom_test.srt', 'srt')
+                """
+            )
+        )
+        file_id = (
+            await conn.execute(text("SELECT last_insert_rowid()"))
+        ).scalar_one()
+
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+                VALUES (:fid, 'srt', 'Phantom row body text.')
+                """
+            ),
+            {"fid": file_id},
+        )
+        sidecar_id = (
+            await conn.execute(text("SELECT last_insert_rowid()"))
+        ).scalar_one()
+
+    async with migrated_engine.connect() as conn:
+        assert await fts_parity_delta(conn) == 0
+
+    # Bypass triggers: delete from the _docsize shadow table directly to
+    # simulate the base table being pruned without an FTS delete command.
+    # (Mutating the shadow table is the cleanest way to create the
+    # phantom-row scenario without disabling triggers.)
+    async with migrated_engine.begin() as conn:
+        await conn.execute(
+            text("DELETE FROM mmingest_sidecars WHERE id = :sid"),
+            {"sid": sidecar_id},
+        )
+        # Re-insert the _docsize row to simulate a phantom FTS entry that
+        # the trigger somehow missed (trigger disabled / direct DB edit).
+        await conn.execute(
+            text(
+                "INSERT INTO mmingest_sidecars_fts_docsize(id, sz) VALUES (:sid, 4)"
+            ),
+            {"sid": sidecar_id},
+        )
+
+    async with migrated_engine.connect() as conn:
+        delta = await fts_parity_delta(conn)
+    # base=0, fts=1 → delta = 0 - 1 = -1
+    assert delta == -1, f"Expected -1 (phantom FTS row), got {delta}"
+
+
+@pytest.mark.asyncio
+async def test_parity_delta_returns_none_before_migration_016():
+    """fts_parity_delta returns None when called against a DB at 013.
+
+    Simulates the deploy-window scenario: app restarted before migration
+    016 has been applied.
+    """
+    from api.services.mmingest._db import fts_parity_delta
+
+    fd, db_path = tempfile.mkstemp(suffix="_pre016_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+    env = {**os.environ, "DATABASE_PATH": db_path}
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "013"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"alembic upgrade 013 failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    try:
+        async with engine.connect() as conn:
+            result = await fts_parity_delta(conn)
+        assert result is None, (
+            f"Expected None for pre-016 DB, got {result!r}"
+        )
+    finally:
+        await engine.dispose()
+        try:
+            os.unlink(db_path)
+        except Exception:
+            pass

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -211,3 +211,24 @@ async def test_fts_match_join_returns_display_fields(migrated_engine):
     # rank is a negative float (BM25); just assert it's present and numeric
     assert row._mapping["rank"] is not None
     assert float(row._mapping["rank"]) < 0
+
+    # Discriminating assertion: read body_text DIRECTLY off the FTS virtual
+    # table (no JOIN).  Under the old DDL — which declared phantom UNINDEXED
+    # columns media_id/prefix/show that don't exist on the content table —
+    # this query raises:
+    #   OperationalError: no such column: T.media_id
+    # even when only body_text is selected, because FTS5 resolves ALL declared
+    # columns from the content table when it opens the cursor.
+    # Under the fixed DDL (body_text only) it succeeds.
+    async with migrated_engine.connect() as conn:
+        direct_rows = (
+            await conn.execute(
+                text(
+                    "SELECT body_text FROM mmingest_sidecars_fts"
+                    " WHERE mmingest_sidecars_fts MATCH 'fox'"
+                )
+            )
+        ).fetchall()
+
+    assert len(direct_rows) == 1
+    assert "fox" in direct_rows[0][0]

--- a/tests/api/test_mmingest_parity.py
+++ b/tests/api/test_mmingest_parity.py
@@ -1,0 +1,142 @@
+"""Tests for api.services.mmingest._db.fts_parity_delta.
+
+Uses an isolated SQLite DB with all migrations applied via alembic so the
+FTS5 virtual table and its sync triggers exist exactly as they would in
+production.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    """Stand up a fresh DB via `alembic upgrade head`, return an async engine.
+
+    Runs alembic as a subprocess so the FTS5 virtual table + triggers are
+    created exactly as in production (SQLAlchemy metadata.create_all does
+    not model virtual tables).
+    """
+    fd, db_path = tempfile.mkstemp(suffix="_parity_test.db")
+    os.close(fd)
+
+    repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
+    repo_root = os.path.abspath(repo_root)
+
+    env = {**os.environ, "DATABASE_PATH": db_path}
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_parity_delta_zero_on_empty_db(migrated_engine):
+    """An empty DB has 0 sidecars and 0 FTS rows — delta must be 0."""
+    from api.services.mmingest._db import fts_parity_delta
+
+    async with migrated_engine.connect() as conn:
+        delta = await fts_parity_delta(conn)
+    assert delta == 0
+
+
+@pytest.mark.asyncio
+async def test_parity_delta_zero_after_insert(migrated_engine):
+    """Inserting a sidecar via the normal path keeps delta at 0.
+
+    The AFTER INSERT trigger on mmingest_sidecars should populate the FTS
+    index immediately, so parity is maintained.
+    """
+    from api.services.mmingest._db import fts_parity_delta
+
+    async with migrated_engine.begin() as conn:
+        # Insert a parent mmingest_files row first (FK constraint)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_files
+                    (remote_url, filename, file_type)
+                VALUES
+                    ('http://example.com/test.srt', 'test.srt', 'srt')
+                """
+            )
+        )
+        file_id_row = await conn.execute(text("SELECT last_insert_rowid()"))
+        file_id = file_id_row.scalar_one()
+
+        # Insert a sidecar — trigger should update FTS
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+                VALUES (:file_id, 'srt', 'This is a test caption body.')
+                """
+            ),
+            {"file_id": file_id},
+        )
+
+    async with migrated_engine.connect() as conn:
+        delta = await fts_parity_delta(conn)
+    assert delta == 0
+
+
+@pytest.mark.asyncio
+async def test_mmingest_schema_tables_exist(migrated_engine):
+    """Smoke-test: all four migration targets are present after upgrade head."""
+    async with migrated_engine.connect() as conn:
+        tables_row = await conn.execute(
+            text("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        )
+        tables = {r[0] for r in tables_row.fetchall()}
+
+    assert "mmingest_files" in tables
+    assert "mmingest_sidecars" in tables
+    assert "consumer_keys" in tables
+    # available_files must still exist (back-compat)
+    assert "available_files" in tables
+
+
+@pytest.mark.asyncio
+async def test_available_files_new_columns_exist(migrated_engine):
+    """Migration 014 added four columns to available_files."""
+    async with migrated_engine.connect() as conn:
+        cols_row = await conn.execute(text("PRAGMA table_info(available_files)"))
+        col_names = {r[1] for r in cols_row.fetchall()}
+
+    assert "etag" in col_names
+    assert "content_type" in col_names
+    assert "last_head_at" in col_names
+    assert "probe_status" in col_names
+
+
+@pytest.mark.asyncio
+async def test_consumer_keys_columns(migrated_engine):
+    """Migration 017: consumer_keys has the expected columns."""
+    async with migrated_engine.connect() as conn:
+        cols_row = await conn.execute(text("PRAGMA table_info(consumer_keys)"))
+        col_names = {r[1] for r in cols_row.fetchall()}
+
+    for expected in ("id", "key_hash", "label", "scopes", "created_at", "last_used_at"):
+        assert expected in col_names, f"Missing column: {expected}"


### PR DESCRIPTION
## Summary

Sprint 1A of the mmingest Search Index + API plan (Phase 1). Foundation schema for the search MVP — nothing consumes these tables yet (crawler lands in S1B, indexer in S2).

- **014** — extends `available_files` with `etag`, `content_type`, `last_head_at`, `probe_status`
- **015** — new `mmingest_files` master table (all asset types), incl. variant-lineage columns `variant_tag` / `superseded_by` per the variant-selection rule
- **016** — `mmingest_sidecars` + FTS5 external-content virtual table (`body_text` only) with sync triggers
- **017** — `consumer_keys` with scoped-auth fields (`mmingest:read` / `mmingest:stream`)
- `api/services/mmingest/_db.py` — `fts_parity_delta()` ops helper (`int | None`; None = pre-016 schema)
- 11 tests: round-trips (incl. full downgrade-to-013), FTS MATCH + JOIN retrieval, parity divergence detection, pre-migration safety

## Review trail

Two-stage review (spec compliance + code quality), both passed:
- Spec review caught and fixed a plan-level FTS5 defect: external-content tables resolve declared columns from the content table at read time, so display columns (media_id/prefix/show) can't live on the FTS table — search consumers JOIN `fts → mmingest_sidecars → mmingest_files` instead. Regression-guarded by a discriminating direct-FTS read test.
- Quality review fixes: parity helper safe during deploy windows; 017 unique constraint made downgrade-symmetric; downgrade round-trip + divergence tests added.

## Notes

- Pre-existing (not introduced here): migration 011's `downgrade()` is broken below 013 — being filed as a separate issue.
- Sprint dependency: S2/S3B build against the JOIN shape documented in 016's docstring.

Agent: the-drone (impl) + reviewers, orchestrated per subagent-driven-development
Ref: planning doc `anyway-the-reason-i-noble-whistle.md` (mmingest Search Index + API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)