### PR TITLE
feat(mmingest): Sprint 3B — search + asset + captions + recent API endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -157,7 +157,7 @@ async def health():
 
 
 # Register routers
-from api.routers import config, export, ingest, jobs, langfuse, queue, system, upload, websocket
+from api.routers import config, export, ingest, jobs, langfuse, mmingest, queue, system, upload, websocket
 
 app.include_router(queue.router, prefix="/api/queue", tags=["queue"])
 app.include_router(jobs.router, prefix="/api/jobs", tags=["jobs"])
@@ -168,3 +168,4 @@ app.include_router(system.router, prefix="/api/system", tags=["system"])
 app.include_router(ingest.router, prefix="/api/ingest", tags=["ingest"])
 app.include_router(langfuse.router, prefix="/api/langfuse", tags=["langfuse"])
 app.include_router(export.router, prefix="/api", tags=["export"])
+app.include_router(mmingest.router, prefix="/api/mmingest", tags=["mmingest"])

--- a/api/models/mmingest.py
+++ b/api/models/mmingest.py
@@ -1,0 +1,116 @@
+"""Pydantic models for the mmingest search/asset/captions/recent API endpoints.
+
+All request and response shapes for the five endpoints in api/routers/mmingest.py
+live here to keep the router file readable.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Search endpoint
+# ---------------------------------------------------------------------------
+
+
+class SearchResult(BaseModel):
+    """One hit returned by GET /api/mmingest/search."""
+
+    media_id: Optional[str] = None
+    prefix: Optional[str] = None
+    season: Optional[str] = None
+    episode: Optional[str] = None
+    revision_date: Optional[str] = None
+    modified_at: Optional[datetime] = None  # alias for remote_modified_at
+    snippet: str
+    sidecar_kind: str  # 'srt' | 'scc'
+
+
+class SearchResponse(BaseModel):
+    """Response envelope for GET /api/mmingest/search."""
+
+    results: list[SearchResult]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Asset endpoint
+# ---------------------------------------------------------------------------
+
+
+class AssetEntry(BaseModel):
+    """One file row returned in an asset response."""
+
+    file_id: int
+    media_id: str
+    variant_tag: Optional[str] = None
+    revision_date: Optional[str] = None
+    url: str
+    file_type: str
+    remote_modified_at: Optional[datetime] = None
+    file_size_bytes: Optional[int] = None
+    # Populated on primary only via Airtable batch lookup.
+    # The indexer also pre-caches this value in mmingest_files.airtable_record_id;
+    # for /assets/{id} we do a live lookup to get the freshest value.
+    airtable_record_id: Optional[str] = None
+
+
+class AssetResponse(BaseModel):
+    """Response for GET /api/mmingest/assets/{media_id}.
+
+    Shape per the variant-selection rule:
+      primary    — the no-variant-tag, latest-REV row (superseded_by IS NULL)
+      variants   — rows with a non-NULL variant_tag and superseded_by IS NULL
+                   (PLEDGE, DS, etc. — coexisting cuts, not superseded)
+      superseded — older _REV rows (superseded_by IS NOT NULL) for all groups
+    """
+
+    primary: Optional[AssetEntry] = None
+    variants: list[AssetEntry] = Field(default_factory=list)
+    superseded: list[AssetEntry] = Field(default_factory=list)
+
+
+class UrlResponse(BaseModel):
+    """Response for GET /api/mmingest/assets/{media_id}/url."""
+
+    url: str
+
+
+# ---------------------------------------------------------------------------
+# Captions endpoint
+# ---------------------------------------------------------------------------
+
+
+class CaptionResponse(BaseModel):
+    """Response for GET /api/mmingest/assets/{media_id}/captions."""
+
+    media_id: str
+    kind: str  # 'srt' | 'scc'
+    body_text: str
+    bytes: Optional[int] = None
+    fetched_at: Optional[datetime] = None
+
+
+# ---------------------------------------------------------------------------
+# Recent endpoint
+# ---------------------------------------------------------------------------
+
+
+class RecentEntry(BaseModel):
+    """One row returned by GET /api/mmingest/recent."""
+
+    media_id: Optional[str] = None
+    prefix: Optional[str] = None
+    show_name: Optional[str] = None
+    file_type: str
+    url: str
+    first_seen_at: datetime
+    remote_modified_at: Optional[datetime] = None
+
+
+class RecentResponse(BaseModel):
+    """Response envelope for GET /api/mmingest/recent."""
+
+    results: list[RecentEntry]
+    total: int

--- a/api/routers/mmingest.py
+++ b/api/routers/mmingest.py
@@ -1,0 +1,479 @@
+"""FastAPI router for mmingest search/asset/captions/recent endpoints.
+
+Five endpoints under /api/mmingest (registered in api/main.py with
+prefix="/api/mmingest"):
+
+  GET /search                       — FTS5 BM25-ranked full-text search
+  GET /assets/{media_id}            — {primary, variants, superseded} shape
+  GET /assets/{media_id}/url        — resolved URL string (convenience)
+  GET /assets/{media_id}/captions   — cached sidecar body from DB (no round-trip)
+  GET /recent                       — chronological listing for arrival watchers
+
+Auth seam
+---------
+Sprint 3A's middleware enforces mmingest:read scope before these endpoints
+fire.  While S3A is in flight, _require_scope is a no-op marker so endpoint
+signatures stay compatible once S3A merges.
+
+Audit log
+---------
+Audit log writes are middleware territory (S3A).  This router does NOT write
+to mmingest_audit_log.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Annotated, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from api.models.mmingest import (
+    AssetEntry,
+    AssetResponse,
+    CaptionResponse,
+    RecentEntry,
+    RecentResponse,
+    SearchResponse,
+    SearchResult,
+    UrlResponse,
+)
+from api.services.airtable import AirtableClient, get_airtable_client
+from api.services.database import get_db_url
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Scope-enforcement stub (no-op until S3A merges)
+# ---------------------------------------------------------------------------
+
+
+def _require_scope(scope: str) -> Depends:
+    """Stub: real scope enforcement lands in Sprint 3A middleware.
+
+    Kept as a no-op dependency so endpoint signatures don't change when S3A
+    merges.  Once S3A's middleware is live, request.state.consumer_scopes is
+    set and the middleware has already rejected the call with 403 if the
+    required scope is missing.  This dep stays as a marker so endpoint
+    signatures document required scope.
+
+    TODO(S3A): _require_scope makes this real once the middleware lands.
+    """
+
+    async def _dep(request: Request) -> None:  # noqa: ARG001
+        return None
+
+    return Depends(_dep)
+
+
+# ---------------------------------------------------------------------------
+# DB engine helper
+# ---------------------------------------------------------------------------
+
+
+def _get_engine() -> AsyncEngine:
+    """Return (or create) the async engine for the mmingest tables.
+
+    Uses the same DATABASE_PATH as the rest of the app so all queries hit the
+    same SQLite file.  A module-level singleton is fine for the dev server;
+    production should switch to the shared engine from api.services.database
+    once that module exposes a getter.
+
+    TODO: wire to the shared engine factory from api.services.database after
+    that module grows an engine-getter (currently it only exposes get_session).
+    """
+    return create_async_engine(get_db_url(), echo=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. GET /search
+# ---------------------------------------------------------------------------
+
+
+@router.get("/search", response_model=SearchResponse)
+async def search(
+    q: Annotated[str, Query(description="FTS5 MATCH query string")],
+    prefix: Annotated[Optional[str], Query(description="Filter by 4-char prefix (exact, case-insensitive)")] = None,
+    since: Annotated[Optional[datetime], Query(description="Filter where remote_modified_at >= since")] = None,
+    limit: Annotated[int, Query(ge=1, le=100, description="Max results (1-100)")] = 25,
+    offset: Annotated[int, Query(ge=0, description="Pagination offset")] = 0,
+    _scope=_require_scope("mmingest:read"),
+) -> SearchResponse:
+    """Full-text search over indexed sidecar bodies (BM25 ranked).
+
+    Surfaces only current rows (superseded_by IS NULL) by default.
+    Airtable is NOT queried here — keep search fast.
+    """
+    engine = _get_engine()
+    try:
+        async with engine.connect() as conn:
+            # BM25-ranked search via FTS5 JOIN shape (per migration 016 design note).
+            # DO NOT select mmingest_sidecars_fts.media_id — that column does not
+            # exist on the FTS table.  Always JOIN to mmingest_files for display fields.
+            search_sql = text("""
+                SELECT
+                    mf.media_id,
+                    mf.prefix,
+                    mf.season,
+                    mf.episode,
+                    mf.revision_date,
+                    mf.remote_modified_at,
+                    snippet(mmingest_sidecars_fts, 0, '<b>', '</b>', '...', 32) AS snippet,
+                    s.kind AS sidecar_kind,
+                    fts.rank
+                FROM   mmingest_sidecars_fts AS fts
+                JOIN   mmingest_sidecars AS s ON s.id = fts.rowid
+                JOIN   mmingest_files AS mf ON mf.id = s.file_id
+                WHERE  mmingest_sidecars_fts MATCH :q
+                  AND  (:prefix IS NULL OR LOWER(mf.prefix) = LOWER(:prefix))
+                  AND  (:since IS NULL OR mf.remote_modified_at >= :since)
+                  AND  mf.superseded_by IS NULL
+                ORDER  BY fts.rank
+                LIMIT  :limit OFFSET :offset
+            """)
+
+            count_sql = text("""
+                SELECT COUNT(*)
+                FROM   mmingest_sidecars_fts AS fts
+                JOIN   mmingest_sidecars AS s ON s.id = fts.rowid
+                JOIN   mmingest_files AS mf ON mf.id = s.file_id
+                WHERE  mmingest_sidecars_fts MATCH :q
+                  AND  (:prefix IS NULL OR LOWER(mf.prefix) = LOWER(:prefix))
+                  AND  (:since IS NULL OR mf.remote_modified_at >= :since)
+                  AND  mf.superseded_by IS NULL
+            """)
+
+            params = {
+                "q": q,
+                "prefix": prefix,
+                "since": since.isoformat() if since else None,
+                "limit": limit,
+                "offset": offset,
+            }
+            count_params = {
+                "q": q,
+                "prefix": prefix,
+                "since": since.isoformat() if since else None,
+            }
+
+            rows = (await conn.execute(search_sql, params)).fetchall()
+            total = (await conn.execute(count_sql, count_params)).scalar() or 0
+    finally:
+        await engine.dispose()
+
+    results = [
+        SearchResult(
+            media_id=row._mapping["media_id"],
+            prefix=row._mapping["prefix"],
+            season=row._mapping["season"],
+            episode=row._mapping["episode"],
+            revision_date=row._mapping["revision_date"],
+            modified_at=row._mapping["remote_modified_at"],
+            snippet=row._mapping["snippet"] or "",
+            sidecar_kind=row._mapping["sidecar_kind"],
+        )
+        for row in rows
+    ]
+
+    return SearchResponse(results=results, total=total)
+
+
+# ---------------------------------------------------------------------------
+# Shared asset-resolution helper
+# ---------------------------------------------------------------------------
+
+
+def _row_to_asset_entry(row, airtable_record_id: Optional[str] = None) -> AssetEntry:
+    """Convert a DB row (mapping) to an AssetEntry model."""
+    return AssetEntry(
+        file_id=row._mapping["id"],
+        media_id=row._mapping["media_id"],
+        variant_tag=row._mapping["variant_tag"],
+        revision_date=row._mapping["revision_date"],
+        url=row._mapping["remote_url"],
+        file_type=row._mapping["file_type"],
+        remote_modified_at=row._mapping["remote_modified_at"],
+        file_size_bytes=row._mapping["file_size_bytes"],
+        airtable_record_id=airtable_record_id,
+    )
+
+
+async def _resolve_asset(
+    media_id: str,
+    conn,
+) -> tuple[list, list, list]:
+    """Fetch and partition all rows for media_id into (primary_rows, variant_rows, superseded_rows).
+
+    Returns three lists of row mappings:
+      primary_rows   — variant_tag IS NULL AND superseded_by IS NULL  (should be 0 or 1)
+      variant_rows   — variant_tag IS NOT NULL AND superseded_by IS NULL
+      superseded_rows — superseded_by IS NOT NULL (any variant_tag)
+    """
+    sql = text("""
+        SELECT id, media_id, variant_tag, revision_date, remote_url,
+               file_type, remote_modified_at, file_size_bytes,
+               superseded_by, airtable_record_id
+        FROM   mmingest_files
+        WHERE  media_id = :media_id
+    """)
+    rows = (await conn.execute(sql, {"media_id": media_id})).fetchall()
+    if not rows:
+        return [], [], []
+
+    primary_rows = []
+    variant_rows = []
+    superseded_rows = []
+
+    for row in rows:
+        m = row._mapping
+        if m["superseded_by"] is not None:
+            superseded_rows.append(row)
+        elif m["variant_tag"] is None:
+            primary_rows.append(row)
+        else:
+            variant_rows.append(row)
+
+    return primary_rows, variant_rows, superseded_rows
+
+
+# ---------------------------------------------------------------------------
+# 2. GET /assets/{media_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/assets/{media_id}", response_model=AssetResponse)
+async def get_asset(
+    media_id: str,
+    airtable_client: Annotated[AirtableClient, Depends(get_airtable_client)],
+    _scope=_require_scope("mmingest:read"),
+) -> AssetResponse:
+    """Return the full {primary, variants, superseded} shape for a media_id.
+
+    Airtable record_id is looked up live for the primary only (one call,
+    one media_id).  Variants and superseded rows do not get Airtable calls.
+
+    TODO: add response caching (TTL=300s) once usage patterns are known.
+    """
+    engine = _get_engine()
+    try:
+        async with engine.connect() as conn:
+            primary_rows, variant_rows, superseded_rows = await _resolve_asset(media_id, conn)
+    finally:
+        await engine.dispose()
+
+    # 404 if nothing at all matches this media_id
+    if not primary_rows and not variant_rows and not superseded_rows:
+        raise HTTPException(status_code=404, detail=f"No asset found for media_id={media_id!r}")
+
+    # Live Airtable lookup for primary (single-element list, single batch call)
+    at_record_id: Optional[str] = None
+    if primary_rows:
+        try:
+            at_results = await airtable_client.batch_search_sst_by_media_ids([media_id])
+            at_record = at_results.get(media_id)
+            if at_record:
+                at_record_id = at_record.get("id")
+        except Exception:
+            # Airtable unavailable — surface the pre-cached value from DB instead
+            at_record_id = primary_rows[0]._mapping.get("airtable_record_id")
+
+    primary: Optional[AssetEntry] = None
+    if primary_rows:
+        # Per variant-selection rule: exactly one primary (the winner).
+        # If somehow there are multiples (shouldn't happen with S2 algorithm),
+        # take the first row — the indexer guarantees uniqueness.
+        primary = _row_to_asset_entry(primary_rows[0], airtable_record_id=at_record_id)
+
+    variants = [_row_to_asset_entry(r) for r in variant_rows]
+    superseded = [_row_to_asset_entry(r) for r in superseded_rows]
+
+    return AssetResponse(primary=primary, variants=variants, superseded=superseded)
+
+
+# ---------------------------------------------------------------------------
+# 3. GET /assets/{media_id}/url
+# ---------------------------------------------------------------------------
+
+
+@router.get("/assets/{media_id}/url", response_model=UrlResponse)
+async def get_asset_url(
+    media_id: str,
+    variant: Annotated[
+        Optional[str], Query(description="Variant tag override (e.g. PLEDGE).  Omit for primary URL.")
+    ] = None,
+    _scope=_require_scope("mmingest:read"),
+) -> UrlResponse:
+    """Return just the resolved URL for a media_id.
+
+    Convenience for editors who need to paste a URL into PMM.
+    Default returns primary.url.  With ?variant=PLEDGE returns that variant's URL.
+    404 if the media_id has no primary (or no such variant).
+    """
+    engine = _get_engine()
+    try:
+        async with engine.connect() as conn:
+            primary_rows, variant_rows, _ = await _resolve_asset(media_id, conn)
+    finally:
+        await engine.dispose()
+
+    if not primary_rows and not variant_rows:
+        raise HTTPException(status_code=404, detail=f"No asset found for media_id={media_id!r}")
+
+    if variant is not None:
+        # Return the matching variant's URL
+        matched = [r for r in variant_rows if (r._mapping["variant_tag"] or "").upper() == variant.upper()]
+        if not matched:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No variant {variant!r} found for media_id={media_id!r}",
+            )
+        return UrlResponse(url=matched[0]._mapping["remote_url"])
+
+    # Default: primary URL
+    if not primary_rows:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No primary (non-variant) asset found for media_id={media_id!r}",
+        )
+    return UrlResponse(url=primary_rows[0]._mapping["remote_url"])
+
+
+# ---------------------------------------------------------------------------
+# 4. GET /assets/{media_id}/captions
+# ---------------------------------------------------------------------------
+
+
+@router.get("/assets/{media_id}/captions", response_model=CaptionResponse)
+async def get_captions(
+    media_id: str,
+    format: Annotated[Literal["srt", "scc"], Query(description="Caption format")] = "srt",
+    _scope=_require_scope("mmingest:read"),
+) -> CaptionResponse:
+    """Return cached sidecar body from DB.  NEVER round-trips to mmingest.
+
+    404 — no sidecar row of that kind exists for the primary asset.
+    503 — sidecar row exists but body_text is NULL or empty (indexer pending).
+    """
+    engine = _get_engine()
+    try:
+        async with engine.connect() as conn:
+            primary_rows, _, _ = await _resolve_asset(media_id, conn)
+
+            if not primary_rows:
+                raise HTTPException(status_code=404, detail=f"No asset found for media_id={media_id!r}")
+
+            file_id = primary_rows[0]._mapping["id"]
+
+            sidecar_sql = text("""
+                SELECT id, kind, body_text, bytes, fetched_at
+                FROM   mmingest_sidecars
+                WHERE  file_id = :file_id
+                  AND  kind = :kind
+                LIMIT 1
+            """)
+            sidecar_row = (await conn.execute(sidecar_sql, {"file_id": file_id, "kind": format})).fetchone()
+    finally:
+        await engine.dispose()
+
+    if sidecar_row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No {format!r} sidecar found for media_id={media_id!r}",
+        )
+
+    body_text = sidecar_row._mapping["body_text"]
+    if not body_text:
+        # Row exists but indexer hasn't filled body_text yet.
+        # Return 503 — do NOT proxy to mmingest.
+        raise HTTPException(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            detail=f"Sidecar body for media_id={media_id!r} format={format!r} is still being indexed.  Retry shortly.",
+        )
+
+    return CaptionResponse(
+        media_id=media_id,
+        kind=sidecar_row._mapping["kind"],
+        body_text=body_text,
+        bytes=sidecar_row._mapping["bytes"],
+        fetched_at=sidecar_row._mapping["fetched_at"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. GET /recent
+# ---------------------------------------------------------------------------
+
+
+@router.get("/recent", response_model=RecentResponse)
+async def get_recent(
+    since: Annotated[
+        Optional[datetime],
+        Query(description="Return rows where first_seen_at >= since.  Default: last 24h."),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Max results (1-200)")] = 50,
+    prefix: Annotated[Optional[str], Query(description="Filter by 4-char prefix (exact, case-insensitive)")] = None,
+    _scope=_require_scope("mmingest:read"),
+) -> RecentResponse:
+    """Chronological listing of recently-indexed files.
+
+    Surfaces only current rows (superseded_by IS NULL).
+    Ordered by first_seen_at DESC so the newest arrivals appear first.
+    """
+    if since is None:
+        since = datetime.now(timezone.utc) - timedelta(hours=24)
+
+    engine = _get_engine()
+    try:
+        async with engine.connect() as conn:
+            recent_sql = text("""
+                SELECT media_id, prefix, show_name, file_type, remote_url,
+                       first_seen_at, remote_modified_at
+                FROM   mmingest_files
+                WHERE  first_seen_at >= :since
+                  AND  (:prefix IS NULL OR LOWER(prefix) = LOWER(:prefix))
+                  AND  superseded_by IS NULL
+                ORDER  BY first_seen_at DESC
+                LIMIT  :limit
+            """)
+
+            count_sql = text("""
+                SELECT COUNT(*)
+                FROM   mmingest_files
+                WHERE  first_seen_at >= :since
+                  AND  (:prefix IS NULL OR LOWER(prefix) = LOWER(:prefix))
+                  AND  superseded_by IS NULL
+            """)
+
+            params = {
+                "since": since.isoformat(),
+                "prefix": prefix,
+                "limit": limit,
+            }
+            count_params = {
+                "since": since.isoformat(),
+                "prefix": prefix,
+            }
+
+            rows = (await conn.execute(recent_sql, params)).fetchall()
+            total = (await conn.execute(count_sql, count_params)).scalar() or 0
+    finally:
+        await engine.dispose()
+
+    results = [
+        RecentEntry(
+            media_id=row._mapping["media_id"],
+            prefix=row._mapping["prefix"],
+            show_name=row._mapping["show_name"],
+            file_type=row._mapping["file_type"],
+            url=row._mapping["remote_url"],
+            first_seen_at=row._mapping["first_seen_at"],
+            remote_modified_at=row._mapping["remote_modified_at"],
+        )
+        for row in rows
+    ]
+
+    return RecentResponse(results=results, total=total)

--- a/tests/api/test_mmingest_router.py
+++ b/tests/api/test_mmingest_router.py
@@ -1,0 +1,824 @@
+"""Tests for the mmingest API router (Sprint 3B).
+
+Verification gates covered here (per sprint-3b-handoff.md):
+  Gate 1  — /search happy path: FTS5 hit with snippet + BM25 ordering
+  Gate 2  — /search filters: ?prefix=, ?since=, ?limit= / ?offset= pagination
+  Gate 3  — /assets/{id} primary-only
+  Gate 4  — /assets/{id} with variant
+  Gate 5  — /assets/{id} with superseded REV
+  Gate 6  — /assets/{id} 404 for unknown media_id
+  Gate 7  — /assets/{id}/url happy path
+  Gate 8  — /assets/{id}/url?variant=PLEDGE
+  Gate 9  — /assets/{id}/url?variant=PLEDGE 404 (no such variant)
+  Gate 10 — /assets/{id}/captions happy path (no mmingest network call)
+  Gate 11 — /assets/{id}/captions 503 (body_text NULL/empty)
+  Gate 12 — /recent ordering + filtering
+
+Uses fastapi.testclient.TestClient against an isolated migrated SQLite DB.
+AirtableClient calls are mocked via app.dependency_overrides so FastAPI's DI
+system doesn't try to introspect the mock's *args/**kwargs signature.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# ---------------------------------------------------------------------------
+# Shared fixture: isolated migrated DB engine + DB-path override
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    """Stand up a fresh DB via `alembic upgrade head`, return (engine, db_path).
+
+    Mirrors the pattern in tests/api/test_mmingest_parity.py exactly.
+    """
+    fd, db_path = tempfile.mkstemp(suffix="_mmingest_router_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine, db_path
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TestClient / mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_airtable(media_id: str = "6POL0101", at_record_id: str = "recTEST000001") -> MagicMock:
+    """Return a mock AirtableClient whose batch_search_sst_by_media_ids returns a known record."""
+    mock = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock.batch_search_sst_by_media_ids = AsyncMock(
+        return_value={
+            media_id: {
+                "id": at_record_id,
+                "fields": {"Media ID": media_id, "Title": "Test Episode"},
+            }
+        }
+    )
+    return mock
+
+
+def _make_client(db_path: str, mock_airtable: MagicMock) -> TestClient:
+    """Return a FastAPI TestClient with DATABASE_PATH patched and Airtable mocked.
+
+    Uses app.dependency_overrides so FastAPI's DI system receives a callable
+    with a clean signature (not the *args/**kwargs of a raw MagicMock).
+    """
+    import importlib
+
+    # Reload the router and app so DATABASE_PATH env var is picked up fresh.
+    os.environ["DATABASE_PATH"] = db_path
+
+    import api.routers.mmingest
+
+    importlib.reload(api.routers.mmingest)
+
+    import api.main
+
+    importlib.reload(api.main)
+
+    from api.services.airtable import get_airtable_client
+
+    # dependency_overrides: override with a plain callable that returns the mock.
+    # This avoids FastAPI introspecting the mock's *args/**kwargs call signature.
+    api.main.app.dependency_overrides[get_airtable_client] = lambda: mock_airtable
+
+    client = TestClient(api.main.app, raise_server_exceptions=True)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# DB seed helpers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_file(
+    conn,
+    *,
+    remote_url: str,
+    filename: str,
+    file_type: str = "srt",
+    media_id: str = "6POL0101",
+    prefix: str = "6POL",
+    show_name: str = "Wisconsin Politics",
+    season: str = "01",
+    episode: str = "01",
+    revision_date: str = "2026-03-19",
+    variant_tag: str | None = None,
+    superseded_by: int | None = None,
+    remote_modified_at: str | None = None,
+    first_seen_at: str | None = None,
+    airtable_record_id: str | None = None,
+) -> int:
+    await conn.execute(
+        text("""
+            INSERT INTO mmingest_files
+                (remote_url, filename, file_type, media_id, prefix, show_name,
+                 season, episode, revision_date, variant_tag, superseded_by,
+                 remote_modified_at, first_seen_at, airtable_record_id)
+            VALUES
+                (:remote_url, :filename, :file_type, :media_id, :prefix, :show_name,
+                 :season, :episode, :revision_date, :variant_tag, :superseded_by,
+                 :remote_modified_at, :first_seen_at, :airtable_record_id)
+        """),
+        {
+            "remote_url": remote_url,
+            "filename": filename,
+            "file_type": file_type,
+            "media_id": media_id,
+            "prefix": prefix,
+            "show_name": show_name,
+            "season": season,
+            "episode": episode,
+            "revision_date": revision_date,
+            "variant_tag": variant_tag,
+            "superseded_by": superseded_by,
+            "remote_modified_at": remote_modified_at or "2026-03-19T10:00:00",
+            "first_seen_at": first_seen_at or "2026-03-19T10:00:00",
+            "airtable_record_id": airtable_record_id,
+        },
+    )
+    return (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
+
+
+async def _insert_sidecar(
+    conn,
+    *,
+    file_id: int,
+    kind: str = "srt",
+    body_text: str | None = None,
+) -> int:
+    await conn.execute(
+        text("""
+            INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+            VALUES (:file_id, :kind, :body_text)
+        """),
+        {"file_id": file_id, "kind": kind, "body_text": body_text},
+    )
+    return (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — /search happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_happy_path(migrated_engine):
+    """Gate 1: FTS5 hit returns snippet + correct display fields."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101_REV20260319.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+            revision_date="2026-03-19",
+        )
+        await _insert_sidecar(
+            conn,
+            file_id=fid,
+            body_text="inside wisconsin politics: a look at the state legislature",
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/search?q=politics")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total"] >= 1
+    hit = data["results"][0]
+    assert hit["media_id"] == "6POL0101"
+    assert hit["prefix"] == "6POL"
+    assert hit["revision_date"] == "2026-03-19"
+    assert "politics" in hit["snippet"].lower() or "wisconsin" in hit["snippet"].lower()
+    assert hit["sidecar_kind"] == "srt"
+
+
+@pytest.mark.asyncio
+async def test_search_bm25_ordering(migrated_engine):
+    """Gate 1 (BM25): Higher-relevance document ranks first."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        # Row A: mentions "politics" once
+        fid_a = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+        )
+        await _insert_sidecar(conn, file_id=fid_a, body_text="just one mention of politics here")
+
+        # Row B: mentions "politics" many times — should rank higher
+        fid_b = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102.srt",
+            filename="6POL0102.srt",
+            media_id="6POL0102",
+            prefix="6POL",
+        )
+        await _insert_sidecar(
+            conn,
+            file_id=fid_b,
+            body_text="politics politics politics politics is the topic of this episode about politics",
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/search?q=politics&limit=10")
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 2
+    # Row B has higher TF so it should rank first (BM25 ORDER BY rank — lower rank value = better)
+    assert results[0]["media_id"] == "6POL0102"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2 — /search filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_prefix_filter(migrated_engine):
+    """Gate 2: ?prefix=6POL filters correctly."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid_a = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+        )
+        await _insert_sidecar(conn, file_id=fid_a, body_text="wisconsin politics")
+
+        fid_b = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/WLIA0101.srt",
+            filename="WLIA0101.srt",
+            media_id="WLIA0101",
+            prefix="WLIA",
+        )
+        await _insert_sidecar(conn, file_id=fid_b, body_text="wisconsin nature politics")
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/search?q=politics&prefix=6POL")
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert all(r["prefix"] == "6POL" for r in results)
+    assert any(r["media_id"] == "6POL0101" for r in results)
+    assert not any(r["media_id"] == "WLIA0101" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_since_filter(migrated_engine):
+    """Gate 2: ?since= filters by remote_modified_at."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid_old = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_old.srt",
+            filename="6POL0101_old.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+            remote_modified_at="2025-01-01T00:00:00",
+        )
+        await _insert_sidecar(conn, file_id=fid_old, body_text="wisconsin politics old episode")
+
+        fid_new = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102_new.srt",
+            filename="6POL0102_new.srt",
+            media_id="6POL0102",
+            prefix="6POL",
+            remote_modified_at="2026-03-19T10:00:00",
+        )
+        await _insert_sidecar(conn, file_id=fid_new, body_text="wisconsin politics new episode")
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/search?q=politics&since=2026-03-01T00:00:00")
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert all(r["media_id"] != "6POL0101" for r in results), "Old row should be filtered out"
+    assert any(r["media_id"] == "6POL0102" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_search_pagination(migrated_engine):
+    """Gate 2: limit=1 returns 1 result; offset=1 returns the next."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        for i in range(3):
+            fid = await _insert_file(
+                conn,
+                remote_url=f"http://mmingest.example/6POL010{i}.srt",
+                filename=f"6POL010{i}.srt",
+                media_id=f"6POL010{i}",
+                prefix="6POL",
+            )
+            await _insert_sidecar(conn, file_id=fid, body_text=f"wisconsin politics episode {i}")
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+
+    resp0 = client.get("/api/mmingest/search?q=politics&limit=1&offset=0")
+    resp1 = client.get("/api/mmingest/search?q=politics&limit=1&offset=1")
+
+    assert resp0.status_code == 200
+    assert resp1.status_code == 200
+    r0 = resp0.json()
+    r1 = resp1.json()
+    assert len(r0["results"]) == 1
+    assert len(r1["results"]) == 1
+    assert r0["total"] == 3
+    # The two pages return different items
+    assert r0["results"][0]["media_id"] != r1["results"][0]["media_id"]
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — /assets/{id} primary-only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_primary_only(migrated_engine):
+    """Gate 3: Primary-only asset returns {primary, variants:[], superseded:[]}."""
+    engine, db_path = migrated_engine
+    at_record_id = "recTEST123"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            variant_tag=None,
+            superseded_by=None,
+        )
+
+    mock_at = _make_mock_airtable(media_id="6POL0101", at_record_id=at_record_id)
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["primary"] is not None
+    assert data["primary"]["media_id"] == "6POL0101"
+    assert data["primary"]["airtable_record_id"] == at_record_id
+    assert data["variants"] == []
+    assert data["superseded"] == []
+    # Verify Airtable was called with the right media_id
+    mock_at.batch_search_sst_by_media_ids.assert_called_once_with(["6POL0101"])
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — /assets/{id} with variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_with_variant(migrated_engine):
+    """Gate 4: Primary + PLEDGE variant returns both in correct slots."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_PLEDGE.mp4",
+            filename="6POL0101_PLEDGE.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag="PLEDGE",
+            superseded_by=None,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["primary"] is not None
+    assert data["primary"]["variant_tag"] is None
+    assert len(data["variants"]) == 1
+    assert data["variants"][0]["variant_tag"] == "PLEDGE"
+    assert data["superseded"] == []
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — /assets/{id} with superseded REV
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_with_superseded_rev(migrated_engine):
+    """Gate 5: Older REV row is in superseded[], newer is primary."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        # Newer REV (current primary — no superseded_by)
+        new_id = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_REV20260319.mp4",
+            filename="6POL0101_REV20260319.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            revision_date="2026-03-19",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        # Older REV (points at new_id as superseded_by)
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_REV20260101.mp4",
+            filename="6POL0101_REV20260101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            revision_date="2026-01-01",
+            variant_tag=None,
+            superseded_by=new_id,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["primary"] is not None
+    assert data["primary"]["revision_date"] == "2026-03-19"
+    assert data["variants"] == []
+    assert len(data["superseded"]) == 1
+    assert data["superseded"][0]["revision_date"] == "2026-01-01"
+
+
+# ---------------------------------------------------------------------------
+# Gate 6 — /assets/{id} 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_404(migrated_engine):
+    """Gate 6: Unknown media_id returns clean 404."""
+    _, db_path = migrated_engine
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/NONEXISTENT9999")
+
+    assert resp.status_code == 404
+    data = resp.json()
+    assert "detail" in data
+    assert "NONEXISTENT9999" in data["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Gate 7 — /assets/{id}/url happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_asset_url_happy_path(migrated_engine):
+    """Gate 7: Returns {url: ...} matching the primary's URL."""
+    engine, db_path = migrated_engine
+    expected_url = "http://mmingest.example/6POL0101.mp4"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url=expected_url,
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/url")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"url": expected_url}
+
+
+# ---------------------------------------------------------------------------
+# Gate 8 — /assets/{id}/url?variant=PLEDGE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_asset_url_variant(migrated_engine):
+    """Gate 8: ?variant=PLEDGE returns the variant's URL."""
+    engine, db_path = migrated_engine
+    pledge_url = "http://mmingest.example/6POL0101_PLEDGE.mp4"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        await _insert_file(
+            conn,
+            remote_url=pledge_url,
+            filename="6POL0101_PLEDGE.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag="PLEDGE",
+            superseded_by=None,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/url?variant=PLEDGE")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"url": pledge_url}
+
+
+# ---------------------------------------------------------------------------
+# Gate 9 — /assets/{id}/url?variant=PLEDGE 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_asset_url_variant_404(migrated_engine):
+    """Gate 9: No PLEDGE variant for this media_id returns 404."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        # No PLEDGE variant seeded
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/url?variant=PLEDGE")
+
+    assert resp.status_code == 404
+    assert "PLEDGE" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Gate 10 — /assets/{id}/captions happy path (no mmingest network call)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_captions_happy_path(migrated_engine):
+    """Gate 10: Returns cached SRT body; no mmingest network call."""
+    engine, db_path = migrated_engine
+    srt_body = "1\n00:00:01,000 --> 00:00:04,000\nWisconsin politics.\n"
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        await _insert_sidecar(conn, file_id=fid, kind="srt", body_text=srt_body)
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/captions?format=srt")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["media_id"] == "6POL0101"
+    assert data["kind"] == "srt"
+    assert data["body_text"] == srt_body
+
+
+# ---------------------------------------------------------------------------
+# Gate 11 — /assets/{id}/captions 503 (no sidecar / empty body_text)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_captions_missing_sidecar_404(migrated_engine):
+    """Gate 11a: No sidecar row of that format returns 404."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        # Only SRT sidecar; requesting SCC should 404
+        await _insert_sidecar(conn, file_id=fid, kind="srt", body_text="some caption text")
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/captions?format=scc")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_captions_empty_body_503(migrated_engine):
+    """Gate 11b: Sidecar row exists but body_text is NULL/empty returns 503."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        # body_text is NULL — indexer hasn't run yet
+        await _insert_sidecar(conn, file_id=fid, kind="srt", body_text=None)
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101/captions?format=srt")
+
+    assert resp.status_code == 503
+    assert "Retry-After" in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# Gate 12 — /recent ordering + filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_ordering_and_filtering(migrated_engine):
+    """Gate 12: Results are in reverse-chronological order; since and prefix filters work."""
+    engine, db_path = migrated_engine
+
+    t_old = "2026-01-01T00:00:00"
+    t_mid = "2026-03-01T00:00:00"
+    t_new = "2026-06-01T00:00:00"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            first_seen_at=t_old,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102.mp4",
+            filename="6POL0102.mp4",
+            file_type="mp4",
+            media_id="6POL0102",
+            prefix="6POL",
+            first_seen_at=t_mid,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/WLIA0101.mp4",
+            filename="WLIA0101.mp4",
+            file_type="mp4",
+            media_id="WLIA0101",
+            prefix="WLIA",
+            first_seen_at=t_new,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+
+    # All three — ordered newest first
+    resp_all = client.get("/api/mmingest/recent?since=2025-01-01T00:00:00")
+    assert resp_all.status_code == 200
+    all_results = resp_all.json()["results"]
+    assert len(all_results) == 3
+    # Verify reverse-chronological ordering
+    assert all_results[0]["media_id"] == "WLIA0101"
+    assert all_results[1]["media_id"] == "6POL0102"
+    assert all_results[2]["media_id"] == "6POL0101"
+
+    # since filter: only after t_mid
+    resp_since = client.get("/api/mmingest/recent?since=2026-02-01T00:00:00")
+    since_results = resp_since.json()["results"]
+    assert not any(r["media_id"] == "6POL0101" for r in since_results)
+    assert any(r["media_id"] == "6POL0102" for r in since_results)
+    assert any(r["media_id"] == "WLIA0101" for r in since_results)
+
+    # prefix filter
+    resp_prefix = client.get("/api/mmingest/recent?since=2025-01-01T00:00:00&prefix=6POL")
+    prefix_results = resp_prefix.json()["results"]
+    assert all(r["prefix"] == "6POL" for r in prefix_results)
+    assert not any(r["media_id"] == "WLIA0101" for r in prefix_results)
+
+
+@pytest.mark.asyncio
+async def test_recent_default_24h_window(migrated_engine):
+    """Gate 12: Without ?since=, defaults to last 24h."""
+    engine, db_path = migrated_engine
+
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).strftime("%Y-%m-%dT%H:%M:%S")
+    new_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_old.mp4",
+            filename="6POL0101_old.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            first_seen_at=old_ts,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102_new.mp4",
+            filename="6POL0102_new.mp4",
+            file_type="mp4",
+            media_id="6POL0102",
+            prefix="6POL",
+            first_seen_at=new_ts,
+        )
+
+    mock_at = _make_mock_airtable()
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/recent")
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    # Old (48h ago) should NOT appear; new (1h ago) should appear
+    assert not any(r["media_id"] == "6POL0101" for r in results)
+    assert any(r["media_id"] == "6POL0102" for r in results)


### PR DESCRIPTION
## Summary

Implements the five search/asset API endpoints that surface Sprint 2 indexer data to consumers. This is Sprint 3B of [the plan](file:///Users/mriechers/.claude/plans/anyway-the-reason-i-noble-whistle.md).

- **`GET /api/mmingest/search`** — FTS5 BM25-ranked full-text search over sidecar bodies. JOIN shape per migration 016 design note (no phantom UNINDEXED columns). Supports `?q=`, `?prefix=`, `?since=`, `?limit=`, `?offset=`. Surfaces only current rows (`superseded_by IS NULL`) by default.
- **`GET /api/mmingest/assets/{media_id}`** — Full `{primary, variants, superseded}` response shape per the variant-selection rule. Live Airtable `record_id` lookup on the primary only (single batched call).
- **`GET /api/mmingest/assets/{media_id}/url`** — Convenience URL resolver for editors pasting into PMM. `?variant=` override for named cuts.
- **`GET /api/mmingest/assets/{media_id}/captions`** — Cached sidecar body from DB; never round-trips to mmingest. 503 with `Retry-After: 60` if body not yet indexed.
- **`GET /api/mmingest/recent`** — Reverse-chronological arrival watcher. Defaults to last 24h; `?since=`, `?prefix=` filters.

## New files

| File | Purpose |
|------|---------|
| `api/models/mmingest.py` | Pydantic request/response models (`SearchResult`, `AssetEntry`, `AssetResponse`, `CaptionResponse`, `RecentEntry`, etc.) |
| `api/routers/mmingest.py` | Router + `_require_scope()` no-op stub |
| `tests/api/test_mmingest_router.py` | 17 tests covering all 12 verification gates |

Modified: `api/main.py` — adds `mmingest.router` to the registration block.

## Verification gates

- [x] Gate 1: `/search` happy path — FTS5 hit with snippet + BM25 ordering
- [x] Gate 2: `/search` filters — `?prefix=`, `?since=`, `?limit=`/`?offset=` pagination
- [x] Gate 3: `/assets/{id}` primary-only — `{primary, variants:[], superseded:[]}`
- [x] Gate 4: `/assets/{id}` with variant — primary + PLEDGE in correct slots
- [x] Gate 5: `/assets/{id}` with superseded REV — older REV in `superseded[]`
- [x] Gate 6: `/assets/{id}` 404 — unknown media_id returns clean 404 with detail string
- [x] Gate 7: `/assets/{id}/url` happy path — `{url: ...}` matching primary URL
- [x] Gate 8: `/assets/{id}/url?variant=PLEDGE` — returns variant URL
- [x] Gate 9: `/assets/{id}/url?variant=PLEDGE` 404 — no such variant for this media_id
- [x] Gate 10: `/assets/{id}/captions` happy path — cached SRT body; no mmingest call
- [x] Gate 11: `/assets/{id}/captions` — 503 when body_text NULL (indexer pending)
- [x] Gate 12: `/recent` — reverse-chronological order; `?since=`/`?prefix=` filters; default 24h window
- [x] Gate 13: S-1 batched upsert regression — `TestBatchedUpsert` 3/3 pass
- [x] Gate 14: S1A parity tests — `test_mmingest_parity.py` 11/11 pass
- [x] Gate 15: S1B service tests — `tests/services/mmingest/` all pass
- [x] Gate 16: S2 integration tests — `test_mmingest_index.py` 8/8 pass
- [x] Gate 17: `black --check .` + `ruff check .` both clean
- [x] Gate 18: Live smoke test (see below)

**Total: 130/130 tests pass across all suites.**

## Live smoke test results

Against a fresh migrated DB seeded with `6POL0101` (primary + PLEDGE variant + superseded older REV) and a sidecar SRT body:

```
GET /search?q=politics         [200]  14ms  payload=373B
  total=1  results=1
  hit: media_id=6POL0101  kind=srt  snippet='1\n00:00:01,000 --> 00:00:04,...'

GET /assets/6POL0101           [200]   3ms  payload=846B
  primary.media_id=6POL0101
  primary.airtable_record_id=recABC123
  variants=['PLEDGE']
  superseded_count=1

GET /assets/6POL0101/url                   [200]   2ms
  url=http://mmingest.pbswi.wisc.edu/6POL/6POL0101_REV20260319.mp4

GET /assets/6POL0101/url?variant=PLEDGE    [200]   2ms
  url=http://mmingest.pbswi.wisc.edu/6POL/6POL0101_REV20260319_PLEDGE.mp4

GET /assets/6POL0101/captions?format=srt   [200]   3ms  payload=266B
  kind=srt  bytes=200  body_text='1\n00:00:01,000 --> ...'

GET /assets/6POL0101/captions?format=scc   [404]   2ms  (expected — no SCC sidecar seeded)

GET /recent?since=2026-01-01T00:00:00      [200]   3ms  payload=751B
  total=3  results=3  (primary + PLEDGE variant + 2WLI0101 show, all current rows)
  ordered newest-first by first_seen_at

GET /assets/NONEXISTENT                    [404]   3ms
  detail="No asset found for media_id='NONEXISTENT'"
```

Response times are all 2–14ms against an in-process test DB. No notable surprises — the FTS5 JOIN shape performed correctly on first attempt (the handoff note about phantom UNINDEXED columns was well-documented and avoided). Airtable join on `/assets/{id}` is a single batched call and returns in <1ms against the mock; in production it will be a single Airtable API call per `/assets/{id}` request.

## Scope-enforcement seam

`_require_scope("mmingest:read")` in `api/routers/mmingest.py` is a no-op `Depends` stub:

```python
def _require_scope(scope: str) -> Depends:
    """Stub: real scope enforcement lands in Sprint 3A middleware."""
    async def _dep(request: Request) -> None:
        return None
    return Depends(_dep)
```

Each endpoint declares `_scope=_require_scope("mmingest:read")` in its signature. When S3A's middleware lands, it enforces scope before the endpoint fires — no endpoint changes needed. The stub stays as a marker documenting required scope.

## Superseded filtering default

`/search` and `/recent` filter `WHERE superseded_by IS NULL` by default, surfacing only current rows. `/assets/{media_id}` exposes the full `superseded[]` list for audit/debugging. No `?include_superseded=true` param added — deferred as out of scope unless a consumer requests it.

## Out-of-scope issues (tracked separately)

- #182 — parser sync between cardigan-v4 and pbswi Sprint 0 (unrelated to API)
- #183 — TokenBucket burst tuning (unrelated to API)
- #184 — unknown-variant-tag log level (unrelated to API)

---

Ready for review. Do NOT merge — Mark gates before merge.

[Agent: the-drone]

🤖 Generated with [Claude Code](https://claude.com/claude-code)