### PR TITLE
feat(ops): Sprint 5 — staging soak harness + acceptance envelope

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -30,7 +30,7 @@ import json
 import logging
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -107,6 +107,16 @@ WRITABLE_FIELDS: dict[str, tuple[str, str, int | None]] = {
     "facebook_description": ("Facebook Description", "fldnprt2bJEsndv96", None),
     "hashtags": ("Hashtags", "fldYSGo5EBidQYL7W", None),
 }
+
+# ---------------------------------------------------------------------------
+# mmingest: in-process DB + Airtable imports (Sprint 4A)
+# ---------------------------------------------------------------------------
+from sqlalchemy import exc as _sa_exc  # noqa: E402
+from sqlalchemy import text as sa_text  # noqa: E402
+from sqlalchemy.ext.asyncio import create_async_engine as _create_async_engine  # noqa: E402
+
+from api.services.airtable import AirtableClient as _AirtableClient  # noqa: E402
+from api.services.database import get_db_url as _get_mmingest_db_url  # noqa: E402
 
 # Initialize MCP server
 server = Server("cardigan")
@@ -698,6 +708,92 @@ async def list_tools() -> list[Tool]:
                 "required": ["media_id"],
             },
         ),
+        # -----------------------------------------------------------------------
+        # mmingest tools (Sprint 4A) — in-process, no HTTP round-trip
+        # -----------------------------------------------------------------------
+        Tool(
+            name="search_mmingest",
+            description=(
+                "Full-text search PBS Wisconsin's mmingest caption corpus via FTS5. "
+                "Returns BM25-ranked results with snippets. Mirrors HTTP "
+                "GET /api/mmingest/search but runs in-process (no HTTP, no auth round-trip). "
+                "Use for finding episodes by transcript content (e.g. 'inside wisconsin politics' "
+                "or 'climate change')."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "FTS5 MATCH query string. Phrases in double quotes match adjacently; bare terms are AND-ed.",
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "Optional 4-char show prefix filter (e.g. '6POL' or '2WLI'). Exact case-insensitive match.",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "Optional ISO 8601 datetime; only return results modified at-or-after this timestamp.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return. Default 25, max 100.",
+                        "default": 25,
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+                "required": ["query"],
+            },
+        ),
+        Tool(
+            name="get_mmingest_asset",
+            description=(
+                "Get the canonical asset record for a PBS Wisconsin Media ID, including "
+                "primary URL, variants (PLEDGE/DS cuts), superseded REVs, and the linked "
+                "Airtable record ID. Mirrors HTTP GET /api/mmingest/assets/{media_id} "
+                "but runs in-process."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "media_id": {
+                        "type": "string",
+                        "description": "8-character Media ID (e.g. '6POL0101'). Case-insensitive.",
+                    }
+                },
+                "required": ["media_id"],
+            },
+        ),
+        Tool(
+            name="list_recent_mmingest_assets",
+            description=(
+                "List recently-arrived PBS Wisconsin assets on mmingest, ordered by "
+                "first-seen timestamp. Mirrors HTTP GET /api/mmingest/recent but runs "
+                "in-process. Use to poll for new arrivals (e.g. caption files just "
+                "delivered for an episode in production)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "since": {
+                        "type": "string",
+                        "description": ("Optional ISO 8601 datetime cutoff. If absent, defaults to 24 hours ago."),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results to return. Default 50, max 200.",
+                        "default": 50,
+                        "minimum": 1,
+                        "maximum": 200,
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "Optional 4-char show prefix filter.",
+                    },
+                },
+            },
+        ),
     ]
 
 
@@ -933,6 +1029,12 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return await handle_review_proposed_edits(arguments)
     elif name == "commit_sst_edits":
         return await handle_commit_sst_edits(arguments)
+    elif name == "search_mmingest":
+        return await handle_search_mmingest(arguments)
+    elif name == "get_mmingest_asset":
+        return await handle_get_mmingest_asset(arguments)
+    elif name == "list_recent_mmingest_assets":
+        return await handle_list_recent_mmingest_assets(arguments)
     else:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
@@ -2114,6 +2216,349 @@ async def handle_commit_sst_edits(arguments: dict) -> list[TextContent]:
         lines.append(f"\n⚠️ Fields updated but audit comment failed to post on `{record_id}`. Check Airtable manually.")
         logger.warning(f"Failed to post audit comment on {record_id} for {media_id}")
     lines.append(f"✅ {len(proposed)} field{'s' if len(proposed) != 1 else ''} written successfully")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+# =============================================================================
+# mmingest MCP Tool Handlers (Sprint 4A)
+#
+# These three handlers run in-process against the same SQLite DB that the
+# FastAPI app and routers use.  No HTTP round-trip to localhost:8100.
+#
+# SQL queries are duplicates of api/routers/mmingest.py with sync comments.
+# Chosen approach: Option B (duplicate with comments) to avoid touching the
+# frozen S3B router surface.  See PR description for the rationale.
+# =============================================================================
+
+
+def _mmingest_engine():
+    """Return a fresh async engine for the mmingest tables.
+
+    MIRROR OF api/routers/mmingest.py::_get_engine — same DATABASE_PATH logic.
+    Each MCP call creates a short-lived engine and disposes it on exit.
+    """
+    return _create_async_engine(_get_mmingest_db_url(), echo=False)
+
+
+async def handle_search_mmingest(arguments: dict) -> list[TextContent]:
+    """FTS5 full-text search over the mmingest sidecar corpus.
+
+    In-process mirror of GET /api/mmingest/search.
+    SQL: MIRROR OF api/routers/mmingest.py::search — keep in sync.
+    """
+    query = (arguments.get("query") or "").strip()
+    if not query:
+        return [TextContent(type="text", text="Error: query is required and must not be empty.")]
+
+    prefix = arguments.get("prefix") or None
+    since_raw = arguments.get("since") or None
+    limit = min(max(int(arguments.get("limit") or 25), 1), 100)
+
+    # Parse optional since datetime
+    since_iso: Optional[str] = None
+    if since_raw:
+        try:
+            since_dt = datetime.fromisoformat(since_raw.replace("Z", "+00:00"))
+            since_iso = since_dt.isoformat()
+        except ValueError:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: invalid ISO 8601 datetime for 'since': {since_raw!r}",
+                )
+            ]
+
+    # MIRROR OF api/routers/mmingest.py::search SQL
+    search_sql = sa_text("""
+        SELECT
+            mf.media_id,
+            mf.prefix,
+            mf.season,
+            mf.episode,
+            mf.revision_date,
+            mf.remote_modified_at,
+            snippet(mmingest_sidecars_fts, 0, '<b>', '</b>', '...', 32) AS snippet,
+            s.kind AS sidecar_kind,
+            fts.rank
+        FROM   mmingest_sidecars_fts AS fts
+        JOIN   mmingest_sidecars AS s ON s.id = fts.rowid
+        JOIN   mmingest_files AS mf ON mf.id = s.file_id
+        WHERE  mmingest_sidecars_fts MATCH :q
+          AND  (:prefix IS NULL OR LOWER(mf.prefix) = LOWER(:prefix))
+          AND  (:since IS NULL OR mf.remote_modified_at >= :since)
+          AND  mf.superseded_by IS NULL
+        ORDER  BY fts.rank
+        LIMIT  :limit OFFSET 0
+    """)
+
+    count_sql = sa_text("""
+        SELECT COUNT(*)
+        FROM   mmingest_sidecars_fts AS fts
+        JOIN   mmingest_sidecars AS s ON s.id = fts.rowid
+        JOIN   mmingest_files AS mf ON mf.id = s.file_id
+        WHERE  mmingest_sidecars_fts MATCH :q
+          AND  (:prefix IS NULL OR LOWER(mf.prefix) = LOWER(:prefix))
+          AND  (:since IS NULL OR mf.remote_modified_at >= :since)
+          AND  mf.superseded_by IS NULL
+    """)
+
+    params = {"q": query, "prefix": prefix, "since": since_iso, "limit": limit}
+    count_params = {"q": query, "prefix": prefix, "since": since_iso}
+
+    engine = _mmingest_engine()
+    try:
+        async with engine.connect() as conn:
+            try:
+                rows = (await conn.execute(search_sql, params)).fetchall()
+                total = (await conn.execute(count_sql, count_params)).scalar() or 0
+            except _sa_exc.OperationalError:
+                # Catch malformed FTS5 query syntax (e.g. unbalanced quotes,
+                # "unterminated string", "fts5: syntax error", etc.).
+                # Per issue #191: HTTP side returns 500; MCP returns friendly error.
+                return [
+                    TextContent(
+                        type="text",
+                        text=("Error: invalid FTS5 query syntax. " "Use double quotes around multi-word phrases."),
+                    )
+                ]
+    finally:
+        await engine.dispose()
+
+    if not rows:
+        filters = []
+        if prefix:
+            filters.append(f"prefix={prefix!r}")
+        if since_raw:
+            filters.append(f"since={since_raw!r}")
+        filter_str = f" (filters: {', '.join(filters)})" if filters else ""
+        return [
+            TextContent(
+                type="text",
+                text=f"No results found for query {query!r}{filter_str}.",
+            )
+        ]
+
+    # Format results as markdown
+    lines = [f"# mmingest Search: {query!r}\n"]
+    lines.append(f"**{total} total match{'es' if total != 1 else ''}** (showing {len(rows)})\n")
+
+    for row in rows:
+        m = row._mapping
+        media_id = m["media_id"] or "(unknown)"
+        prefix_val = m["prefix"] or ""
+        rev_date = m["revision_date"] or ""
+        modified = m["remote_modified_at"] or ""
+        snippet_raw = m["snippet"] or ""
+        kind = m["sidecar_kind"] or ""
+
+        header = f"## {media_id}"
+        if prefix_val:
+            header += f"  |  show: {prefix_val}"
+        if rev_date:
+            header += f"  |  rev: {rev_date}"
+        lines.append(header)
+
+        lines.append(f"**Type:** {kind}  |  **Modified:** {modified}")
+        lines.append(f"**Snippet:** {snippet_raw}")
+        lines.append("")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_get_mmingest_asset(arguments: dict) -> list[TextContent]:
+    """Return the {primary, variants, superseded} shape for a PBS Wisconsin Media ID.
+
+    In-process mirror of GET /api/mmingest/assets/{media_id}.
+    SQL: MIRROR OF api/routers/mmingest.py::_resolve_asset — keep in sync.
+    Airtable lookup mirrors api/routers/mmingest.py::get_asset — same fallback.
+    """
+    media_id = (arguments.get("media_id") or "").strip()
+    if not media_id:
+        return [TextContent(type="text", text="Error: media_id is required.")]
+
+    # MIRROR OF api/routers/mmingest.py::_resolve_asset SQL
+    asset_sql = sa_text("""
+        SELECT id, media_id, variant_tag, revision_date, remote_url,
+               file_type, remote_modified_at, file_size_bytes,
+               superseded_by, airtable_record_id
+        FROM   mmingest_files
+        WHERE  media_id = :media_id
+    """)
+
+    engine = _mmingest_engine()
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(asset_sql, {"media_id": media_id})).fetchall()
+    finally:
+        await engine.dispose()
+
+    if not rows:
+        return [
+            TextContent(
+                type="text",
+                text=f"No asset found for media_id={media_id!r}.",
+            )
+        ]
+
+    # Partition rows into primary / variants / superseded
+    primary_rows = []
+    variant_rows = []
+    superseded_rows = []
+    for row in rows:
+        m = row._mapping
+        if m["superseded_by"] is not None:
+            superseded_rows.append(m)
+        elif m["variant_tag"] is None:
+            primary_rows.append(m)
+        else:
+            variant_rows.append(m)
+
+    # Live Airtable lookup for primary (single batch call, same as S3B router)
+    at_record_id: Optional[str] = None
+    at_lookup_failed = False
+    if primary_rows:
+        airtable_api_key = os.environ.get("AIRTABLE_API_KEY")
+        if airtable_api_key:
+            try:
+                at_client = _AirtableClient(api_key=airtable_api_key)
+                at_results = await at_client.batch_search_sst_by_media_ids([media_id])
+                at_record = at_results.get(media_id)
+                if at_record:
+                    at_record_id = at_record.get("id")
+            except Exception as exc:
+                logger.warning(f"Airtable lookup failed for mmingest asset {media_id}: {exc}")
+                # Fallback: use the pre-cached value from the DB row (same as S3B)
+                at_record_id = primary_rows[0].get("airtable_record_id")
+                at_lookup_failed = True
+        else:
+            # No API key — use cached DB value
+            at_record_id = primary_rows[0].get("airtable_record_id") if primary_rows else None
+
+    # Format as markdown
+    lines = [f"# Asset: {media_id}\n"]
+
+    if primary_rows:
+        p = primary_rows[0]
+        lines.append("## Primary")
+        lines.append(f"**URL:** {p['remote_url']}")
+        lines.append(f"**Type:** {p['file_type']}  |  **REV date:** {p['revision_date'] or 'n/a'}")
+        lines.append(f"**Modified:** {p['remote_modified_at'] or 'n/a'}")
+        if at_record_id:
+            at_url = f"https://airtable.com/appZ2HGwhiifQToB6/tblTKFOwTvK7xw1H5/{at_record_id}"
+            lines.append(f"**Airtable:** [{at_record_id}]({at_url})")
+        elif at_lookup_failed:
+            lines.append("**Airtable:** (lookup failed — cached value used if available)")
+        else:
+            lines.append("**Airtable:** (not linked)")
+        lines.append("")
+    else:
+        lines.append("## Primary\n(no primary row — asset may be variants-only)\n")
+
+    lines.append("## Variants")
+    if variant_rows:
+        for v in variant_rows:
+            lines.append(f"- **{v['variant_tag']}** — {v['remote_url']}  |  {v['file_type']}")
+    else:
+        lines.append("(none)")
+    lines.append("")
+
+    lines.append("## Superseded REVs")
+    if superseded_rows:
+        for s in superseded_rows:
+            lines.append(f"- REV {s['revision_date'] or 'n/a'} — {s['remote_url']}  |  {s['file_type']}")
+    else:
+        lines.append("(none)")
+    lines.append("")
+
+    return [TextContent(type="text", text="\n".join(lines))]
+
+
+async def handle_list_recent_mmingest_assets(arguments: dict) -> list[TextContent]:
+    """List recently-arrived PBS Wisconsin assets on mmingest.
+
+    In-process mirror of GET /api/mmingest/recent.
+    SQL: MIRROR OF api/routers/mmingest.py::get_recent — keep in sync.
+    """
+    since_raw = arguments.get("since") or None
+    limit = min(max(int(arguments.get("limit") or 50), 1), 200)
+    prefix = arguments.get("prefix") or None
+
+    # Default: last 24 hours (same as S3B router)
+    if since_raw:
+        try:
+            since_dt = datetime.fromisoformat(since_raw.replace("Z", "+00:00"))
+            since_iso = since_dt.isoformat()
+        except ValueError:
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: invalid ISO 8601 datetime for 'since': {since_raw!r}",
+                )
+            ]
+    else:
+        since_dt = datetime.now(timezone.utc) - timedelta(hours=24)
+        since_iso = since_dt.isoformat()
+
+    # MIRROR OF api/routers/mmingest.py::get_recent SQL
+    recent_sql = sa_text("""
+        SELECT media_id, prefix, show_name, file_type, remote_url,
+               first_seen_at, remote_modified_at
+        FROM   mmingest_files
+        WHERE  first_seen_at >= :since
+          AND  (:prefix IS NULL OR LOWER(prefix) = LOWER(:prefix))
+          AND  superseded_by IS NULL
+        ORDER  BY first_seen_at DESC
+        LIMIT  :limit
+    """)
+
+    count_sql = sa_text("""
+        SELECT COUNT(*)
+        FROM   mmingest_files
+        WHERE  first_seen_at >= :since
+          AND  (:prefix IS NULL OR LOWER(prefix) = LOWER(:prefix))
+          AND  superseded_by IS NULL
+    """)
+
+    params = {"since": since_iso, "prefix": prefix, "limit": limit}
+    count_params = {"since": since_iso, "prefix": prefix}
+
+    engine = _mmingest_engine()
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(recent_sql, params)).fetchall()
+            total = (await conn.execute(count_sql, count_params)).scalar() or 0
+    finally:
+        await engine.dispose()
+
+    if not rows:
+        window = since_raw or f"last 24 hours (since {since_iso})"
+        return [
+            TextContent(
+                type="text",
+                text=f"No new arrivals in the window ({window}).",
+            )
+        ]
+
+    # Format as markdown list
+    lines = ["# Recent mmingest Arrivals\n"]
+    lines.append(f"**{total} file{'s' if total != 1 else ''}** since {since_iso} (showing {len(rows)})\n")
+
+    for row in rows:
+        m = row._mapping
+        media_id = m["media_id"] or m.get("remote_url", "(unknown)")
+        prefix_val = m["prefix"] or ""
+        show = m["show_name"] or ""
+        ftype = m["file_type"] or ""
+        seen = m["first_seen_at"] or ""
+        url = m["remote_url"] or ""
+
+        label = media_id
+        if show:
+            label += f" — {show}"
+        lines.append(f"- **{label}**")
+        lines.append(f"  Prefix: {prefix_val}  |  Type: {ftype}  |  First seen: {seen}")
+        lines.append(f"  URL: {url}")
 
     return [TextContent(type="text", text="\n".join(lines))]
 

--- a/planning/sprint-4a-handoff.md
+++ b/planning/sprint-4a-handoff.md
@@ -1,0 +1,358 @@
+# Sprint 4A Drone Handoff — mmingest MCP Tools
+
+**Dispatched by:** the-conductor
+**Date:** 2026-06-05
+**Plan:** `/Users/mriechers/.claude/plans/anyway-the-reason-i-noble-whistle.md` (Sprint 4 section)
+**Repo:** `mriechers/cardigan`
+**Branch:** `sprint-4a/mmingest-mcp-tools` off `origin/main` (`5e0f1c6`)
+**Parallel siblings:** Sprint 4B (pbswi skill refactor: `brainstorm-title-options`), Sprint 4C (pbswi skill refactor: `audit-assets`). Different repos, different files — fully parallel-safe.
+
+**Gates merged upstream (cardigan main `5e0f1c6`):**
+- S-1 — `36fc41a` (cheap fix)
+- S1A — `3db4e6c` (schema)
+- S1B — `afd5fee` (crawler) + `73e5ad4` (follow-up: queue race, dedup, politeness, lenient parse)
+- S2 — `1b9ae61` (indexer)
+- S3B — `b7a6afa` (search API, the `/api/mmingest/*` endpoints you'll mirror)
+- S3A — `5e0f1c6` (consumer keys + scoped auth + audit log)
+
+---
+
+## Your job, in one paragraph
+
+Add three MCP tools to `mcp_server/server.py` that let agents (including Claude Code) query the mmingest search index without an HTTP round-trip. The tools mirror Sprint 3B's HTTP endpoints (`/api/mmingest/search`, `/api/mmingest/assets/{media_id}`, `/api/mmingest/recent`) but call into Cardigan's own service layer in-process. The MCP server runs alongside the FastAPI app and shares its DB connection layer; no HTTP, no auth round-trip — same engine, same models, same Pydantic shapes.
+
+---
+
+## Start state (already on `origin/main`)
+
+| Piece | Path | What it gives you |
+|-------|------|-------------------|
+| **MCP server** | `mcp_server/server.py` | 2174-line file with `list_tools()` returning `Tool(...)` definitions and `call_tool()` dispatching by name. Standard MCP SDK pattern. |
+| **Sprint 3B router** | `api/routers/mmingest.py` | The HTTP endpoints whose shape you mirror. Read this for the exact SQL queries + Pydantic models you'll reuse. |
+| **Pydantic models** | `api/models/mmingest.py` | `SearchResult`, `AssetEntry`, `AssetResponse`, `RecentEntry`, `RecentResponse`, etc. Reuse these — don't redefine. |
+| **AirtableClient** | `api/services/airtable.py` | `batch_search_sst_by_media_ids` — reuse on `get_mmingest_asset` (primary only, NOT in search/recent). |
+| **DB layer** | `api/services/database.py` | Async session factories. The MCP server should use the same engine the FastAPI app does. |
+| **Existing MCP tool pattern** | `mcp_server/server.py` | Search the file for `name == "search_projects"` for a working example of an MCP tool that queries the DB and returns formatted markdown. Mirror that pattern. |
+
+---
+
+## Files to create
+
+None. This sprint is purely additive edits to `mcp_server/server.py`.
+
+If you find yourself wanting to extract a helper, put it in `mcp_server/server.py` alongside the existing helpers (e.g. near `async def fetch_sst_context`, `async def search_sst_by_media_id`). Don't create new modules unless you have a strong reason and surface it to the conductor first.
+
+## Files to modify (surgical only)
+
+| Path | Change |
+|------|--------|
+| `mcp_server/server.py` | Add three `Tool(...)` entries to `list_tools()`; add three `elif name == "..."` branches to `call_tool()`; add three async handler functions for the new tools. Mirror the existing pattern exactly. |
+| `tests/mcp_server/test_mmingest_tools.py` (if no existing `tests/mcp_server/` exists, create this directory + `__init__.py`) | Unit tests for the three new tools using `pytest-asyncio` and a seeded sqlite fixture mirroring `tests/api/test_mmingest_parity.py::migrated_engine` |
+
+## Files to leave alone (do not touch)
+
+- `api/routers/mmingest.py` — Sprint 3B's surface, frozen. You consume its services, not its routes.
+- `api/services/mmingest/*` — S1B/S2's surface, frozen.
+- `api/middleware/auth.py` — S3A's surface, frozen. MCP runs in-process, doesn't go through the HTTP auth middleware.
+- All Alembic migrations.
+- Any existing MCP tools (`list_processed_projects`, `search_projects`, etc.) — don't refactor them; just add yours alongside.
+
+---
+
+## Tool specifications
+
+The three tools mirror Sprint 3B's HTTP endpoints. Reuse the same SQL queries, the same Pydantic models, and the same auth-agnostic semantics (the MCP server doesn't enforce scopes — it runs in-process and trusts the caller).
+
+### Tool 1: `search_mmingest`
+
+```python
+Tool(
+    name="search_mmingest",
+    description=(
+        "Full-text search PBS Wisconsin's mmingest caption corpus via FTS5. "
+        "Returns BM25-ranked results with snippets. Mirrors HTTP "
+        "GET /api/mmingest/search but runs in-process (no HTTP, no auth round-trip). "
+        "Use for finding episodes by transcript content (e.g. 'inside wisconsin politics' "
+        "or 'climate change')."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "FTS5 MATCH query string. Phrases in double quotes match adjacently; bare terms are AND-ed."
+            },
+            "prefix": {
+                "type": "string",
+                "description": "Optional 4-char show prefix filter (e.g. '6POL' or '2WLI'). Exact case-insensitive match."
+            },
+            "since": {
+                "type": "string",
+                "description": "Optional ISO 8601 datetime; only return results modified at-or-after this timestamp."
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return. Default 25, max 100.",
+                "default": 25,
+                "minimum": 1,
+                "maximum": 100
+            }
+        },
+        "required": ["query"]
+    }
+)
+```
+
+**Implementation:**
+1. Reuse the SQL from `api/routers/mmingest.py::search`. Same JOIN shape (`mmingest_sidecars_fts → mmingest_sidecars → mmingest_files`). Same superseded filter (`mf.superseded_by IS NULL` by default).
+2. Return a markdown-formatted string (per MCP convention — tools return `list[TextContent]`). Header per result with media_id + show_name + revision_date; body with the FTS5 snippet (HTML-stripped to plain text with `<b>...</b>` highlight markers preserved for Claude to interpret).
+3. If `query` is empty or whitespace, return an error TextContent.
+4. If the FTS5 MATCH raises (malformed query syntax — see issue #191 for the parallel HTTP-side fix), catch and return an error TextContent like `"Error: invalid FTS5 query syntax. Use double quotes around multi-word phrases."` — do NOT propagate the SQLAlchemy exception.
+
+### Tool 2: `get_mmingest_asset`
+
+```python
+Tool(
+    name="get_mmingest_asset",
+    description=(
+        "Get the canonical asset record for a PBS Wisconsin Media ID, including "
+        "primary URL, variants (PLEDGE/DS cuts), superseded REVs, and the linked "
+        "Airtable record ID. Mirrors HTTP GET /api/mmingest/assets/{media_id} "
+        "but runs in-process."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "media_id": {
+                "type": "string",
+                "description": "8-character Media ID (e.g. '6POL0101'). Case-insensitive."
+            }
+        },
+        "required": ["media_id"]
+    }
+)
+```
+
+**Implementation:**
+1. Reuse the asset-resolution logic from `api/routers/mmingest.py::get_asset`. Same `{primary, variants, superseded}` shape.
+2. Call `AirtableClient.batch_search_sst_by_media_ids([media_id])` for the primary. If Airtable is unconfigured or raises, log a warning and return the response with `primary.airtable_record_id = None` (don't fail the whole call — same fallback as S3B does, per issue #193 the test for this fallback is tracked separately).
+3. Format the response as markdown. Sections: `# Asset: {media_id}` → `## Primary` (URL, REV date, show, Airtable link if available) → `## Variants` (one bullet per variant_tag) → `## Superseded REVs` (one bullet per older REV).
+4. 404 case (no rows for that media_id) → return an error TextContent saying so; don't raise.
+
+### Tool 3: `list_recent_mmingest_assets`
+
+```python
+Tool(
+    name="list_recent_mmingest_assets",
+    description=(
+        "List recently-arrived PBS Wisconsin assets on mmingest, ordered by "
+        "first-seen timestamp. Mirrors HTTP GET /api/mmingest/recent but runs "
+        "in-process. Use to poll for new arrivals (e.g. caption files just "
+        "delivered for an episode in production)."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "since": {
+                "type": "string",
+                "description": (
+                    "Optional ISO 8601 datetime cutoff. If absent, defaults to "
+                    "24 hours ago."
+                )
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return. Default 50, max 200.",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 200
+            },
+            "prefix": {
+                "type": "string",
+                "description": "Optional 4-char show prefix filter."
+            }
+        }
+    }
+)
+```
+
+**Implementation:**
+1. Reuse the SQL from `api/routers/mmingest.py::recent`. Default `since = now - 24h` if absent. Same superseded filter.
+2. Return markdown list: one line per file with `media_id` (or `filename` if media_id is None), `prefix`, `show_name`, `file_type`, `first_seen_at` (ISO), and the URL.
+3. Empty result set → return a friendly "no new arrivals in the window" message.
+
+---
+
+## Critical rules
+
+### 1. In-process call, not HTTP.
+
+The MCP server is in the same process tree as the FastAPI app. Your tools call into the service layer (or directly construct the SQL via a `get_session()` async session), they do NOT make HTTP calls to `localhost:8100/api/mmingest/*`. Doing so would defeat the purpose, add latency, and re-do the auth dance unnecessarily.
+
+If you find yourself reaching for `httpx.AsyncClient` to call back into Cardigan's own router, stop. Read the existing MCP tools (`search_projects`, etc.) for the pattern — they use the DB layer directly.
+
+### 2. Reuse Sprint 3B's SQL and Pydantic models verbatim.
+
+DO NOT re-derive the SQL queries. DO NOT redefine the Pydantic models. Import from `api.models.mmingest` (or the equivalent if S3B's router defined models inline — check the S3B PR's actual structure). If the router code is structured such that its query functions can be reused (e.g. a `_search_query(conn, q, prefix, since, limit, offset)` helper), reuse those.
+
+If the SQL or models live inline in the router and there's no clean reuse path, you have two options:
+- **Option A (preferred):** lift the query/format helpers into a new `api/services/mmingest/query.py` module, import from both the router and the MCP server. Surgical, no behavior change.
+- **Option B:** duplicate the query in the MCP tool with a clear comment `# MIRROR OF api/routers/mmingest.py::search — keep in sync`. Slightly less clean but acceptable for v1.
+
+Surface the decision in the PR description.
+
+### 3. The MCP server does NOT enforce mmingest scopes.
+
+The MCP server runs in-process; the caller is already trusted (you're running inside Cardigan's own runtime, not exposed over the network). Don't try to call into S3A's scope-check middleware — it's an HTTP middleware, not a service-layer construct. The audit log table (`mmingest_audit_log` from S3A) is also middleware-driven; you do NOT write to it from MCP tools.
+
+If a future need arises to track MCP tool calls, that's a separate sprint.
+
+### 4. Markdown formatting consistent with existing MCP tools.
+
+Look at `name == "get_sst_metadata"` (around line 1500 of `mcp_server/server.py`) for the gold-standard format: bold section headers, code blocks for content, status emoji where applicable. Mirror that style. Don't reinvent.
+
+### 5. Cardigan lint stack — HARD rule.
+
+CI runs `black --check` and `ruff check` on the whole project. Run both locally before pushing:
+
+```bash
+cd /Users/mriechers/Developer/pbswi/cardigan-v4
+source venv/bin/activate
+black .
+ruff check --fix .
+black --check .   # confirm clean
+ruff check .      # confirm clean
+```
+
+Every prior sprint got bitten on this. Don't be the seventh. (Issue #196 tracks pinning ruff+black versions — until that lands, the local install must match the CI install. Verify your `ruff --version` and `black --version` match what `.github/workflows/` configures.)
+
+### 6. Don't merge. Surface for Mark's gate.
+
+Open the PR. Self-verify gates. Surface to the conductor. Do NOT click merge.
+
+---
+
+## Verification gates (must all pass before opening the PR)
+
+1. **`search_mmingest` returns the canonical regression case.** With the dev DB seeded by an S2 indexer run, calling `search_mmingest(query="inside wisconsin politics")` returns at least one result with `media_id` matching `6POL*`.
+
+2. **`search_mmingest` filters work.** `prefix="6POL"` narrows; `since="2026-06-01T00:00:00Z"` filters by modification time; `limit=5` caps.
+
+3. **`search_mmingest` returns the SAME results as the HTTP endpoint.** Compare against `curl -X GET "http://localhost:8100/api/mmingest/search?q=politics" -H "X-API-Key: <shared-key>"`. Ordering, count, and snippets should match (modulo formatting — markdown vs JSON).
+
+4. **`get_mmingest_asset` happy path.** Seeded DB has a row for `6POL0101`. Tool returns `{primary, variants: [], superseded: [...]}` with the primary's URL populated and (if Airtable mocked) the airtable_record_id surfaced.
+
+5. **`get_mmingest_asset` with variants.** Seed primary + `_PLEDGE` variant. Tool surfaces both — primary in the primary section, PLEDGE in the variants section.
+
+6. **`get_mmingest_asset` 404 case.** Media ID not in DB → friendly error TextContent, no exception propagated.
+
+7. **`get_mmingest_asset` Airtable failure fallback.** Mock `batch_search_sst_by_media_ids` to raise. Tool still returns the row with `airtable_record_id = None` and an annotation in the markdown that Airtable lookup failed. Don't crash. (This is the same fallback issue #193 tracks for the HTTP endpoint — apply the same defensive treatment here.)
+
+8. **`list_recent_mmingest_assets` defaults.** No args → returns last 24h. With `since=` → returns from that timestamp forward. `limit=5` caps.
+
+9. **`list_recent_mmingest_assets` matches HTTP `/recent`.** Same comparison as gate 3.
+
+10. **MCP server still starts cleanly.** `python mcp_server/server.py` (or however it's launched per `pyproject.toml`) starts without import errors and reports the new tools in its capabilities. If there's a smoke-test command for the MCP server, run it.
+
+11. **No regression on S1A's parity tests:** `pytest tests/api/test_mmingest_parity.py` — 11/11 pass.
+
+12. **No regression on S1B's tests:** `pytest tests/services/mmingest/` — all green.
+
+13. **No regression on S2's integration tests:** `pytest tests/integration/test_mmingest_index.py` — 8/8 pass.
+
+14. **No regression on S3A's tests:** `pytest tests/api/test_consumer_key_auth.py tests/api/test_consumer_keys_service.py` — all green.
+
+15. **No regression on S3B's tests:** `pytest tests/api/test_mmingest_router.py` — all green.
+
+16. **No regression on S-1's batched upsert:** `pytest tests/test_ingest_scanner.py::TestBatchedUpsert` — 3/3 pass.
+
+17. **Lint stack:** `black --check .` and `ruff check .` both clean on the whole project.
+
+18. **Manual smoke from Claude Code:** restart Claude Code with the cardigan MCP server configured. Call each of the three new tools from Claude Code. Each returns a markdown response. Capture the responses in the PR description. (If you can't manually verify from Claude Code in this session, document a clear set of steps for Mark to do it before merge.)
+
+---
+
+## What to do when you finish
+
+1. Open the PR against `mriechers/cardigan` `main` from branch `sprint-4a/mmingest-mcp-tools`.
+2. PR title: `feat(mcp): Sprint 4A — add 3 mmingest search/asset/recent MCP tools`.
+3. PR body must include:
+   - Summary linking to the plan and this handoff doc.
+   - Verification gates as a checklist.
+   - Manual smoke results from Claude Code (or steps for Mark to run).
+   - A "Code reuse" section explaining whether you took Option A (extracted query helpers) or Option B (duplicated with sync comments) and why.
+   - Reference issues #182, #183, #184, #190, #191, #192, #193, #194, #195, #196 as tracked-but-not-this-PR's-job.
+4. Mark will not merge until a separate `pr-review-toolkit:review-pr` (or `code-reviewer`) agent has run a full pass and posted findings.
+
+---
+
+## Coordination with the parallel S4B/S4C drones
+
+S4B refactors `public-media-work/pbswi/.claude/skills/content/brainstorm-title-options/SKILL.md` to call your `search_mmingest` (or the HTTP `/api/mmingest/search`). S4C refactors `audit-assets/SKILL.md` similarly.
+
+**Coordination points:**
+1. **The skills can call your MCP tool OR the HTTP endpoint.** S3B's endpoints are already merged, so S4B/S4C have a working HTTP fallback even before your MCP tools merge. Don't block S4B/S4C; don't wait on them. Different repos, fully independent.
+2. **Tool naming is your contract.** Once your PR lands, S4B/S4C can invoke `search_mmingest`, `get_mmingest_asset`, `list_recent_mmingest_assets`. If you rename a tool mid-sprint, surface to the conductor so the parallel drones don't get stranded.
+
+**If you finish before S4B/S4C:** open the PR. Don't wait.
+
+---
+
+## Commit attribution
+
+```
+feat(mcp): <subject>
+
+[Agent: the-drone]
+
+<body>
+
+Agent: the-drone
+Machine: <hostname>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+No emojis in commit messages.
+
+---
+
+## Reference docs (read before starting)
+
+- `/Users/mriechers/.claude/plans/anyway-the-reason-i-noble-whistle.md` — Sprint 4 section
+- `mriechers/cardigan` branch `main` at `5e0f1c6` — your start state
+- `mcp_server/server.py` — the file you're editing; especially `list_tools()` and the existing tool handlers like `search_projects`, `get_sst_metadata`
+- `api/routers/mmingest.py` — Sprint 3B's HTTP endpoints; SQL queries to mirror
+- `api/models/mmingest.py` — Pydantic models to reuse
+- `api/services/mmingest/_db.py` — engine factories
+- `api/services/airtable.py` — `batch_search_sst_by_media_ids` signature
+- `tests/api/test_mmingest_router.py` — test patterns for the HTTP endpoints; mirror for MCP tools
+- `~/Developer/the-lodge/conventions/COMMIT_CONVENTIONS.md` — attribution format
+- Memory: `feedback_cardigan_lint_stack` — black + ruff both in CI
+
+---
+
+## Active issues you should be aware of (not your job to fix)
+
+- **#182** — parser sync between cardigan-v4 and pbswi Sprint 0 (unrelated to MCP; FYI)
+- **#183** — TokenBucket burst tuning (unrelated to MCP; FYI)
+- **#184** — unknown-variant-tag log level (unrelated to MCP; FYI)
+- **#190** — replace per-request AsyncEngine with shared get_session() in S3B router (will reduce duplication you might be tempted to add)
+- **#191** — FTS5 syntax errors return 500 instead of 400 (HTTP side — defend the same case in your tool with a friendly error string)
+- **#192** — Airtable timeout configuration on `/assets/{id}` (you inherit the same client; you might want to set a shorter timeout in your tool's call, but coordinate with #192's fix to avoid divergence)
+- **#193** — test for Airtable-exception fallback path (HTTP side — apply same fallback in your tool, but the test is tracked separately for HTTP)
+- **#194** — `?include_superseded=true` opt-in (HTTP side — if you add the same option to your tool's `inputSchema`, document it; if not, that's fine, mirror the default behavior)
+- **#195** — adopt TwoLaneWorkQueue in indexer enqueue path (unrelated to MCP; FYI)
+- **#196** — pin ruff + black versions in CI (until merged, ensure your local versions match CI's)
+
+---
+
+## If you get stuck
+
+- **MCP SDK Tool definitions feel verbose** — they are. The existing tools have the same boilerplate. Copy-paste-adjust.
+- **`call_tool()` dispatch chain is unwieldy at 2174 lines** — it is. Don't refactor it in this sprint. Just add your three `elif name == "..."` branches. Refactor can be a separate PR if Mark wants it.
+- **Pydantic v2 import errors** — Cardigan is on v2. Use `model_validate`, `model_dump`, not `parse_obj` / `.dict()`.
+- **Sprint 3B's SQL is hard to extract cleanly** — Option B (duplicate with sync comments) is acceptable. Document the choice.
+- **Real blocker** — STOP and report. A broken MCP server breaks Claude Code's connection to Cardigan, which downstream blocks S4B/S4C from using the MCP path (they fall back to HTTP, which is fine, but worth surfacing).
+
+Good hunting. — the-conductor

--- a/planning/sprint-5-staging-soak.md
+++ b/planning/sprint-5-staging-soak.md
@@ -79,7 +79,7 @@ EOF
 ### A4. Configure indexer scope to `/wisconsinlife/` at depth 1
 
 The scheduler instantiates `MmingestIndexer` with `directories=["/"]` by default (see
-`api/services/mmingest/scheduler.py`). For the soak, you want **only** `/wisconsinlist/` at
+`api/services/mmingest/scheduler.py`). For the soak, you want **only** `/wisconsinlife/` at
 depth 1 so crawl load is bounded and results are scoped.
 
 **Option A — environment override (recommended for the soak):**

--- a/planning/sprint-5-staging-soak.md
+++ b/planning/sprint-5-staging-soak.md
@@ -1,0 +1,489 @@
+# Sprint 5 — Staging Soak Runbook
+
+**Sprint:** 5 (final Phase 1 gate)
+**Directory under crawl:** `/wisconsinlife/` at depth 1, prefix `2WLI`
+**Duration:** 24 hours
+**Environment:** local dev (Studio) against production mmingest
+**Gate output:** GO/NO-GO + tunable-defaults snapshot for production rollout
+
+---
+
+## Prerequisites
+
+- Cardigan main at `ff3a3be` or newer (S4A merged — `search_mmingest`, `get_mmingest_asset`,
+  `list_recent_mmingest_assets` MCP tools live)
+- VPN/campus tunnel active (mmingest is campus-only)
+- `tmux` available for background sessions
+- Python 3.13 + virtual environment at `venv/` (or `.venv/`)
+- `cron` or `launchd` for smoke-test scheduling (see Section C)
+
+---
+
+## Section A — Setup (one-time, ~10 minutes)
+
+### A1. Pull latest cardigan main
+
+```bash
+cd /Users/mriechers/Developer/pbswi/cardigan-v4
+git fetch origin
+git checkout main
+git pull --ff-only
+```
+
+Confirm you're at `ff3a3be` or newer:
+```bash
+git log --oneline | head -3
+```
+
+Expected: `ff3a3be feat(mcp): Sprint 4A — add 3 mmingest search/asset/recent MCP tools` or a later commit.
+
+### A2. Activate virtual environment and install dependencies
+
+```bash
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Verify `httpx`, `sqlalchemy[asyncio]`, `aiosqlite`, and `apscheduler` are present:
+```bash
+pip show httpx sqlalchemy apscheduler aiosqlite 2>&1 | grep -E "^(Name|Version)"
+```
+
+### A3. Migrate dev DB to head
+
+```bash
+alembic upgrade head
+```
+
+Expected output ends with `Running upgrade ... -> 018, add_mmingest_audit_log` (or the latest migration).
+Verify the key tables exist:
+```bash
+python3 - <<'EOF'
+import sqlite3, os
+db = os.environ.get("DATABASE_PATH", "dashboard.db")
+conn = sqlite3.connect(db)
+tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+required = {"mmingest_files", "mmingest_sidecars", "consumer_keys", "mmingest_audit_log"}
+missing = required - tables
+if missing:
+    print(f"MISSING tables: {missing}")
+else:
+    print("All required tables present")
+# Verify FTS5 virtual table
+fts = conn.execute("SELECT name FROM sqlite_master WHERE name='mmingest_sidecars_fts'").fetchone()
+print(f"FTS5 virtual table: {'present' if fts else 'MISSING'}")
+conn.close()
+EOF
+```
+
+### A4. Configure indexer scope to `/wisconsinlife/` at depth 1
+
+The scheduler instantiates `MmingestIndexer` with `directories=["/"]` by default (see
+`api/services/mmingest/scheduler.py`). For the soak, you want **only** `/wisconsinlist/` at
+depth 1 so crawl load is bounded and results are scoped.
+
+**Option A — environment override (recommended for the soak):**
+
+Add a `MMINGEST_DIRECTORIES` environment variable handling. The scheduler currently hardcodes
+`directories=["/"]`; the cleanest short-term approach is to patch the scheduler's
+`run_delta_walk()` temporarily:
+
+```python
+# In api/services/mmingest/scheduler.py, replace the MmingestIndexer call temporarily:
+indexer = MmingestIndexer(
+    engine=engine,
+    base_url="https://mmingest.pbswi.wisc.edu/",
+    directories=["/wisconsinlife/"],   # <-- soak scope
+    max_concurrent=4,
+    rate_per_second=1.0,               # <-- 1 req/s for the soak
+)
+```
+
+**Note:** Do NOT commit this change to main; it's soak-only. Revert after Section F.
+The production scheduler will walk `/` with the production tunables once GO is confirmed.
+
+**Option B — run the indexer directly (avoids modifying scheduler.py):**
+
+Use the one-shot indexer script at `scripts/sprint5_soak_monitor.sh` (Section B) — it
+invokes `MmingestIndexer` directly with the soak parameters, bypassing the scheduler entirely.
+The scheduler can stay at its defaults during the soak since the monitor script controls timing.
+
+> **Recommendation: Use Option B.** It leaves the scheduler untouched, runs outside the
+> APScheduler machinery, and produces JSONL telemetry. The 24h soak doesn't need APScheduler
+> cadence — the monitor script handles timing.
+
+### A5. Create a consumer key for smoke tests
+
+```bash
+python3 scripts/create_consumer_key.py \
+  --label "sprint5-smoke" \
+  --scopes "mmingest:read"
+```
+
+Save the output key — you'll need it in Section C's smoke script. The key is stored hashed;
+you cannot retrieve it afterward.
+
+### A6. Record baseline file count for coverage criterion
+
+Before starting the soak, capture the ground-truth count from mmingest directly:
+
+```bash
+BASELINE=$(curl -s "https://mmingest.pbswi.wisc.edu/wisconsinlife/" \
+  | grep -oi 'href="[^"]*\.mp4"' | wc -l | tr -d ' ')
+echo "Baseline MP4 count for /wisconsinlife/: $BASELINE"
+echo "$BASELINE" > /tmp/sprint5-baseline-count.txt
+```
+
+This number is your coverage target for Section D criterion 4.
+
+### A7. Bring up Cardigan dev
+
+```bash
+./init.sh
+uvicorn api.main:app --reload --port 8100
+```
+
+Wait for the startup log lines:
+```
+INFO:     Application startup complete.
+```
+
+Verify the health endpoint returns 200 (do not trust the `active_backend` / `active_model` /
+`last_run` fields in the body — these are known-unreliable; see project memory):
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8100/api/system/health
+# Expected: 200
+```
+
+Verify the mmingest search endpoint is live:
+
+```bash
+curl -s "http://localhost:8100/api/mmingest/search?q=wisconsin" \
+  -H "X-API-Key: <your-consumer-key>" | python3 -m json.tool | head -10
+```
+
+Expected: JSON with `total` field (may be 0 before indexing, but the endpoint must return 200).
+
+### A8. Start monitor and smoke in tmux
+
+```bash
+tmux new-session -d -s soak-monitor
+tmux send-keys -t soak-monitor \
+  'bash /Users/mriechers/Developer/pbswi/cardigan-v4/scripts/sprint5_soak_monitor.sh 2>&1 | tee /tmp/sprint5-monitor.log' \
+  Enter
+
+# Smoke script runs via cron (see Section C) — no tmux pane needed for the scheduler itself,
+# but keep a pane for manual test runs:
+tmux new-window -t soak-monitor
+tmux send-keys -t soak-monitor \
+  'tail -f /tmp/sprint5-smoke-log.jsonl' \
+  Enter
+```
+
+---
+
+## Section B — Background monitor (`scripts/sprint5_soak_monitor.sh`)
+
+The script at `scripts/sprint5_soak_monitor.sh` runs for 24 hours and logs to
+`/tmp/sprint5-soak-log.jsonl`. It:
+
+1. Runs one full `MmingestIndexer` pass against `/wisconsinlife/` at depth 1
+2. Checks `fts_parity_delta()` every 6 hours
+3. Records HTTP client telemetry: total requests, status codes, latency, in-flight peak,
+   response sizes
+4. Captures sidecar-first vs MP4 queue depth snapshots
+5. Appends structured JSONL to `/tmp/sprint5-soak-log.jsonl`
+
+**To start:**
+```bash
+# In a tmux pane or nohup:
+bash scripts/sprint5_soak_monitor.sh
+# OR with nohup:
+nohup bash scripts/sprint5_soak_monitor.sh > /tmp/sprint5-monitor.log 2>&1 &
+echo $! > /tmp/sprint5-monitor.pid
+```
+
+**To watch progress:**
+```bash
+tail -f /tmp/sprint5-soak-log.jsonl | python3 -c "
+import sys, json
+for line in sys.stdin:
+    d = json.loads(line.strip())
+    print(f\"{d.get('ts','')} [{d.get('event','?')}] {d.get('msg','')}\")
+"
+```
+
+**Telemetry fields logged per event:**
+
+| Event | Key fields |
+|-------|-----------|
+| `indexer_run` | `files_seen`, `files_new`, `sidecars_fetched`, `fts_parity_delta`, `elapsed_s`, `req_total`, `req_5xx`, `req_errors`, `p50_latency_ms`, `p95_latency_ms`, `peak_inflight`, `sidecar_qsize`, `mp4_qsize` |
+| `parity_check` | `fts_delta`, `mmingest_files_count` (prefix=2WLI), `mmingest_sidecars_count` |
+| `pause_window` | `window_start`, `window_end`, `now_utc` |
+| `error` | `exc_type`, `msg` |
+
+**Pause window:** The soak configures `pause_window = (11:00, 15:00) UTC` which maps to
+`06:00–10:00 America/Chicago` (CDT = UTC-5 in summer). No requests will be made during this
+window. The monitor script respects the same window.
+
+**Queue depth instrumentation note:** `TwoLaneWorkQueue.qsize()` tracks total items; there
+is no public `sidecar_qsize()` / `mp4_qsize()` accessor on `TwoLaneWorkQueue` directly.
+The monitor script instruments queue depth at the `MmingestIndexer` level by patching
+`_sidecar.qsize()` and `_primary.qsize()` on the internal queue object post-instantiation.
+See the script comments for the approach.
+
+---
+
+## Section C — Smoke test (`scripts/sprint5_smoke_search.sh`)
+
+The smoke script runs every 30 minutes across the 24h soak. It tests three queries:
+
+| Query | Expected behaviour |
+|-------|-------------------|
+| `wisconsin` | Common term — should return hits once `/wisconsinlife/` sidecars are indexed |
+| `"Wisconsin Life"` | Known phrase from WLI episode transcripts — should match once indexed |
+| `xyzzy_no_match_expected_404` | Unlikely term — should return empty results (not a 404/500) |
+
+Each call's status, latency, and result count are appended to `/tmp/sprint5-smoke-log.jsonl`.
+
+**Schedule via cron:**
+```bash
+# Add to crontab:
+crontab -e
+```
+Insert line:
+```
+*/30 * * * * CONSUMER_KEY=<your-key> bash /Users/mriechers/Developer/pbswi/cardigan-v4/scripts/sprint5_smoke_search.sh >> /tmp/sprint5-cron.log 2>&1
+```
+
+**OR run in a loop in a tmux pane:**
+```bash
+# In tmux pane:
+export CONSUMER_KEY=<your-key>
+while true; do
+  bash /Users/mriechers/Developer/pbswi/cardigan-v4/scripts/sprint5_smoke_search.sh
+  sleep 1800
+done
+```
+
+**Manual one-shot run (useful for verifying setup):**
+```bash
+CONSUMER_KEY=<your-key> bash scripts/sprint5_smoke_search.sh
+```
+
+Expected first output (before `/wisconsinlife/` is indexed):
+```json
+{"ts": "2026-...", "event": "smoke", "query": "wisconsin", "status": 200, "hits": 0, "latency_ms": 12}
+```
+After indexing completes, `hits` should be > 0 for the first two queries.
+
+---
+
+## Section D — Acceptance envelope (GO criteria)
+
+All five categories must pass for a GO decision.
+
+### D1. Politeness
+
+| Criterion | Threshold | How measured |
+|-----------|-----------|--------------|
+| Average request rate to mmingest | ≤ 1.0 req/s over any 5-min window | `sprint5_soak_report.py` bins requests by 5-min window |
+| Peak in-flight concurrency | ≤ 4 simultaneous requests | `peak_inflight` field in `indexer_run` events |
+| Error rate (5xx + connect errors) | < 1% of all requests | `(req_5xx + req_errors) / req_total` |
+| Zero requests during pause window | 06:00–10:00 America/Chicago (CDT) | `pause_window` events logged; zero `indexer_run` events with `ts` in that window |
+
+**GO:** all four sub-criteria met.
+**NO-GO trigger:** any window where avg rate > 1 req/s, OR any `peak_inflight` > 4, OR error rate ≥ 1%, OR any HTTP request timestamped inside the pause window.
+
+### D2. FTS parity
+
+| Criterion | Threshold |
+|-----------|-----------|
+| `fts_parity_delta()` at each 6h check | Must return 0 |
+
+Checks occur at approximately: T+0h (initial), T+6h, T+12h, T+18h, T+24h.
+
+**GO:** all five checks return 0 (or None at T+0h before migration, treated as "not yet populated" not "fail").
+**NO-GO trigger:** any non-zero delta at any check.
+
+### D3. Latency
+
+| Metric | Threshold | Measured over |
+|--------|-----------|---------------|
+| `/api/mmingest/search` p95 | < 50ms | All 48 smoke calls (2/h × 24h) |
+| `/api/mmingest/search` p99 | < 200ms | Same 48 calls |
+
+Latency is measured from the smoke script (wall-clock curl time), not server-side.
+Dev mode includes some overhead; the threshold is deliberately conservative.
+
+**GO:** p95 < 50ms AND p99 < 200ms.
+**NO-GO trigger:** p95 ≥ 50ms OR p99 ≥ 200ms.
+
+### D4. Coverage
+
+| Criterion | Threshold |
+|-----------|-----------|
+| `mmingest_files` row count where `prefix LIKE '2WLI%'` at hour 24 | Within ±5% of baseline MP4 count |
+
+Baseline was captured in step A6 (`/tmp/sprint5-baseline-count.txt`).
+
+Note: `mmingest_files` tracks ALL file types (MP4 + SRT + SCC + images), so the raw row count
+will be higher than the baseline MP4 count. The report script compares MP4-only rows
+(`file_type = 'mp4'`).
+
+**GO:** `|actual_mp4_count - baseline| / baseline ≤ 0.05`
+**NO-GO trigger:** difference > 5%.
+
+### D5. No regression
+
+| Criterion | How verified |
+|-----------|-------------|
+| `/api/jobs` returns 200 | Smoke script pings this endpoint alongside the mmingest search |
+| `/api/system/health` returns 200 | Same |
+| No unhandled exceptions in API log during soak | Review `api.log` for ERROR-level entries |
+
+**GO:** both legacy endpoints 200 throughout; no unhandled exceptions in logs.
+**NO-GO trigger:** any non-200 response on `/api/jobs` or `/api/system/health`; any
+`ERROR` or `CRITICAL` in `api.log` not present pre-soak.
+
+### D6. Tunable-defaults snapshot (always captured, not a pass/fail gate)
+
+Regardless of GO/NO-GO, the report records the empirical values observed during the soak
+for use as production defaults:
+
+- Observed average request rate (req/s)
+- Observed peak concurrency
+- Actual pause window effectiveness (% of schedule covered)
+- Sidecar vs MP4 queue drain ratio
+- Recommended `max_concurrent` setting (≤ observed peak, round down to nearest power of 2)
+- Recommended `rate_per_second` setting (≤ 80% of observed max burst)
+
+---
+
+## Section E — End-of-soak report
+
+After the 24h window:
+
+```bash
+cd /Users/mriechers/Developer/pbswi/cardigan-v4
+source venv/bin/activate
+python3 scripts/sprint5_soak_report.py \
+  --soak-log /tmp/sprint5-soak-log.jsonl \
+  --smoke-log /tmp/sprint5-smoke-log.jsonl \
+  --baseline-count /tmp/sprint5-baseline-count.txt \
+  --output planning/sprint-5-soak-report.md
+```
+
+The report covers each Section D criterion with concrete numbers. If `matplotlib` is available
+in the virtual environment, it also writes PNG plots to `planning/sprint-5-plots/`.
+
+Review the report, then update the plan file's `[ ] Sprint 5 soak execution` and
+`[ ] Sprint 5 GO/NO-GO report` checkboxes with the result.
+
+---
+
+## Section F — Rollback if soak fails
+
+Sprint 5 is a soak against local dev — there is nothing to roll back at the code level since no
+production deployment has occurred. The appropriate response to each failure mode:
+
+### Polite-crawl violation (rate > 1 req/s or peak concurrency > 4)
+
+1. Stop the monitor script: `kill $(cat /tmp/sprint5-monitor.pid)` or Ctrl-C in tmux.
+2. File an issue on `mriechers/cardigan` with the specific 5-min window data from the report.
+3. Patch `MmingestIndexer` parameters (reduce `rate_per_second` or `max_concurrent`) on a fix branch.
+4. Re-soak from scratch (reset `/tmp/sprint5-soak-log.jsonl`) once the fix is verified in
+   unit tests.
+
+### FTS parity drift (non-zero delta)
+
+1. Stop the monitor, stop Cardigan.
+2. Run the parity check manually:
+   ```bash
+   python3 - <<'EOF'
+   import asyncio
+   from sqlalchemy.ext.asyncio import create_async_engine
+   from api.services.mmingest._db import fts_parity_delta
+   engine = create_async_engine("sqlite+aiosqlite:///dashboard.db")
+   async def check():
+       async with engine.connect() as conn:
+           d = await fts_parity_delta(conn)
+           print(f"delta={d}")
+   asyncio.run(check())
+   EOF
+   ```
+3. If delta persists: check for missing FTS5 triggers (migration 016 trigger on
+   `mmingest_sidecars` INSERT/DELETE/UPDATE) with `SELECT * FROM sqlite_master WHERE name LIKE '%fts%'`.
+4. File issue on `mriechers/cardigan` with the delta value and any trigger anomalies found.
+5. Do NOT rebuild/replace FTS5 index manually — fix the root cause and re-soak.
+
+### Latency regression (p95 > 50ms)
+
+p95 > 50ms on a local SQLite DB is unexpected and likely indicates:
+- Too many rows without a covering index (check `EXPLAIN QUERY PLAN` for the FTS5 JOIN query)
+- FTS5 index corruption (run `INSERT INTO mmingest_sidecars_fts(mmingest_sidecars_fts) VALUES('integrity-check')`)
+- Cardigan dev mode overhead (run a quick benchmark with `uvicorn --no-reload` to isolate)
+
+File issue if root cause is an index or query problem. If it's purely dev-mode overhead,
+re-run with `--no-reload` and document the baseline diff in the report.
+
+### Back-compat break (legacy endpoint returns non-200)
+
+1. Check `api.log` for the error.
+2. If it's an unrelated error (DB lock, scheduler conflict), stop and restart Cardigan.
+3. If it's a regression in the mmingest code path leaking to other endpoints, bisect with
+   `git bisect` between S3A (`5e0f1c6`) and S4A (`ff3a3be`).
+4. File issue with the specific endpoint + error + commit range.
+
+### Coverage miss (>5% gap in file count)
+
+Most likely explanation: the crawler's change-detection triple is skipping files on
+re-runs (false "unchanged" matches). Check:
+- `files_seen` vs `files_new` ratios across `indexer_run` events in the soak log.
+- If `files_new` drops to 0 after the first run but `files_seen` is also 0, the crawler is
+  not walking — check the `max_depth` parameter (must be ≥ 1 for `/wisconsinlife/` contents).
+
+File issue if coverage is consistently below 95%.
+
+---
+
+## Quick reference: tunables
+
+| Parameter | Soak value | Notes |
+|-----------|-----------|-------|
+| `directories` | `["/wisconsinlife/"]` | Depth 1; files live directly in this dir |
+| `max_concurrent` | 4 | Hard cap enforced by semaphore |
+| `rate_per_second` | 1.0 | Token bucket refill (one token = one request) |
+| `pause_window` | `(11:00, 15:00) UTC` | Maps to 06:00–10:00 CDT |
+| `max_depth` | 1 | Depth 0 = `/wisconsinlife/` listing; depth 1 = files within |
+| Smoke interval | 30 min | 48 calls over 24h |
+| Parity check interval | 6h | 5 checks over 24h |
+
+---
+
+## Expected sequence of events
+
+| Time | Expected |
+|------|----------|
+| T+0h | First indexer run begins; 2WLI files start appearing in `mmingest_files` |
+| T+0h to T+4h | Sidecars fetched and FTS5 populated; first smoke call returns hits |
+| T+6h | First 6h parity check (should be 0) |
+| T+11:00–15:00 UTC | Pause window — zero crawl activity; monitor logs `pause_window` events |
+| T+12h | Second 6h parity check |
+| T+18h | Third 6h parity check |
+| T+24h | Final parity check; run `sprint5_soak_report.py` |
+
+---
+
+## Files produced by this soak
+
+| File | Contents |
+|------|----------|
+| `/tmp/sprint5-soak-log.jsonl` | Indexer run telemetry + parity checks (JSONL) |
+| `/tmp/sprint5-smoke-log.jsonl` | Smoke search results (JSONL) |
+| `/tmp/sprint5-baseline-count.txt` | Ground-truth MP4 count from mmingest |
+| `/tmp/sprint5-monitor.log` | Monitor script stdout/stderr |
+| `/tmp/sprint5-cron.log` | Cron-scheduled smoke script log |
+| `planning/sprint-5-soak-report.md` | Final GO/NO-GO report (generated by report script) |
+| `planning/sprint-5-plots/*.png` | Optional latency/rate plots (if matplotlib available) |

--- a/scripts/sprint5_smoke_search.sh
+++ b/scripts/sprint5_smoke_search.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Sprint 5 Staging Soak — Smoke Search Script
+#
+# Runs three test queries against /api/mmingest/search and records results
+# to /tmp/sprint5-smoke-log.jsonl. Also pings legacy endpoints for regression
+# detection.
+#
+# Intended to run every 30 minutes for the duration of the 24h soak.
+#
+# Setup:
+#   1. Create a consumer key: python3 scripts/create_consumer_key.py \
+#        --label sprint5-smoke --scopes mmingest:read
+#   2. Set CONSUMER_KEY in your environment or crontab
+#   3. Ensure Cardigan is running on CARDIGAN_URL (default http://localhost:8100)
+#
+# Schedule via cron (add to crontab with: crontab -e):
+#   */30 * * * * CONSUMER_KEY=<key> bash /path/to/sprint5_smoke_search.sh
+#
+# OR run in a tmux loop:
+#   export CONSUMER_KEY=<key>
+#   while true; do bash scripts/sprint5_smoke_search.sh; sleep 1800; done
+#
+# Configuration (override via environment):
+#   CONSUMER_KEY     API key with mmingest:read scope (REQUIRED)
+#   CARDIGAN_URL     Base URL for Cardigan API (default: http://localhost:8100)
+#   SMOKE_LOG        Output JSONL path (default: /tmp/sprint5-smoke-log.jsonl)
+#
+set -euo pipefail
+
+CARDIGAN_URL="${CARDIGAN_URL:-http://localhost:8100}"
+SMOKE_LOG="${SMOKE_LOG:-/tmp/sprint5-smoke-log.jsonl}"
+
+if [ -z "${CONSUMER_KEY:-}" ]; then
+    echo "ERROR: CONSUMER_KEY environment variable is required." >&2
+    echo "  Create a key with: python3 scripts/create_consumer_key.py --label sprint5-smoke --scopes mmingest:read" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: run one search query, record results
+# ---------------------------------------------------------------------------
+
+run_smoke_query() {
+    local query="$1"
+    local description="$2"
+    local expect_hits="$3"   # "yes", "no", or "any"
+
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+    local encoded_query
+    # URL-encode the query string (basic percent-encoding for common chars)
+    encoded_query="$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$query")"
+
+    local url="${CARDIGAN_URL}/api/mmingest/search?q=${encoded_query}&limit=5"
+
+    # Time the request
+    local t0
+    t0="$(date +%s%3N)"  # milliseconds since epoch (GNU date; macOS: use python fallback)
+
+    # macOS date doesn't support %3N — use python for ms precision
+    t0="$(python3 -c 'import time; print(int(time.time() * 1000))')"
+
+    local http_response
+    local http_status
+    local http_body
+
+    # curl: -s silent, -w for status code, -o to capture body
+    local tmp_body
+    tmp_body="$(mktemp /tmp/sprint5_smoke_body_XXXXXX.json)"
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp_body'" RETURN
+
+    http_status="$(curl -s -o "$tmp_body" -w "%{http_code}" \
+        -H "X-API-Key: $CONSUMER_KEY" \
+        --max-time 10 \
+        "$url" 2>/dev/null)" || http_status="000"
+
+    local t1
+    t1="$(python3 -c 'import time; print(int(time.time() * 1000))')"
+    local latency_ms=$(( t1 - t0 ))
+
+    http_body="$(cat "$tmp_body" 2>/dev/null || echo '{}')"
+
+    # Extract hit count from JSON response
+    local hits
+    hits="$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+    print(d.get('total', d.get('count', len(d.get('results', [])))))
+except Exception:
+    print(-1)
+" "$http_body" 2>/dev/null)" || hits="-1"
+
+    # Determine pass/fail for this query
+    local outcome
+    case "$expect_hits" in
+        "yes")
+            if [ "$http_status" = "200" ] && [ "${hits:-0}" -gt 0 ] 2>/dev/null; then
+                outcome="pass"
+            elif [ "$http_status" = "200" ] && [ "${hits:-0}" -eq 0 ] 2>/dev/null; then
+                outcome="warn_no_hits"   # OK early in soak before indexing completes
+            else
+                outcome="fail"
+            fi
+            ;;
+        "no")
+            if [ "$http_status" = "200" ]; then
+                outcome="pass"   # 200 with empty results is correct
+            else
+                outcome="fail"
+            fi
+            ;;
+        *)
+            outcome=$([ "$http_status" = "200" ] && echo "pass" || echo "fail")
+            ;;
+    esac
+
+    local record
+    record="$(python3 -c "
+import json
+print(json.dumps({
+    'ts': '$ts',
+    'event': 'smoke',
+    'query': $(python3 -c "import json, sys; print(json.dumps(sys.argv[1]))" "$query"),
+    'description': '$description',
+    'status': int('$http_status') if '$http_status'.isdigit() else 0,
+    'hits': int('$hits') if '$hits'.lstrip('-').isdigit() else -1,
+    'latency_ms': $latency_ms,
+    'outcome': '$outcome',
+    'expect_hits': '$expect_hits',
+}))")"
+
+    echo "$record" >> "$SMOKE_LOG"
+    echo "$record"
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Helper: ping a legacy endpoint for regression detection
+# ---------------------------------------------------------------------------
+
+run_regression_check() {
+    local endpoint="$1"
+    local label="$2"
+
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+    local t0
+    t0="$(python3 -c 'import time; print(int(time.time() * 1000))')"
+
+    local http_status
+    http_status="$(curl -s -o /dev/null -w "%{http_code}" \
+        --max-time 5 \
+        "${CARDIGAN_URL}${endpoint}" 2>/dev/null)" || http_status="000"
+
+    local t1
+    t1="$(python3 -c 'import time; print(int(time.time() * 1000))')"
+    local latency_ms=$(( t1 - t0 ))
+
+    local outcome
+    outcome=$([ "$http_status" = "200" ] && echo "pass" || echo "fail")
+
+    local record
+    record="$(python3 -c "
+import json
+print(json.dumps({
+    'ts': '$ts',
+    'event': 'regression_check',
+    'endpoint': '$endpoint',
+    'label': '$label',
+    'status': int('$http_status') if '$http_status'.isdigit() else 0,
+    'latency_ms': $latency_ms,
+    'outcome': '$outcome',
+}))")"
+
+    echo "$record" >> "$SMOKE_LOG"
+    echo "$record"
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run smoke queries
+# ---------------------------------------------------------------------------
+
+echo "Sprint 5 smoke test at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "Target: $CARDIGAN_URL"
+echo "Log: $SMOKE_LOG"
+echo "---"
+
+# Query 1: Common term — should have hits once /wisconsinlife/ sidecars are indexed
+run_smoke_query "wisconsin" "common_term" "yes"
+
+# Query 2: Known phrase from Wisconsin Life transcripts — phrase-match
+# Using a phrase likely to appear in WLI captions: "Wisconsin Life" is
+# the show name, commonly spoken in episode intros/outros.
+# Wrapped in double quotes for FTS5 adjacent-phrase match.
+run_smoke_query '"Wisconsin Life"' "wli_phrase_match" "yes"
+
+# Query 3: Unlikely term — should return empty results, not a 404/500
+# xyzzy is a well-known no-match sentinel in testing; the endpoint must
+# return 200 with empty results, not an error.
+run_smoke_query "xyzzy_no_match_expected_s5" "no_match_sentinel" "no"
+
+# Regression checks: verify pre-existing endpoints still respond
+run_regression_check "/api/system/health" "health_check"
+run_regression_check "/api/jobs?limit=1" "jobs_endpoint"
+
+echo "---"
+echo "Smoke test complete."

--- a/scripts/sprint5_soak_monitor.sh
+++ b/scripts/sprint5_soak_monitor.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# Sprint 5 Staging Soak — Background Monitor
+#
+# Drives one MmingestIndexer pass against /wisconsinlife/ at depth 1,
+# then repeats the parity check every 6 hours for 24 hours.
+#
+# Telemetry is appended to /tmp/sprint5-soak-log.jsonl as JSONL.
+#
+# Usage:
+#   bash scripts/sprint5_soak_monitor.sh
+#   # OR with nohup:
+#   nohup bash scripts/sprint5_soak_monitor.sh > /tmp/sprint5-monitor.log 2>&1 &
+#   echo $! > /tmp/sprint5-monitor.pid
+#
+# Configuration (override via environment):
+#   CARDIGAN_DIR      Path to cardigan-v4 checkout (default: directory containing this script's parent)
+#   DATABASE_PATH     SQLite DB path (default: $CARDIGAN_DIR/dashboard.db)
+#   SOAK_LOG          Output JSONL path (default: /tmp/sprint5-soak-log.jsonl)
+#   SOAK_HOURS        Total soak duration in hours (default: 24)
+#   PARITY_INTERVAL   Parity check interval in hours (default: 6)
+#   MMINGEST_BASE_URL mmingest server URL (default: https://mmingest.pbswi.wisc.edu/)
+#
+# Requirements:
+#   - Python 3.13+ with venv at $CARDIGAN_DIR/venv/ or $CARDIGAN_DIR/.venv/
+#   - Cardigan dependencies installed (httpx, sqlalchemy[asyncio], aiosqlite)
+#   - VPN/campus tunnel active (mmingest is campus-only)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CARDIGAN_DIR="${CARDIGAN_DIR:-$(dirname "$SCRIPT_DIR")}"
+DATABASE_PATH="${DATABASE_PATH:-$CARDIGAN_DIR/dashboard.db}"
+SOAK_LOG="${SOAK_LOG:-/tmp/sprint5-soak-log.jsonl}"
+SOAK_HOURS="${SOAK_HOURS:-24}"
+PARITY_INTERVAL="${PARITY_INTERVAL:-6}"
+MMINGEST_BASE_URL="${MMINGEST_BASE_URL:-https://mmingest.pbswi.wisc.edu/}"
+
+# ---------------------------------------------------------------------------
+# Activate virtual environment
+# ---------------------------------------------------------------------------
+
+VENV_PATH=""
+if [ -d "$CARDIGAN_DIR/venv" ]; then
+    VENV_PATH="$CARDIGAN_DIR/venv"
+elif [ -d "$CARDIGAN_DIR/.venv" ]; then
+    VENV_PATH="$CARDIGAN_DIR/.venv"
+else
+    echo "ERROR: No virtual environment found at $CARDIGAN_DIR/venv or $CARDIGAN_DIR/.venv" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_PATH/bin/activate"
+
+PYTHON="$VENV_PATH/bin/python3"
+echo "Using Python: $($PYTHON --version)"
+echo "Soak log: $SOAK_LOG"
+echo "Cardigan dir: $CARDIGAN_DIR"
+echo "Database: $DATABASE_PATH"
+echo "Duration: ${SOAK_HOURS}h, parity check every ${PARITY_INTERVAL}h"
+
+# ---------------------------------------------------------------------------
+# Inline Python helper — run one indexer pass and emit JSONL telemetry
+# ---------------------------------------------------------------------------
+# The Python script below is written to a temp file and executed directly
+# so it can import Cardigan's own modules from CARDIGAN_DIR.
+# ---------------------------------------------------------------------------
+
+RUNNER_PY="$(mktemp /tmp/sprint5_runner_XXXXXX.py)"
+trap 'rm -f "$RUNNER_PY"' EXIT
+
+cat > "$RUNNER_PY" << 'PYEOF'
+"""Sprint 5 soak monitor — Python runner.
+
+Called by sprint5_soak_monitor.sh with these environment variables:
+  CARDIGAN_DIR, DATABASE_PATH, SOAK_LOG, MMINGEST_BASE_URL,
+  RUNNER_MODE (indexer_run | parity_check)
+
+Appends one or more JSONL records to SOAK_LOG.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Prepend CARDIGAN_DIR to sys.path so Cardigan modules are importable.
+cardigan_dir = os.environ["CARDIGAN_DIR"]
+sys.path.insert(0, cardigan_dir)
+os.chdir(cardigan_dir)
+
+# Override DATABASE_PATH for Cardigan's database module.
+os.environ.setdefault("DATABASE_PATH", os.environ.get("DATABASE_PATH", "dashboard.db"))
+
+soak_log = Path(os.environ["SOAK_LOG"])
+base_url = os.environ.get("MMINGEST_BASE_URL", "https://mmingest.pbswi.wisc.edu/")
+mode = os.environ.get("RUNNER_MODE", "indexer_run")
+db_path = Path(os.environ.get("DATABASE_PATH", "dashboard.db"))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def emit(record: dict) -> None:
+    record.setdefault("ts", now_iso())
+    line = json.dumps(record)
+    with soak_log.open("a") as f:
+        f.write(line + "\n")
+    print(line, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Instrumented MmingestCrawler wrapper
+# ---------------------------------------------------------------------------
+
+class _TelemetryCrawler:
+    """Wraps MmingestCrawler to collect HTTP telemetry during delta_walk."""
+
+    def __init__(self, **kwargs) -> None:
+        from api.services.mmingest.crawler import MmingestCrawler, TokenBucket
+        from datetime import time as dtime
+
+        # Pause window: 11:00–15:00 UTC = 06:00–10:00 CDT
+        pause_start = dtime(11, 0)
+        pause_end   = dtime(15, 0)
+
+        self._crawler = MmingestCrawler(
+            base_url=kwargs.get("base_url", base_url),
+            max_concurrent=kwargs.get("max_concurrent", 4),
+            rate_per_second=kwargs.get("rate_per_second", 1.0),
+            max_depth=kwargs.get("max_depth", 1),
+            pause_window=(pause_start, pause_end),
+        )
+
+        # Telemetry accumulators (monkey-patched into the crawler's HTTP layer)
+        self.req_total   = 0
+        self.req_2xx     = 0
+        self.req_5xx     = 0
+        self.req_errors  = 0
+        self.latencies_ms: list[float] = []
+        self.peak_inflight = 0
+        self._inflight  = 0
+        self._resp_sizes_bytes: list[int] = []
+
+        # Patch _fetch_with_backoff to record telemetry
+        original_fetch = self._crawler._fetch_with_backoff.__func__
+
+        crawler_ref = self._crawler
+        telem = self
+
+        async def _instrumented_fetch(self_inner, client, semaphore, url, max_retries=4):
+            telem.req_total += 1
+            telem._inflight += 1
+            if telem._inflight > telem.peak_inflight:
+                telem.peak_inflight = telem._inflight
+            t0 = time.monotonic()
+            try:
+                result = await original_fetch(self_inner, client, semaphore, url, max_retries)
+                latency_ms = (time.monotonic() - t0) * 1000
+                telem.latencies_ms.append(latency_ms)
+                if result is not None:
+                    telem.req_2xx += 1
+                    telem._resp_sizes_bytes.append(len(result.encode("utf-8", errors="replace")))
+                return result
+            except Exception:
+                telem.req_errors += 1
+                raise
+            finally:
+                telem._inflight -= 1
+
+        import types
+        self._crawler._fetch_with_backoff = types.MethodType(_instrumented_fetch, self._crawler)
+
+    async def delta_walk(self, directories, known=None) -> list:
+        return await self._crawler.delta_walk(directories=directories, known=known)
+
+
+# ---------------------------------------------------------------------------
+# Parity check only (no crawl)
+# ---------------------------------------------------------------------------
+
+async def run_parity_check() -> None:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from api.services.mmingest._db import fts_parity_delta
+
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    engine = create_async_engine(db_url, echo=False)
+
+    async with engine.connect() as conn:
+        delta = await fts_parity_delta(conn)
+
+        # Count mmingest_files rows for prefix='2WLI'
+        from sqlalchemy import text
+        files_row = await conn.execute(text(
+            "SELECT COUNT(*) FROM mmingest_files WHERE prefix LIKE '2WLI%'"
+        ))
+        files_count: int = files_row.scalar_one()
+
+        sidecars_row = await conn.execute(text(
+            "SELECT COUNT(*) FROM mmingest_sidecars AS s "
+            "JOIN mmingest_files AS mf ON mf.id = s.file_id "
+            "WHERE mf.prefix LIKE '2WLI%'"
+        ))
+        sidecars_count: int = sidecars_row.scalar_one()
+
+    await engine.dispose()
+
+    emit({
+        "event": "parity_check",
+        "fts_delta": delta,
+        "mmingest_files_count_2wli": files_count,
+        "mmingest_sidecars_count_2wli": sidecars_count,
+        "msg": f"FTS delta={delta}; 2WLI files={files_count}; 2WLI sidecars={sidecars_count}",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Full indexer run
+# ---------------------------------------------------------------------------
+
+async def run_indexer() -> None:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from api.services.mmingest._db import fts_parity_delta
+    from api.services.mmingest.indexer import MmingestIndexer
+    from api.services.mmingest.crawler import ChangeTriple
+    from sqlalchemy import text
+
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    engine = create_async_engine(db_url, echo=False)
+
+    t0 = time.monotonic()
+
+    try:
+        # Check pause window before starting
+        from datetime import time as dtime, datetime as dt, timezone
+        pause_start = dtime(11, 0)
+        pause_end   = dtime(15, 0)
+        now_utc = dt.now(timezone.utc).time()
+        in_window = pause_start <= now_utc <= pause_end
+        if in_window:
+            emit({
+                "event": "pause_window",
+                "window_start": "11:00 UTC",
+                "window_end": "15:00 UTC",
+                "now_utc": now_utc.strftime("%H:%M"),
+                "msg": "Crawl paused — inside broadcast peak window (06:00–10:00 CDT)",
+            })
+            return
+
+        # Load known state for change detection
+        async with engine.connect() as conn:
+            known_rows = (await conn.execute(text(
+                "SELECT remote_url, etag, remote_modified_at, file_size_bytes "
+                "FROM mmingest_files WHERE directory_path LIKE '/wisconsinlife/%'"
+            ))).fetchall()
+
+        known: dict[str, ChangeTriple] = {
+            row[0]: (row[1], row[2], row[3]) for row in known_rows
+        }
+
+        # Instrumented crawl
+        telem_crawler = _TelemetryCrawler(
+            base_url=base_url,
+            max_concurrent=4,
+            rate_per_second=1.0,
+            max_depth=1,
+        )
+        work_items = await telem_crawler.delta_walk(
+            directories=["/wisconsinlife/"],
+            known=known,
+        )
+
+        files_seen = len(work_items)
+        elapsed_crawl = time.monotonic() - t0
+
+        # Persist via indexer (using internal methods for soak isolation)
+        indexer = MmingestIndexer(
+            engine=engine,
+            base_url=base_url,
+            directories=["/wisconsinlife/"],
+            max_concurrent=4,
+            rate_per_second=1.0,
+        )
+
+        # Upsert and fetch sidecars
+        from api.services.mmingest.indexer import _SIDECAR_FILE_TYPES
+        from api.services.mmingest.sidecar_fetcher import SidecarFetcher
+
+        files_new = 0
+        sidecars_fetched = 0
+        sidecars_persisted = 0
+        url_to_id: dict[str, int] = {}
+
+        if work_items:
+            async with engine.begin() as conn:
+                url_to_id = await indexer._upsert_files(conn, work_items)
+            files_new = len(work_items)
+
+            async with engine.begin() as conn:
+                await indexer._apply_variant_lineage(conn, work_items, url_to_id)
+
+            sidecar_items = [wi for wi in work_items if wi.file_type in _SIDECAR_FILE_TYPES]
+            if sidecar_items:
+                fetcher = SidecarFetcher()
+                fetch_inputs = [(wi.url, url_to_id.get(wi.url)) for wi in sidecar_items]
+                results = await fetcher.fetch_many(
+                    urls=fetch_inputs,
+                    max_concurrent=4,
+                )
+                sidecars_fetched = len(results)
+                ok_results = [r for r in results if r.ok]
+                sidecars_persisted = len(ok_results)
+
+                if ok_results:
+                    async with engine.begin() as conn:
+                        await indexer._persist_sidecars(conn, ok_results)
+
+        # Parity check
+        async with engine.connect() as conn:
+            fts_delta = await fts_parity_delta(conn)
+
+        # Latency percentiles
+        lats = sorted(telem_crawler.latencies_ms)
+        def pct(p: float) -> float:
+            if not lats:
+                return 0.0
+            idx = int(len(lats) * p / 100)
+            return round(lats[min(idx, len(lats)-1)], 1)
+
+        elapsed_total = round(time.monotonic() - t0, 1)
+
+        emit({
+            "event": "indexer_run",
+            "files_seen": files_seen,
+            "files_new": files_new,
+            "sidecars_fetched": sidecars_fetched,
+            "sidecars_persisted": sidecars_persisted,
+            "fts_parity_delta": fts_delta,
+            "elapsed_s": elapsed_total,
+            # HTTP telemetry
+            "req_total": telem_crawler.req_total,
+            "req_2xx": telem_crawler.req_2xx,
+            "req_5xx": telem_crawler.req_5xx,
+            "req_errors": telem_crawler.req_errors,
+            "p50_latency_ms": pct(50),
+            "p95_latency_ms": pct(95),
+            "p99_latency_ms": pct(99),
+            "peak_inflight": telem_crawler.peak_inflight,
+            # Queue depth: captured at end of run (items remaining in queue = 0 if complete)
+            "queue_final_size": 0,  # crawl is synchronous; queue drains before return
+            "msg": (
+                f"files_seen={files_seen} files_new={files_new} "
+                f"sidecars={sidecars_persisted} fts_delta={fts_delta} "
+                f"req_total={telem_crawler.req_total} "
+                f"peak_inflight={telem_crawler.peak_inflight} "
+                f"p95={pct(95)}ms elapsed={elapsed_total}s"
+            ),
+        })
+
+    except RuntimeError as exc:
+        # Pause window raised by crawler
+        emit({
+            "event": "pause_window",
+            "msg": str(exc),
+        })
+    except Exception as exc:
+        emit({
+            "event": "error",
+            "exc_type": type(exc).__name__,
+            "msg": str(exc),
+        })
+        raise
+    finally:
+        await engine.dispose()
+
+
+if mode == "parity_check":
+    asyncio.run(run_parity_check())
+else:
+    asyncio.run(run_indexer())
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Soak loop
+# ---------------------------------------------------------------------------
+
+SOAK_END=$(( $(date +%s) + SOAK_HOURS * 3600 ))
+PARITY_INTERVAL_SECS=$(( PARITY_INTERVAL * 3600 ))
+NEXT_PARITY=$(( $(date +%s) + PARITY_INTERVAL_SECS ))
+
+echo "Soak started at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "Soak ends at $(date -u -r "$SOAK_END" '+%Y-%m-%dT%H:%M:%SZ')"
+echo "First parity check at $(date -u -r "$NEXT_PARITY" '+%Y-%m-%dT%H:%M:%SZ')"
+
+# Emit soak-start event
+python3 - << STARTEOF
+import json, os
+from datetime import datetime, timezone
+soak_log = os.environ.get("SOAK_LOG", "/tmp/sprint5-soak-log.jsonl")
+with open(soak_log, "a") as f:
+    f.write(json.dumps({
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": "soak_start",
+        "config": {
+            "directory": "/wisconsinlife/",
+            "depth": 1,
+            "prefix": "2WLI",
+            "max_concurrent": 4,
+            "rate_per_second": 1.0,
+            "pause_window_utc": "11:00-15:00",
+            "soak_hours": int(os.environ.get("SOAK_HOURS", 24)),
+            "parity_interval_hours": int(os.environ.get("PARITY_INTERVAL", 6)),
+        },
+        "msg": "Sprint 5 soak started",
+    }) + "\n")
+STARTEOF
+
+# Initial indexer run (T+0h)
+echo "Running initial indexer pass..."
+CARDIGAN_DIR="$CARDIGAN_DIR" \
+DATABASE_PATH="$DATABASE_PATH" \
+SOAK_LOG="$SOAK_LOG" \
+MMINGEST_BASE_URL="$MMINGEST_BASE_URL" \
+RUNNER_MODE="indexer_run" \
+PYTHONPATH="$CARDIGAN_DIR:${PYTHONPATH:-}" \
+"$PYTHON" "$RUNNER_PY"
+
+# Soak loop: sleep 1h, check if parity due, repeat
+while [ "$(date +%s)" -lt "$SOAK_END" ]; do
+    echo "Sleeping 1h... (next wakeup at $(date -u -r "$(( $(date +%s) + 3600 ))" '+%H:%M UTC'))"
+    sleep 3600
+
+    NOW=$(date +%s)
+    [ "$NOW" -ge "$SOAK_END" ] && break
+
+    # Parity check
+    if [ "$NOW" -ge "$NEXT_PARITY" ]; then
+        echo "Running parity check at $(date -u '+%Y-%m-%dT%H:%M:%SZ')..."
+        CARDIGAN_DIR="$CARDIGAN_DIR" \
+        DATABASE_PATH="$DATABASE_PATH" \
+        SOAK_LOG="$SOAK_LOG" \
+        MMINGEST_BASE_URL="$MMINGEST_BASE_URL" \
+        RUNNER_MODE="parity_check" \
+        PYTHONPATH="$CARDIGAN_DIR:${PYTHONPATH:-}" \
+        "$PYTHON" "$RUNNER_PY"
+        NEXT_PARITY=$(( NOW + PARITY_INTERVAL_SECS ))
+    fi
+
+    # Also run a delta indexer pass each hour
+    echo "Running hourly indexer pass at $(date -u '+%Y-%m-%dT%H:%M:%SZ')..."
+    CARDIGAN_DIR="$CARDIGAN_DIR" \
+    DATABASE_PATH="$DATABASE_PATH" \
+    SOAK_LOG="$SOAK_LOG" \
+    MMINGEST_BASE_URL="$MMINGEST_BASE_URL" \
+    RUNNER_MODE="indexer_run" \
+    PYTHONPATH="$CARDIGAN_DIR:${PYTHONPATH:-}" \
+    "$PYTHON" "$RUNNER_PY"
+done
+
+# Final parity check at T+24h
+echo "Final parity check at $(date -u '+%Y-%m-%dT%H:%M:%SZ')..."
+CARDIGAN_DIR="$CARDIGAN_DIR" \
+DATABASE_PATH="$DATABASE_PATH" \
+SOAK_LOG="$SOAK_LOG" \
+MMINGEST_BASE_URL="$MMINGEST_BASE_URL" \
+RUNNER_MODE="parity_check" \
+PYTHONPATH="$CARDIGAN_DIR:${PYTHONPATH:-}" \
+"$PYTHON" "$RUNNER_PY"
+
+# Emit soak-end event
+python3 - << ENDEOF
+import json, os
+from datetime import datetime, timezone
+soak_log = os.environ.get("SOAK_LOG", "/tmp/sprint5-soak-log.jsonl")
+with open(soak_log, "a") as f:
+    f.write(json.dumps({
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": "soak_end",
+        "msg": "Sprint 5 soak complete — run sprint5_soak_report.py to generate GO/NO-GO report",
+    }) + "\n")
+ENDEOF
+
+echo "Soak complete. Run: python3 scripts/sprint5_soak_report.py to generate the report."

--- a/scripts/sprint5_soak_monitor.sh
+++ b/scripts/sprint5_soak_monitor.sh
@@ -318,7 +318,7 @@ async def run_indexer() -> None:
 
                 if ok_results:
                     async with engine.begin() as conn:
-                        await indexer._persist_sidecars(conn, ok_results)
+                        await indexer._persist_sidecars(conn, ok_results, url_to_id)
 
         # Parity check
         async with engine.connect() as conn:

--- a/scripts/sprint5_soak_report.py
+++ b/scripts/sprint5_soak_report.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python3
+"""Sprint 5 Staging Soak — End-of-Soak Report Generator.
+
+Reads /tmp/sprint5-soak-log.jsonl and /tmp/sprint5-smoke-log.jsonl,
+evaluates each Section D acceptance criterion, and writes a GO/NO-GO
+markdown report to planning/sprint-5-soak-report.md.
+
+Usage:
+    python3 scripts/sprint5_soak_report.py \\
+        [--soak-log /tmp/sprint5-soak-log.jsonl] \\
+        [--smoke-log /tmp/sprint5-smoke-log.jsonl] \\
+        [--baseline-count /tmp/sprint5-baseline-count.txt] \\
+        [--output planning/sprint-5-soak-report.md] \\
+        [--db dashboard.db]
+
+Optional matplotlib support: if matplotlib is installed, latency/rate plots
+are written to planning/sprint-5-plots/.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, median
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--soak-log",       default="/tmp/sprint5-soak-log.jsonl")
+    p.add_argument("--smoke-log",      default="/tmp/sprint5-smoke-log.jsonl")
+    p.add_argument("--baseline-count", default="/tmp/sprint5-baseline-count.txt")
+    p.add_argument("--output",         default="planning/sprint-5-soak-report.md")
+    p.add_argument("--db",             default="dashboard.db")
+    p.add_argument("--no-plots",       action="store_true", help="Skip matplotlib plots")
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading
+# ---------------------------------------------------------------------------
+
+def load_jsonl(path: str) -> list[dict]:
+    records: list[dict] = []
+    p = Path(path)
+    if not p.exists():
+        print(f"WARNING: {path} not found — using empty dataset", file=sys.stderr)
+        return records
+    with p.open() as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(f"WARNING: skipping malformed line {i} in {path}: {exc}", file=sys.stderr)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Section D criterion evaluators
+# ---------------------------------------------------------------------------
+
+# D1: Politeness
+def eval_politeness(soak_records: list[dict]) -> dict[str, Any]:
+    indexer_runs = [r for r in soak_records if r.get("event") == "indexer_run"]
+    pause_events = [r for r in soak_records if r.get("event") == "pause_window"]
+
+    if not indexer_runs:
+        return {
+            "pass": None,
+            "reason": "No indexer_run events found — monitor may not have run.",
+        }
+
+    # Average req rate per 5-min window
+    # Build (ts, req_total) pairs and bucket by 5-min intervals
+    window_secs = 300  # 5 minutes
+    ts_buckets: dict[int, int] = defaultdict(int)  # bucket_start -> req_count
+
+    for run in indexer_runs:
+        ts_str = run.get("ts", "")
+        req_total = run.get("req_total", 0)
+        if not ts_str:
+            continue
+        try:
+            ts_epoch = int(datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp())
+        except ValueError:
+            continue
+        bucket = (ts_epoch // window_secs) * window_secs
+        ts_buckets[bucket] += req_total
+
+    max_rate_5min = 0.0
+    if ts_buckets:
+        # max requests in any 5-min window / 300s = max avg rate
+        max_rate_5min = max(count / window_secs for count in ts_buckets.values())
+
+    # Peak inflight across all runs
+    peak_inflight_observed = max((r.get("peak_inflight", 0) for r in indexer_runs), default=0)
+
+    # Error rate
+    total_reqs = sum(r.get("req_total", 0) for r in indexer_runs)
+    total_errors = sum(r.get("req_5xx", 0) + r.get("req_errors", 0) for r in indexer_runs)
+    error_rate = (total_errors / total_reqs) if total_reqs > 0 else 0.0
+
+    # Pause window compliance: check that no indexer_run ts falls in 11:00–15:00 UTC
+    pause_violations: list[str] = []
+    for run in indexer_runs:
+        ts_str = run.get("ts", "")
+        if not ts_str:
+            continue
+        try:
+            ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            t = ts_dt.time()
+            from datetime import time as dtime
+            in_window = dtime(11, 0) <= t <= dtime(15, 0)
+            if in_window:
+                pause_violations.append(ts_str)
+        except ValueError:
+            pass
+
+    passes = {
+        "avg_rate_5min": max_rate_5min <= 1.0,
+        "peak_inflight": peak_inflight_observed <= 4,
+        "error_rate": error_rate < 0.01,
+        "pause_compliance": len(pause_violations) == 0,
+    }
+
+    overall = all(passes.values())
+
+    return {
+        "pass": overall,
+        "max_avg_rate_5min_req_s": round(max_rate_5min, 4),
+        "peak_inflight_observed": peak_inflight_observed,
+        "total_requests": total_reqs,
+        "total_errors": total_errors,
+        "error_rate_pct": round(error_rate * 100, 3),
+        "pause_window_violations": pause_violations,
+        "pause_events_logged": len(pause_events),
+        "sub_criteria": passes,
+        "reason": (
+            "All politeness criteria met."
+            if overall else
+            "FAIL: " + "; ".join(
+                k for k, v in passes.items() if not v
+            )
+        ),
+    }
+
+
+# D2: FTS parity
+def eval_parity(soak_records: list[dict]) -> dict[str, Any]:
+    parity_events = [r for r in soak_records if r.get("event") == "parity_check"]
+    # Also look at fts_parity_delta from indexer_run events
+    indexer_parities = [
+        {"ts": r.get("ts"), "fts_delta": r.get("fts_parity_delta")}
+        for r in soak_records
+        if r.get("event") == "indexer_run" and "fts_parity_delta" in r
+    ]
+
+    all_deltas: list[dict] = []
+    for e in parity_events:
+        all_deltas.append({"ts": e.get("ts", ""), "delta": e.get("fts_delta"), "source": "parity_check"})
+    for e in indexer_parities:
+        all_deltas.append({"ts": e["ts"] or "", "delta": e["fts_delta"], "source": "indexer_run"})
+
+    failures = [d for d in all_deltas if d["delta"] is not None and d["delta"] != 0]
+
+    return {
+        "pass": len(failures) == 0 and len(all_deltas) > 0,
+        "total_checks": len(all_deltas),
+        "failures": failures,
+        "reason": (
+            "All parity checks returned 0 (FTS in sync)."
+            if not failures
+            else f"FAIL: {len(failures)} non-zero delta(s): " +
+                 "; ".join(f"ts={d['ts']} delta={d['delta']}" for d in failures[:3])
+        ),
+    }
+
+
+# D3: Latency
+def eval_latency(smoke_records: list[dict]) -> dict[str, Any]:
+    search_calls = [
+        r for r in smoke_records
+        if r.get("event") == "smoke" and "latency_ms" in r
+    ]
+
+    if len(search_calls) < 2:
+        return {
+            "pass": None,
+            "reason": f"Insufficient smoke calls ({len(search_calls)}) — need ≥ 2 to evaluate.",
+            "call_count": len(search_calls),
+        }
+
+    lats = sorted(r["latency_ms"] for r in search_calls if r.get("status") == 200)
+    if not lats:
+        return {
+            "pass": False,
+            "reason": "No successful smoke calls (status 200) found.",
+            "call_count": len(search_calls),
+        }
+
+    def pct(p: float) -> float:
+        idx = int(len(lats) * p / 100)
+        return lats[min(idx, len(lats) - 1)]
+
+    p50 = round(pct(50), 1)
+    p95 = round(pct(95), 1)
+    p99 = round(pct(99), 1)
+
+    passes = p95 < 50 and p99 < 200
+
+    return {
+        "pass": passes,
+        "call_count": len(search_calls),
+        "successful_calls": len(lats),
+        "p50_ms": p50,
+        "p95_ms": p95,
+        "p99_ms": p99,
+        "min_ms": lats[0],
+        "max_ms": lats[-1],
+        "mean_ms": round(mean(lats), 1),
+        "reason": (
+            f"p95={p95}ms < 50ms, p99={p99}ms < 200ms — latency envelope met."
+            if passes else
+            f"FAIL: p95={p95}ms (threshold 50ms), p99={p99}ms (threshold 200ms)"
+        ),
+    }
+
+
+# D4: Coverage
+def eval_coverage(soak_records: list[dict], baseline_count: int, db_path: str) -> dict[str, Any]:
+    # Prefer live DB count; fall back to max seen in soak log
+    actual_mp4_count: int | None = None
+
+    if Path(db_path).exists():
+        try:
+            conn = sqlite3.connect(db_path)
+            row = conn.execute(
+                "SELECT COUNT(*) FROM mmingest_files "
+                "WHERE prefix LIKE '2WLI%' AND file_type = 'mp4'"
+            ).fetchone()
+            actual_mp4_count = row[0] if row else 0
+            conn.close()
+        except sqlite3.Error as exc:
+            print(f"WARNING: DB query failed: {exc}", file=sys.stderr)
+
+    if actual_mp4_count is None:
+        # Fall back to log
+        wli_counts = [
+            r.get("mmingest_files_count_2wli", 0)
+            for r in soak_records
+            if r.get("event") == "parity_check"
+        ]
+        actual_mp4_count = max(wli_counts, default=0)
+
+    if baseline_count == 0:
+        return {
+            "pass": None,
+            "reason": "Baseline count is 0 — no baseline was captured (see Section A6).",
+            "actual_mp4_count": actual_mp4_count,
+            "baseline_count": 0,
+        }
+
+    diff_pct = abs(actual_mp4_count - baseline_count) / baseline_count
+    passes = diff_pct <= 0.05
+
+    return {
+        "pass": passes,
+        "actual_mp4_count": actual_mp4_count,
+        "baseline_count": baseline_count,
+        "diff_pct": round(diff_pct * 100, 2),
+        "reason": (
+            f"Coverage {round((actual_mp4_count / baseline_count) * 100, 1)}% "
+            f"(actual={actual_mp4_count} baseline={baseline_count} diff={round(diff_pct*100,2)}%)"
+            if passes else
+            f"FAIL: diff={round(diff_pct*100,2)}% > 5% threshold "
+            f"(actual={actual_mp4_count} baseline={baseline_count})"
+        ),
+    }
+
+
+# D5: No regression
+def eval_regression(smoke_records: list[dict]) -> dict[str, Any]:
+    regression_checks = [r for r in smoke_records if r.get("event") == "regression_check"]
+
+    if not regression_checks:
+        return {
+            "pass": None,
+            "reason": "No regression check events found — smoke script may not have run.",
+        }
+
+    failures = [r for r in regression_checks if r.get("outcome") != "pass"]
+
+    endpoint_summary: dict[str, dict] = {}
+    for r in regression_checks:
+        ep = r.get("endpoint", "?")
+        if ep not in endpoint_summary:
+            endpoint_summary[ep] = {"checks": 0, "failures": 0, "last_status": None}
+        endpoint_summary[ep]["checks"] += 1
+        endpoint_summary[ep]["last_status"] = r.get("status")
+        if r.get("outcome") != "pass":
+            endpoint_summary[ep]["failures"] += 1
+
+    passes = len(failures) == 0
+
+    return {
+        "pass": passes,
+        "total_checks": len(regression_checks),
+        "failed_checks": len(failures),
+        "endpoints": endpoint_summary,
+        "reason": (
+            "All legacy endpoints returned 200 throughout the soak."
+            if passes else
+            f"FAIL: {len(failures)} failed regression checks — " +
+            ", ".join(f"{r.get('endpoint')} status={r.get('status')}" for r in failures[:3])
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tunable defaults snapshot
+# ---------------------------------------------------------------------------
+
+def compute_tunables(soak_records: list[dict]) -> dict[str, Any]:
+    indexer_runs = [r for r in soak_records if r.get("event") == "indexer_run"]
+
+    if not indexer_runs:
+        return {}
+
+    all_reqs = sum(r.get("req_total", 0) for r in indexer_runs)
+    all_elapsed = sum(r.get("elapsed_s", 0) for r in indexer_runs)
+    avg_rate = (all_reqs / all_elapsed) if all_elapsed > 0 else 0.0
+
+    peak_inflight = max((r.get("peak_inflight", 0) for r in indexer_runs), default=0)
+
+    # Recommend max_concurrent: floor to nearest power of 2, cap at observed peak
+    recommended_concurrent = 1
+    for p2 in [4, 2, 1]:
+        if peak_inflight >= p2:
+            recommended_concurrent = p2
+            break
+
+    # Recommend rate: 80% of observed max instantaneous rate
+    # Use the max single-run req rate as proxy
+    per_run_rates = [
+        r.get("req_total", 0) / r.get("elapsed_s", 1)
+        for r in indexer_runs
+        if r.get("elapsed_s", 0) > 0
+    ]
+    max_burst_rate = max(per_run_rates, default=0.0)
+    recommended_rate = round(min(max_burst_rate * 0.8, 1.0), 2)  # never exceed 1.0 for safety
+
+    return {
+        "observed_avg_req_rate_s": round(avg_rate, 4),
+        "observed_peak_inflight": peak_inflight,
+        "recommended_max_concurrent": recommended_concurrent,
+        "recommended_rate_per_second": recommended_rate,
+        "total_indexer_runs": len(indexer_runs),
+        "total_requests_to_mmingest": all_reqs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown report builder
+# ---------------------------------------------------------------------------
+
+PASS_ICON = "GO"
+FAIL_ICON = "NO-GO"
+WARN_ICON = "WARN"
+
+
+def criterion_header(name: str, result: dict[str, Any]) -> str:
+    p = result.get("pass")
+    if p is True:
+        icon = PASS_ICON
+    elif p is False:
+        icon = FAIL_ICON
+    else:
+        icon = WARN_ICON
+    return f"### [{icon}] {name}"
+
+
+def build_report(
+    soak_records: list[dict],
+    smoke_records: list[dict],
+    politeness: dict,
+    parity: dict,
+    latency: dict,
+    coverage: dict,
+    regression: dict,
+    tunables: dict,
+    baseline_count: int,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Overall verdict
+    results = [politeness, parity, latency, coverage, regression]
+    all_pass = all(r.get("pass") is True for r in results)
+    any_fail = any(r.get("pass") is False for r in results)
+
+    if all_pass:
+        verdict = "**OVERALL: GO**"
+        verdict_detail = "All five acceptance criteria passed. Ready for production rollout."
+    elif any_fail:
+        verdict = "**OVERALL: NO-GO**"
+        failing = []
+        if politeness.get("pass") is False:
+            failing.append("Politeness")
+        if parity.get("pass") is False:
+            failing.append("FTS Parity")
+        if latency.get("pass") is False:
+            failing.append("Latency")
+        if coverage.get("pass") is False:
+            failing.append("Coverage")
+        if regression.get("pass") is False:
+            failing.append("Regression")
+        verdict_detail = f"Failing criteria: {', '.join(failing)}. See Section D in runbook for remediation steps."
+    else:
+        verdict = "**OVERALL: INCOMPLETE**"
+        verdict_detail = "Some criteria could not be evaluated (missing data). Re-check after a full 24h soak."
+
+    soak_start_event = next((r for r in soak_records if r.get("event") == "soak_start"), {})
+    soak_end_event = next((r for r in soak_records if r.get("event") == "soak_end"), {})
+    total_smoke_calls = sum(1 for r in smoke_records if r.get("event") == "smoke")
+    total_indexer_runs = sum(1 for r in soak_records if r.get("event") == "indexer_run")
+
+    lines = [
+        "# Sprint 5 Staging Soak Report",
+        "",
+        f"Generated: {now}",
+        "",
+        f"## {verdict}",
+        "",
+        verdict_detail,
+        "",
+        "---",
+        "",
+        "## Soak Summary",
+        "",
+        f"| Field | Value |",
+        f"|-------|-------|",
+        f"| Soak started | {soak_start_event.get('ts', 'unknown')} |",
+        f"| Soak ended | {soak_end_event.get('ts', 'unknown')} |",
+        f"| Directory crawled | `/wisconsinlife/` depth 1 (prefix `2WLI`) |",
+        f"| Total indexer runs | {total_indexer_runs} |",
+        f"| Total smoke calls | {total_smoke_calls} |",
+        f"| Baseline MP4 count | {baseline_count} |",
+        "",
+        "---",
+        "",
+        "## Section D — Acceptance Criteria",
+        "",
+    ]
+
+    # D1 Politeness
+    lines += [
+        criterion_header("D1. Politeness", politeness),
+        "",
+        f"**Result:** {politeness.get('reason', '(no data)')}",
+        "",
+        "| Criterion | Threshold | Observed | Pass? |",
+        "|-----------|-----------|----------|-------|",
+        f"| Avg req rate (5-min window) | ≤ 1.0 req/s | "
+        f"{politeness.get('max_avg_rate_5min_req_s', '?')} req/s | "
+        f"{'yes' if politeness.get('sub_criteria', {}).get('avg_rate_5min') else 'NO'} |",
+        f"| Peak in-flight concurrency | ≤ 4 | "
+        f"{politeness.get('peak_inflight_observed', '?')} | "
+        f"{'yes' if politeness.get('sub_criteria', {}).get('peak_inflight') else 'NO'} |",
+        f"| Error rate | < 1% | "
+        f"{politeness.get('error_rate_pct', '?')}% | "
+        f"{'yes' if politeness.get('sub_criteria', {}).get('error_rate') else 'NO'} |",
+        f"| Pause window compliance | Zero requests 11:00–15:00 UTC | "
+        f"{len(politeness.get('pause_window_violations', []))} violation(s) | "
+        f"{'yes' if politeness.get('sub_criteria', {}).get('pause_compliance') else 'NO'} |",
+        "",
+        f"Total requests to mmingest: {politeness.get('total_requests', '?')}  ",
+        f"Total errors (5xx + connect): {politeness.get('total_errors', '?')}  ",
+        f"Pause events logged: {politeness.get('pause_events_logged', '?')}",
+        "",
+    ]
+
+    # D2 Parity
+    lines += [
+        criterion_header("D2. FTS Parity", parity),
+        "",
+        f"**Result:** {parity.get('reason', '(no data)')}",
+        "",
+        f"Total parity checks: {parity.get('total_checks', 0)}  ",
+        f"Failed checks (non-zero delta): {len(parity.get('failures', []))}",
+        "",
+    ]
+    if parity.get("failures"):
+        lines += [
+            "**Failed checks:**",
+            "",
+        ]
+        for f in parity["failures"][:5]:
+            lines.append(f"- `{f.get('ts')}` delta={f.get('delta')} (source: {f.get('source')})")
+        lines.append("")
+
+    # D3 Latency
+    lines += [
+        criterion_header("D3. Search Latency", latency),
+        "",
+        f"**Result:** {latency.get('reason', '(no data)')}",
+        "",
+        "| Metric | Threshold | Observed | Pass? |",
+        "|--------|-----------|----------|-------|",
+        f"| p95 latency | < 50ms | {latency.get('p95_ms', '?')}ms | "
+        f"{'yes' if latency.get('p95_ms', 9999) < 50 else 'NO'} |",
+        f"| p99 latency | < 200ms | {latency.get('p99_ms', '?')}ms | "
+        f"{'yes' if latency.get('p99_ms', 9999) < 200 else 'NO'} |",
+        "",
+        f"Successful smoke calls: {latency.get('successful_calls', 0)} of {latency.get('call_count', 0)}  ",
+        f"p50: {latency.get('p50_ms', '?')}ms  |  "
+        f"mean: {latency.get('mean_ms', '?')}ms  |  "
+        f"min: {latency.get('min_ms', '?')}ms  |  "
+        f"max: {latency.get('max_ms', '?')}ms",
+        "",
+    ]
+
+    # D4 Coverage
+    lines += [
+        criterion_header("D4. Coverage", coverage),
+        "",
+        f"**Result:** {coverage.get('reason', '(no data)')}",
+        "",
+        f"| Metric | Value |",
+        f"|--------|-------|",
+        f"| Baseline MP4 count (manual curl) | {coverage.get('baseline_count', '?')} |",
+        f"| Observed MP4 count in `mmingest_files` (prefix=2WLI) | {coverage.get('actual_mp4_count', '?')} |",
+        f"| Difference | {coverage.get('diff_pct', '?')}% |",
+        f"| Threshold | ≤ 5% |",
+        "",
+    ]
+
+    # D5 Regression
+    lines += [
+        criterion_header("D5. No Regression", regression),
+        "",
+        f"**Result:** {regression.get('reason', '(no data)')}",
+        "",
+    ]
+    if regression.get("endpoints"):
+        lines += [
+            "| Endpoint | Checks | Failures | Last Status |",
+            "|----------|--------|----------|-------------|",
+        ]
+        for ep, data in regression["endpoints"].items():
+            lines.append(
+                f"| `{ep}` | {data['checks']} | {data['failures']} | {data['last_status']} |"
+            )
+        lines.append("")
+
+    # Tunable defaults
+    lines += [
+        "---",
+        "",
+        "## Tunable Defaults Snapshot",
+        "",
+        "Empirical values observed during the soak — use as production starting point.",
+        "",
+        "| Parameter | Soak Observed | Recommended for Production |",
+        "|-----------|--------------|---------------------------|",
+        f"| `max_concurrent` | {tunables.get('observed_peak_inflight', '?')} | {tunables.get('recommended_max_concurrent', '?')} |",
+        f"| `rate_per_second` | {tunables.get('observed_avg_req_rate_s', '?')} avg | {tunables.get('recommended_rate_per_second', '?')} |",
+        f"| `pause_window` (UTC) | 11:00–15:00 | 11:00–15:00 (= 06:00–10:00 CDT broadcast peak) |",
+        f"| `directories` | `['/wisconsinlife/']` | `['/']` (full crawl for production) |",
+        f"| `delta_walk_interval_hours` | 1h (soak) | 1h (keep for prod; mmingest is stable) |",
+        "",
+        f"Total requests to mmingest during soak: {tunables.get('total_requests_to_mmingest', '?')}  ",
+        f"Total indexer runs: {tunables.get('total_indexer_runs', '?')}",
+        "",
+        "---",
+        "",
+        "## Smoke Query Breakdown",
+        "",
+    ]
+
+    # Smoke query summary
+    by_query: dict[str, list[dict]] = defaultdict(list)
+    for r in smoke_records:
+        if r.get("event") == "smoke":
+            q = r.get("query", "?")
+            by_query[q].append(r)
+
+    if by_query:
+        lines += [
+            "| Query | Calls | Pass | Warn | Fail | Avg Hits | p50 ms | p95 ms |",
+            "|-------|-------|------|------|------|----------|--------|--------|",
+        ]
+        for q, calls in by_query.items():
+            outcomes = [c.get("outcome", "?") for c in calls]
+            n_pass = outcomes.count("pass")
+            n_warn = outcomes.count("warn_no_hits")
+            n_fail = outcomes.count("fail")
+            lats = [c.get("latency_ms", 0) for c in calls if c.get("status") == 200]
+            hits = [c.get("hits", 0) for c in calls if c.get("hits", -1) >= 0]
+            avg_hits = round(mean(hits), 1) if hits else 0
+            lats_s = sorted(lats)
+            p50 = lats_s[len(lats_s)//2] if lats_s else "?"
+            p95 = lats_s[min(int(len(lats_s)*0.95), len(lats_s)-1)] if lats_s else "?"
+            q_display = q[:40] + "..." if len(q) > 40 else q
+            lines.append(f"| `{q_display}` | {len(calls)} | {n_pass} | {n_warn} | {n_fail} | {avg_hits} | {p50} | {p95} |")
+        lines.append("")
+    else:
+        lines += ["(No smoke query data found)", ""]
+
+    # Next steps
+    lines += [
+        "---",
+        "",
+        "## Next Steps",
+        "",
+    ]
+    if all_pass:
+        lines += [
+            "1. Update plan file: mark `[ ] Sprint 5 soak execution` as done.",
+            "2. Configure production scheduler with the tunable defaults above.",
+            "3. Wire `start_mmingest_scheduler()` into `api/main.py` lifespan.",
+            "4. Deploy to production (Cardigan on LXC 103, `cardigan.riechers.co`).",
+            "5. Run a first full-crawl pass from `/` and verify parity within 2h.",
+            "",
+        ]
+    elif any_fail:
+        lines += [
+            "1. Address failing criteria (see Section F of the runbook for per-criterion remediation).",
+            "2. Re-soak from scratch after fixes are verified in unit tests.",
+            "3. Do NOT proceed to production until all five criteria pass.",
+            "",
+        ]
+    else:
+        lines += [
+            "1. Ensure the full 24h soak ran (check `soak_start` and `soak_end` events in JSONL).",
+            "2. Verify the smoke script ran every 30 min (48 smoke calls expected).",
+            "3. Verify the parity check ran at T+0, T+6, T+12, T+18, T+24 (5 checks expected).",
+            "4. Re-run this report after confirming all data is present.",
+            "",
+        ]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Optional: matplotlib plots
+# ---------------------------------------------------------------------------
+
+def generate_plots(
+    soak_records: list[dict],
+    smoke_records: list[dict],
+    output_dir: Path,
+) -> list[str]:
+    """Generate latency and rate plots. Returns list of generated file paths."""
+    try:
+        import matplotlib  # type: ignore[import]
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt  # type: ignore[import]
+    except ImportError:
+        print("matplotlib not available — skipping plots", file=sys.stderr)
+        return []
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated: list[str] = []
+
+    # Plot 1: Smoke search latency over time
+    smoke_calls = [
+        r for r in smoke_records
+        if r.get("event") == "smoke" and r.get("status") == 200 and "ts" in r
+    ]
+    if len(smoke_calls) >= 2:
+        try:
+            xs = [datetime.fromisoformat(r["ts"].replace("Z", "+00:00")) for r in smoke_calls]
+            ys = [r["latency_ms"] for r in smoke_calls]
+            fig, ax = plt.subplots(figsize=(12, 4))
+            ax.scatter(xs, ys, s=10, alpha=0.7, label="Search latency")
+            ax.axhline(50, color="orange", linestyle="--", label="p95 threshold (50ms)")
+            ax.axhline(200, color="red", linestyle="--", label="p99 threshold (200ms)")
+            ax.set_xlabel("Time (UTC)")
+            ax.set_ylabel("Latency (ms)")
+            ax.set_title("Sprint 5 Soak — /api/mmingest/search Latency")
+            ax.legend()
+            fig.autofmt_xdate()
+            path = str(output_dir / "latency_over_time.png")
+            fig.savefig(path, dpi=100, bbox_inches="tight")
+            plt.close(fig)
+            generated.append(path)
+        except Exception as exc:
+            print(f"WARNING: latency plot failed: {exc}", file=sys.stderr)
+
+    # Plot 2: Request rate per indexer run
+    indexer_runs = [
+        r for r in soak_records
+        if r.get("event") == "indexer_run" and "ts" in r and r.get("elapsed_s", 0) > 0
+    ]
+    if len(indexer_runs) >= 2:
+        try:
+            xs = [datetime.fromisoformat(r["ts"].replace("Z", "+00:00")) for r in indexer_runs]
+            ys = [r.get("req_total", 0) / r.get("elapsed_s", 1) for r in indexer_runs]
+            fig, ax = plt.subplots(figsize=(12, 4))
+            ax.bar([x for x in range(len(xs))], ys, label="Req/s per run")
+            ax.axhline(1.0, color="red", linestyle="--", label="Threshold (1.0 req/s)")
+            ax.set_xlabel("Indexer run #")
+            ax.set_ylabel("Avg req/s during run")
+            ax.set_title("Sprint 5 Soak — mmingest Request Rate per Indexer Run")
+            ax.legend()
+            path = str(output_dir / "request_rate_per_run.png")
+            fig.savefig(path, dpi=100, bbox_inches="tight")
+            plt.close(fig)
+            generated.append(path)
+        except Exception as exc:
+            print(f"WARNING: rate plot failed: {exc}", file=sys.stderr)
+
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = parse_args()
+
+    print(f"Loading soak log: {args.soak_log}")
+    soak_records = load_jsonl(args.soak_log)
+
+    print(f"Loading smoke log: {args.smoke_log}")
+    smoke_records = load_jsonl(args.smoke_log)
+
+    print(f"Soak events: {len(soak_records)}")
+    print(f"Smoke events: {len(smoke_records)}")
+
+    # Load baseline count
+    baseline_count = 0
+    bc_path = Path(args.baseline_count)
+    if bc_path.exists():
+        try:
+            baseline_count = int(bc_path.read_text().strip())
+            print(f"Baseline MP4 count: {baseline_count}")
+        except ValueError:
+            print(f"WARNING: invalid baseline count in {args.baseline_count}", file=sys.stderr)
+    else:
+        print(f"WARNING: baseline count file not found: {args.baseline_count}", file=sys.stderr)
+
+    # Evaluate criteria
+    print("\nEvaluating acceptance criteria...")
+    politeness = eval_politeness(soak_records)
+    parity     = eval_parity(soak_records)
+    latency    = eval_latency(smoke_records)
+    coverage   = eval_coverage(soak_records, baseline_count, args.db)
+    regression = eval_regression(smoke_records)
+    tunables   = compute_tunables(soak_records)
+
+    # Print summary
+    print(f"\nD1 Politeness:  {'PASS' if politeness.get('pass') else ('FAIL' if politeness.get('pass') is False else 'INCOMPLETE')}")
+    print(f"D2 Parity:      {'PASS' if parity.get('pass') else ('FAIL' if parity.get('pass') is False else 'INCOMPLETE')}")
+    print(f"D3 Latency:     {'PASS' if latency.get('pass') else ('FAIL' if latency.get('pass') is False else 'INCOMPLETE')}")
+    print(f"D4 Coverage:    {'PASS' if coverage.get('pass') else ('FAIL' if coverage.get('pass') is False else 'INCOMPLETE')}")
+    print(f"D5 Regression:  {'PASS' if regression.get('pass') else ('FAIL' if regression.get('pass') is False else 'INCOMPLETE')}")
+
+    # Build report
+    report = build_report(
+        soak_records, smoke_records,
+        politeness, parity, latency, coverage, regression,
+        tunables, baseline_count,
+    )
+
+    # Write report
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report)
+    print(f"\nReport written to: {output_path}")
+
+    # Optional plots
+    if not args.no_plots:
+        plots_dir = output_path.parent / "sprint-5-plots"
+        generated = generate_plots(soak_records, smoke_records, plots_dir)
+        if generated:
+            print(f"Plots written to: {plots_dir}/")
+            for p in generated:
+                print(f"  {p}")
+
+    # Exit with non-zero if any criterion failed
+    if any(r.get("pass") is False for r in [politeness, parity, latency, coverage, regression]):
+        print("\nVERDICT: NO-GO — see report for details.")
+        sys.exit(1)
+    elif all(r.get("pass") is True for r in [politeness, parity, latency, coverage, regression]):
+        print("\nVERDICT: GO — all criteria passed.")
+        sys.exit(0)
+    else:
+        print("\nVERDICT: INCOMPLETE — some criteria could not be evaluated.")
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sprint5_soak_report.py
+++ b/scripts/sprint5_soak_report.py
@@ -16,38 +16,39 @@ Usage:
 Optional matplotlib support: if matplotlib is installed, latency/rate plots
 are written to planning/sprint-5-plots/.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import sqlite3
 import sys
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from statistics import mean, median
+from statistics import mean
 from typing import Any
-
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--soak-log",       default="/tmp/sprint5-soak-log.jsonl")
-    p.add_argument("--smoke-log",      default="/tmp/sprint5-smoke-log.jsonl")
+    p.add_argument("--soak-log", default="/tmp/sprint5-soak-log.jsonl")
+    p.add_argument("--smoke-log", default="/tmp/sprint5-smoke-log.jsonl")
     p.add_argument("--baseline-count", default="/tmp/sprint5-baseline-count.txt")
-    p.add_argument("--output",         default="planning/sprint-5-soak-report.md")
-    p.add_argument("--db",             default="dashboard.db")
-    p.add_argument("--no-plots",       action="store_true", help="Skip matplotlib plots")
+    p.add_argument("--output", default="planning/sprint-5-soak-report.md")
+    p.add_argument("--db", default="dashboard.db")
+    p.add_argument("--no-plots", action="store_true", help="Skip matplotlib plots")
     return p.parse_args()
 
 
 # ---------------------------------------------------------------------------
 # JSONL loading
 # ---------------------------------------------------------------------------
+
 
 def load_jsonl(path: str) -> list[dict]:
     records: list[dict] = []
@@ -70,6 +71,7 @@ def load_jsonl(path: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Section D criterion evaluators
 # ---------------------------------------------------------------------------
+
 
 # D1: Politeness
 def eval_politeness(soak_records: list[dict]) -> dict[str, Any]:
@@ -122,6 +124,7 @@ def eval_politeness(soak_records: list[dict]) -> dict[str, Any]:
             ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
             t = ts_dt.time()
             from datetime import time as dtime
+
             in_window = dtime(11, 0) <= t <= dtime(15, 0)
             if in_window:
                 pause_violations.append(ts_str)
@@ -148,11 +151,7 @@ def eval_politeness(soak_records: list[dict]) -> dict[str, Any]:
         "pause_events_logged": len(pause_events),
         "sub_criteria": passes,
         "reason": (
-            "All politeness criteria met."
-            if overall else
-            "FAIL: " + "; ".join(
-                k for k, v in passes.items() if not v
-            )
+            "All politeness criteria met." if overall else "FAIL: " + "; ".join(k for k, v in passes.items() if not v)
         ),
     }
 
@@ -182,18 +181,15 @@ def eval_parity(soak_records: list[dict]) -> dict[str, Any]:
         "reason": (
             "All parity checks returned 0 (FTS in sync)."
             if not failures
-            else f"FAIL: {len(failures)} non-zero delta(s): " +
-                 "; ".join(f"ts={d['ts']} delta={d['delta']}" for d in failures[:3])
+            else f"FAIL: {len(failures)} non-zero delta(s): "
+            + "; ".join(f"ts={d['ts']} delta={d['delta']}" for d in failures[:3])
         ),
     }
 
 
 # D3: Latency
 def eval_latency(smoke_records: list[dict]) -> dict[str, Any]:
-    search_calls = [
-        r for r in smoke_records
-        if r.get("event") == "smoke" and "latency_ms" in r
-    ]
+    search_calls = [r for r in smoke_records if r.get("event") == "smoke" and "latency_ms" in r]
 
     if len(search_calls) < 2:
         return {
@@ -232,8 +228,8 @@ def eval_latency(smoke_records: list[dict]) -> dict[str, Any]:
         "mean_ms": round(mean(lats), 1),
         "reason": (
             f"p95={p95}ms < 50ms, p99={p99}ms < 200ms — latency envelope met."
-            if passes else
-            f"FAIL: p95={p95}ms (threshold 50ms), p99={p99}ms (threshold 200ms)"
+            if passes
+            else f"FAIL: p95={p95}ms (threshold 50ms), p99={p99}ms (threshold 200ms)"
         ),
     }
 
@@ -247,8 +243,7 @@ def eval_coverage(soak_records: list[dict], baseline_count: int, db_path: str) -
         try:
             conn = sqlite3.connect(db_path)
             row = conn.execute(
-                "SELECT COUNT(*) FROM mmingest_files "
-                "WHERE prefix LIKE '2WLI%' AND file_type = 'mp4'"
+                "SELECT COUNT(*) FROM mmingest_files " "WHERE prefix LIKE '2WLI%' AND file_type = 'mp4'"
             ).fetchone()
             actual_mp4_count = row[0] if row else 0
             conn.close()
@@ -257,11 +252,7 @@ def eval_coverage(soak_records: list[dict], baseline_count: int, db_path: str) -
 
     if actual_mp4_count is None:
         # Fall back to log
-        wli_counts = [
-            r.get("mmingest_files_count_2wli", 0)
-            for r in soak_records
-            if r.get("event") == "parity_check"
-        ]
+        wli_counts = [r.get("mmingest_files_count_2wli", 0) for r in soak_records if r.get("event") == "parity_check"]
         actual_mp4_count = max(wli_counts, default=0)
 
     if baseline_count == 0:
@@ -283,8 +274,8 @@ def eval_coverage(soak_records: list[dict], baseline_count: int, db_path: str) -
         "reason": (
             f"Coverage {round((actual_mp4_count / baseline_count) * 100, 1)}% "
             f"(actual={actual_mp4_count} baseline={baseline_count} diff={round(diff_pct*100,2)}%)"
-            if passes else
-            f"FAIL: diff={round(diff_pct*100,2)}% > 5% threshold "
+            if passes
+            else f"FAIL: diff={round(diff_pct*100,2)}% > 5% threshold "
             f"(actual={actual_mp4_count} baseline={baseline_count})"
         ),
     }
@@ -321,9 +312,9 @@ def eval_regression(smoke_records: list[dict]) -> dict[str, Any]:
         "endpoints": endpoint_summary,
         "reason": (
             "All legacy endpoints returned 200 throughout the soak."
-            if passes else
-            f"FAIL: {len(failures)} failed regression checks — " +
-            ", ".join(f"{r.get('endpoint')} status={r.get('status')}" for r in failures[:3])
+            if passes
+            else f"FAIL: {len(failures)} failed regression checks — "
+            + ", ".join(f"{r.get('endpoint')} status={r.get('status')}" for r in failures[:3])
         ),
     }
 
@@ -331,6 +322,7 @@ def eval_regression(smoke_records: list[dict]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Tunable defaults snapshot
 # ---------------------------------------------------------------------------
+
 
 def compute_tunables(soak_records: list[dict]) -> dict[str, Any]:
     indexer_runs = [r for r in soak_records if r.get("event") == "indexer_run"]
@@ -353,11 +345,7 @@ def compute_tunables(soak_records: list[dict]) -> dict[str, Any]:
 
     # Recommend rate: 80% of observed max instantaneous rate
     # Use the max single-run req rate as proxy
-    per_run_rates = [
-        r.get("req_total", 0) / r.get("elapsed_s", 1)
-        for r in indexer_runs
-        if r.get("elapsed_s", 0) > 0
-    ]
+    per_run_rates = [r.get("req_total", 0) / r.get("elapsed_s", 1) for r in indexer_runs if r.get("elapsed_s", 0) > 0]
     max_burst_rate = max(per_run_rates, default=0.0)
     recommended_rate = round(min(max_burst_rate * 0.8, 1.0), 2)  # never exceed 1.0 for safety
 
@@ -448,11 +436,11 @@ def build_report(
         "",
         "## Soak Summary",
         "",
-        f"| Field | Value |",
-        f"|-------|-------|",
+        "| Field | Value |",
+        "|-------|-------|",
         f"| Soak started | {soak_start_event.get('ts', 'unknown')} |",
         f"| Soak ended | {soak_end_event.get('ts', 'unknown')} |",
-        f"| Directory crawled | `/wisconsinlife/` depth 1 (prefix `2WLI`) |",
+        "| Directory crawled | `/wisconsinlife/` depth 1 (prefix `2WLI`) |",
         f"| Total indexer runs | {total_indexer_runs} |",
         f"| Total smoke calls | {total_smoke_calls} |",
         f"| Baseline MP4 count | {baseline_count} |",
@@ -536,12 +524,12 @@ def build_report(
         "",
         f"**Result:** {coverage.get('reason', '(no data)')}",
         "",
-        f"| Metric | Value |",
-        f"|--------|-------|",
+        "| Metric | Value |",
+        "|--------|-------|",
         f"| Baseline MP4 count (manual curl) | {coverage.get('baseline_count', '?')} |",
         f"| Observed MP4 count in `mmingest_files` (prefix=2WLI) | {coverage.get('actual_mp4_count', '?')} |",
         f"| Difference | {coverage.get('diff_pct', '?')}% |",
-        f"| Threshold | ≤ 5% |",
+        "| Threshold | ≤ 5% |",
         "",
     ]
 
@@ -558,9 +546,7 @@ def build_report(
             "|----------|--------|----------|-------------|",
         ]
         for ep, data in regression["endpoints"].items():
-            lines.append(
-                f"| `{ep}` | {data['checks']} | {data['failures']} | {data['last_status']} |"
-            )
+            lines.append(f"| `{ep}` | {data['checks']} | {data['failures']} | {data['last_status']} |")
         lines.append("")
 
     # Tunable defaults
@@ -575,9 +561,9 @@ def build_report(
         "|-----------|--------------|---------------------------|",
         f"| `max_concurrent` | {tunables.get('observed_peak_inflight', '?')} | {tunables.get('recommended_max_concurrent', '?')} |",
         f"| `rate_per_second` | {tunables.get('observed_avg_req_rate_s', '?')} avg | {tunables.get('recommended_rate_per_second', '?')} |",
-        f"| `pause_window` (UTC) | 11:00–15:00 | 11:00–15:00 (= 06:00–10:00 CDT broadcast peak) |",
-        f"| `directories` | `['/wisconsinlife/']` | `['/']` (full crawl for production) |",
-        f"| `delta_walk_interval_hours` | 1h (soak) | 1h (keep for prod; mmingest is stable) |",
+        "| `pause_window` (UTC) | 11:00–15:00 | 11:00–15:00 (= 06:00–10:00 CDT broadcast peak) |",
+        "| `directories` | `['/wisconsinlife/']` | `['/']` (full crawl for production) |",
+        "| `delta_walk_interval_hours` | 1h (soak) | 1h (keep for prod; mmingest is stable) |",
         "",
         f"Total requests to mmingest during soak: {tunables.get('total_requests_to_mmingest', '?')}  ",
         f"Total indexer runs: {tunables.get('total_indexer_runs', '?')}",
@@ -609,10 +595,12 @@ def build_report(
             hits = [c.get("hits", 0) for c in calls if c.get("hits", -1) >= 0]
             avg_hits = round(mean(hits), 1) if hits else 0
             lats_s = sorted(lats)
-            p50 = lats_s[len(lats_s)//2] if lats_s else "?"
-            p95 = lats_s[min(int(len(lats_s)*0.95), len(lats_s)-1)] if lats_s else "?"
+            p50 = lats_s[len(lats_s) // 2] if lats_s else "?"
+            p95 = lats_s[min(int(len(lats_s) * 0.95), len(lats_s) - 1)] if lats_s else "?"
             q_display = q[:40] + "..." if len(q) > 40 else q
-            lines.append(f"| `{q_display}` | {len(calls)} | {n_pass} | {n_warn} | {n_fail} | {avg_hits} | {p50} | {p95} |")
+            lines.append(
+                f"| `{q_display}` | {len(calls)} | {n_pass} | {n_warn} | {n_fail} | {avg_hits} | {p50} | {p95} |"
+            )
         lines.append("")
     else:
         lines += ["(No smoke query data found)", ""]
@@ -656,6 +644,7 @@ def build_report(
 # Optional: matplotlib plots
 # ---------------------------------------------------------------------------
 
+
 def generate_plots(
     soak_records: list[dict],
     smoke_records: list[dict],
@@ -664,6 +653,7 @@ def generate_plots(
     """Generate latency and rate plots. Returns list of generated file paths."""
     try:
         import matplotlib  # type: ignore[import]
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt  # type: ignore[import]
     except ImportError:
@@ -674,10 +664,7 @@ def generate_plots(
     generated: list[str] = []
 
     # Plot 1: Smoke search latency over time
-    smoke_calls = [
-        r for r in smoke_records
-        if r.get("event") == "smoke" and r.get("status") == 200 and "ts" in r
-    ]
+    smoke_calls = [r for r in smoke_records if r.get("event") == "smoke" and r.get("status") == 200 and "ts" in r]
     if len(smoke_calls) >= 2:
         try:
             xs = [datetime.fromisoformat(r["ts"].replace("Z", "+00:00")) for r in smoke_calls]
@@ -700,8 +687,7 @@ def generate_plots(
 
     # Plot 2: Request rate per indexer run
     indexer_runs = [
-        r for r in soak_records
-        if r.get("event") == "indexer_run" and "ts" in r and r.get("elapsed_s", 0) > 0
+        r for r in soak_records if r.get("event") == "indexer_run" and "ts" in r and r.get("elapsed_s", 0) > 0
     ]
     if len(indexer_runs) >= 2:
         try:
@@ -727,6 +713,7 @@ def generate_plots(
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     args = parse_args()
@@ -755,24 +742,40 @@ def main() -> None:
     # Evaluate criteria
     print("\nEvaluating acceptance criteria...")
     politeness = eval_politeness(soak_records)
-    parity     = eval_parity(soak_records)
-    latency    = eval_latency(smoke_records)
-    coverage   = eval_coverage(soak_records, baseline_count, args.db)
+    parity = eval_parity(soak_records)
+    latency = eval_latency(smoke_records)
+    coverage = eval_coverage(soak_records, baseline_count, args.db)
     regression = eval_regression(smoke_records)
-    tunables   = compute_tunables(soak_records)
+    tunables = compute_tunables(soak_records)
 
     # Print summary
-    print(f"\nD1 Politeness:  {'PASS' if politeness.get('pass') else ('FAIL' if politeness.get('pass') is False else 'INCOMPLETE')}")
-    print(f"D2 Parity:      {'PASS' if parity.get('pass') else ('FAIL' if parity.get('pass') is False else 'INCOMPLETE')}")
-    print(f"D3 Latency:     {'PASS' if latency.get('pass') else ('FAIL' if latency.get('pass') is False else 'INCOMPLETE')}")
-    print(f"D4 Coverage:    {'PASS' if coverage.get('pass') else ('FAIL' if coverage.get('pass') is False else 'INCOMPLETE')}")
-    print(f"D5 Regression:  {'PASS' if regression.get('pass') else ('FAIL' if regression.get('pass') is False else 'INCOMPLETE')}")
+    print(
+        f"\nD1 Politeness:  {'PASS' if politeness.get('pass') else ('FAIL' if politeness.get('pass') is False else 'INCOMPLETE')}"
+    )
+    print(
+        f"D2 Parity:      {'PASS' if parity.get('pass') else ('FAIL' if parity.get('pass') is False else 'INCOMPLETE')}"
+    )
+    print(
+        f"D3 Latency:     {'PASS' if latency.get('pass') else ('FAIL' if latency.get('pass') is False else 'INCOMPLETE')}"
+    )
+    print(
+        f"D4 Coverage:    {'PASS' if coverage.get('pass') else ('FAIL' if coverage.get('pass') is False else 'INCOMPLETE')}"
+    )
+    print(
+        f"D5 Regression:  {'PASS' if regression.get('pass') else ('FAIL' if regression.get('pass') is False else 'INCOMPLETE')}"
+    )
 
     # Build report
     report = build_report(
-        soak_records, smoke_records,
-        politeness, parity, latency, coverage, regression,
-        tunables, baseline_count,
+        soak_records,
+        smoke_records,
+        politeness,
+        parity,
+        latency,
+        coverage,
+        regression,
+        tunables,
+        baseline_count,
     )
 
     # Write report

--- a/tests/mcp_server/test_mmingest_tools.py
+++ b/tests/mcp_server/test_mmingest_tools.py
@@ -1,0 +1,709 @@
+"""Tests for the three mmingest MCP tools added in Sprint 4A.
+
+Verification gates covered (per sprint-4a-handoff.md):
+  Gate 1  — search_mmingest happy path: FTS5 hit with correct display fields
+  Gate 2a — search_mmingest prefix filter narrows results
+  Gate 2b — search_mmingest since filter by remote_modified_at
+  Gate 2c — search_mmingest limit cap
+  Gate 3  — search_mmingest returns same media_ids as HTTP /search
+  Gate 4  — get_mmingest_asset primary-only happy path (Airtable mocked)
+  Gate 5  — get_mmingest_asset with PLEDGE variant
+  Gate 6  — get_mmingest_asset 404 case returns friendly error TextContent
+  Gate 7  — get_mmingest_asset Airtable failure fallback (no exception)
+  Gate 8a — list_recent_mmingest_assets since= filter
+  Gate 8b — list_recent_mmingest_assets limit cap
+  Gate 9  — list_recent_mmingest_assets returns same media_ids as HTTP /recent
+  Gate 10 — search_mmingest empty-query guard
+  Gate 11 — search_mmingest FTS5 syntax error returns friendly error
+  Gate 12 — list_recent_mmingest_assets empty result returns friendly message
+
+Uses an isolated migrated SQLite DB (same fixture pattern as
+tests/api/test_mmingest_router.py).  AirtableClient is patched at the
+os.environ level so no real Airtable calls are made.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# ---------------------------------------------------------------------------
+# Shared fixture: isolated migrated DB engine
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    """Stand up a fresh DB via `alembic upgrade head`, return (engine, db_path).
+
+    Mirrors the pattern in tests/api/test_mmingest_router.py exactly.
+    """
+    fd, db_path = tempfile.mkstemp(suffix="_mmingest_mcp_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine, db_path
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# DB seed helpers (mirrors test_mmingest_router.py)
+# ---------------------------------------------------------------------------
+
+
+async def _insert_file(
+    conn,
+    *,
+    remote_url: str,
+    filename: str,
+    file_type: str = "srt",
+    media_id: str = "6POL0101",
+    prefix: str = "6POL",
+    show_name: str = "Wisconsin Politics",
+    season: str = "01",
+    episode: str = "01",
+    revision_date: str = "2026-03-19",
+    variant_tag: str | None = None,
+    superseded_by: int | None = None,
+    remote_modified_at: str | None = None,
+    first_seen_at: str | None = None,
+    airtable_record_id: str | None = None,
+) -> int:
+    await conn.execute(
+        text("""
+            INSERT INTO mmingest_files
+                (remote_url, filename, file_type, media_id, prefix, show_name,
+                 season, episode, revision_date, variant_tag, superseded_by,
+                 remote_modified_at, first_seen_at, airtable_record_id)
+            VALUES
+                (:remote_url, :filename, :file_type, :media_id, :prefix, :show_name,
+                 :season, :episode, :revision_date, :variant_tag, :superseded_by,
+                 :remote_modified_at, :first_seen_at, :airtable_record_id)
+        """),
+        {
+            "remote_url": remote_url,
+            "filename": filename,
+            "file_type": file_type,
+            "media_id": media_id,
+            "prefix": prefix,
+            "show_name": show_name,
+            "season": season,
+            "episode": episode,
+            "revision_date": revision_date,
+            "variant_tag": variant_tag,
+            "superseded_by": superseded_by,
+            "remote_modified_at": remote_modified_at or "2026-03-19T10:00:00",
+            "first_seen_at": first_seen_at or "2026-03-19T10:00:00",
+            "airtable_record_id": airtable_record_id,
+        },
+    )
+    return (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
+
+
+async def _insert_sidecar(
+    conn,
+    *,
+    file_id: int,
+    kind: str = "srt",
+    body_text: str | None = None,
+) -> int:
+    await conn.execute(
+        text("""
+            INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+            VALUES (:file_id, :kind, :body_text)
+        """),
+        {"file_id": file_id, "kind": kind, "body_text": body_text},
+    )
+    return (await conn.execute(text("SELECT last_insert_rowid()"))).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Helper: call handler with DATABASE_PATH pointing at the test DB
+# ---------------------------------------------------------------------------
+
+
+async def _call_search(db_path: str, **kwargs) -> list:
+    """Invoke handle_search_mmingest with the test DB path."""
+    from mcp_server.server import handle_search_mmingest
+
+    os.environ["DATABASE_PATH"] = db_path
+    return await handle_search_mmingest(kwargs)
+
+
+async def _call_get_asset(db_path: str, media_id: str, mock_at=None) -> list:
+    """Invoke handle_get_mmingest_asset with the test DB path.
+
+    If mock_at is provided, patch AirtableClient with it.
+    """
+    from mcp_server.server import handle_get_mmingest_asset
+
+    os.environ["DATABASE_PATH"] = db_path
+    os.environ["AIRTABLE_API_KEY"] = "pat-ci-dummy-not-real"
+
+    if mock_at is not None:
+        with patch("mcp_server.server._AirtableClient", return_value=mock_at):
+            return await handle_get_mmingest_asset({"media_id": media_id})
+    return await handle_get_mmingest_asset({"media_id": media_id})
+
+
+async def _call_recent(db_path: str, **kwargs) -> list:
+    """Invoke handle_list_recent_mmingest_assets with the test DB path."""
+    from mcp_server.server import handle_list_recent_mmingest_assets
+
+    os.environ["DATABASE_PATH"] = db_path
+    return await handle_list_recent_mmingest_assets(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — search_mmingest happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_happy_path(migrated_engine):
+    """Gate 1: FTS5 hit returns formatted markdown with correct fields."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101_REV20260319.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+            revision_date="2026-03-19",
+        )
+        await _insert_sidecar(
+            conn,
+            file_id=fid,
+            body_text="inside wisconsin politics: a look at the state legislature",
+        )
+
+    results = await _call_search(db_path, query="politics")
+    assert len(results) == 1
+    text_out = results[0].text
+    assert "6POL0101" in text_out
+    assert "6POL" in text_out
+    # snippet should contain the matched term
+    assert "politics" in text_out.lower() or "wisconsin" in text_out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Gate 2a — search_mmingest prefix filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_prefix_filter(migrated_engine):
+    """Gate 2a: prefix= filter narrows to matching show prefix only."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid_a = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+        )
+        await _insert_sidecar(conn, file_id=fid_a, body_text="wisconsin politics")
+
+        fid_b = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/WLIA0101.srt",
+            filename="WLIA0101.srt",
+            media_id="WLIA0101",
+            prefix="WLIA",
+        )
+        await _insert_sidecar(conn, file_id=fid_b, body_text="wisconsin nature politics")
+
+    results = await _call_search(db_path, query="politics", prefix="6POL")
+    text_out = results[0].text
+    assert "6POL0101" in text_out
+    assert "WLIA0101" not in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 2b — search_mmingest since filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_since_filter(migrated_engine):
+    """Gate 2b: since= filters by remote_modified_at."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid_old = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_old.srt",
+            filename="6POL0101_old.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+            remote_modified_at="2025-01-01T00:00:00",
+        )
+        await _insert_sidecar(conn, file_id=fid_old, body_text="wisconsin politics old episode")
+
+        fid_new = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102_new.srt",
+            filename="6POL0102_new.srt",
+            media_id="6POL0102",
+            prefix="6POL",
+            remote_modified_at="2026-03-19T10:00:00",
+        )
+        await _insert_sidecar(conn, file_id=fid_new, body_text="wisconsin politics new episode")
+
+    results = await _call_search(db_path, query="politics", since="2026-03-01T00:00:00")
+    text_out = results[0].text
+    assert "6POL0101" not in text_out, "Old row should be filtered out"
+    assert "6POL0102" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 2c — search_mmingest limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_limit(migrated_engine):
+    """Gate 2c: limit= caps results returned."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        for i in range(5):
+            fid = await _insert_file(
+                conn,
+                remote_url=f"http://mmingest.example/6POL010{i}.srt",
+                filename=f"6POL010{i}.srt",
+                media_id=f"6POL010{i}",
+                prefix="6POL",
+            )
+            await _insert_sidecar(conn, file_id=fid, body_text=f"wisconsin politics episode {i}")
+
+    results = await _call_search(db_path, query="politics", limit=2)
+    text_out = results[0].text
+    # "showing 2" should appear in the header line
+    assert "showing 2" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 3 — search_mmingest same results as HTTP /search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_same_results_as_http(migrated_engine):
+    """Gate 3: MCP search returns same media_ids as the HTTP router.
+
+    Both paths share the same SQL query (Option B mirror).  With identical
+    seed data, both should return the same set of media_ids for a given query.
+    """
+    import importlib
+
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        for mid, body in [
+            ("6POL0101", "inside wisconsin politics legislature"),
+            ("6POL0102", "wisconsin politics budget debate"),
+            ("2WLI0101", "wisconsin life farming nature"),
+        ]:
+            fid = await _insert_file(
+                conn,
+                remote_url=f"http://mmingest.example/{mid}.srt",
+                filename=f"{mid}.srt",
+                media_id=mid,
+                prefix=mid[:4],
+            )
+            await _insert_sidecar(conn, file_id=fid, body_text=body)
+
+    # MCP results
+    mcp_results = await _call_search(db_path, query="politics")
+    mcp_text = mcp_results[0].text
+    mcp_media_ids = {line.split()[1] for line in mcp_text.splitlines() if line.startswith("##")}
+
+    # HTTP router results (via FastAPI TestClient)
+    os.environ["DATABASE_PATH"] = db_path
+    from api.services.airtable import get_airtable_client
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(return_value={})
+
+    importlib.reload(importlib.import_module("api.routers.mmingest"))
+    importlib.reload(importlib.import_module("api.main"))
+
+    import api.main
+
+    api.main.app.dependency_overrides[get_airtable_client] = lambda: mock_at
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(api.main.app, raise_server_exceptions=True)
+    resp = client.get("/api/mmingest/search?q=politics")
+    assert resp.status_code == 200
+    http_media_ids = {r["media_id"] for r in resp.json()["results"]}
+
+    assert mcp_media_ids == http_media_ids, (
+        f"MCP and HTTP returned different media_ids:\n" f"  MCP:  {mcp_media_ids}\n" f"  HTTP: {http_media_ids}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 4 — get_mmingest_asset primary-only happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_asset_primary_only(migrated_engine):
+    """Gate 4: Primary-only asset returns primary section + Airtable record ID."""
+    engine, db_path = migrated_engine
+    at_record_id = "recTEST123456"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(
+        return_value={
+            "6POL0101": {"id": at_record_id, "fields": {"Media ID": "6POL0101"}},
+        }
+    )
+
+    results = await _call_get_asset(db_path, "6POL0101", mock_at=mock_at)
+    text_out = results[0].text
+    assert "6POL0101" in text_out
+    assert "Primary" in text_out
+    assert at_record_id in text_out
+    assert "Variants" in text_out
+    assert "Superseded" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 5 — get_mmingest_asset with PLEDGE variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_asset_with_variant(migrated_engine):
+    """Gate 5: Primary + PLEDGE variant both appear in correct sections."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101_PLEDGE.mp4",
+            filename="6POL0101_PLEDGE.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag="PLEDGE",
+            superseded_by=None,
+        )
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(return_value={})
+
+    results = await _call_get_asset(db_path, "6POL0101", mock_at=mock_at)
+    text_out = results[0].text
+    assert "Primary" in text_out
+    assert "PLEDGE" in text_out
+    assert "6POL0101_PLEDGE.mp4" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 6 — get_mmingest_asset 404 case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_asset_not_found(migrated_engine):
+    """Gate 6: Unknown media_id returns friendly error TextContent, no exception."""
+    _, db_path = migrated_engine
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(return_value={})
+
+    results = await _call_get_asset(db_path, "NONEXISTENT999", mock_at=mock_at)
+    assert len(results) == 1
+    text_out = results[0].text
+    assert "No asset found" in text_out
+    assert "NONEXISTENT999" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 7 — get_mmingest_asset Airtable failure fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_asset_airtable_failure_fallback(migrated_engine):
+    """Gate 7: Airtable exception does not crash the tool; fallback annotation shown."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            variant_tag=None,
+            superseded_by=None,
+            airtable_record_id="recCACHED000001",
+        )
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(side_effect=Exception("Airtable timeout"))
+
+    results = await _call_get_asset(db_path, "6POL0101", mock_at=mock_at)
+    assert len(results) == 1
+    text_out = results[0].text
+    # Must not raise; must return asset info
+    assert "6POL0101" in text_out
+    assert "Primary" in text_out
+    # Must note the fallback failure
+    assert "lookup failed" in text_out.lower() or "cached" in text_out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Gate 8a — list_recent_mmingest_assets since= filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_since_filter(migrated_engine):
+    """Gate 8a: since= filter returns only files arrived on/after that timestamp."""
+    engine, db_path = migrated_engine
+
+    t_old = "2026-01-01T00:00:00"
+    t_new = "2026-06-01T00:00:00"
+
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            first_seen_at=t_old,
+        )
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0102.mp4",
+            filename="6POL0102.mp4",
+            file_type="mp4",
+            media_id="6POL0102",
+            prefix="6POL",
+            first_seen_at=t_new,
+        )
+
+    results = await _call_recent(db_path, since="2026-05-01T00:00:00")
+    text_out = results[0].text
+    assert "6POL0102" in text_out
+    assert "6POL0101" not in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 8b — list_recent_mmingest_assets limit cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_limit(migrated_engine):
+    """Gate 8b: limit= caps results returned."""
+    engine, db_path = migrated_engine
+
+    now = datetime.now(timezone.utc)
+    async with engine.begin() as conn:
+        for i in range(5):
+            ts = (now - timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%S")
+            await _insert_file(
+                conn,
+                remote_url=f"http://mmingest.example/6POL010{i}.mp4",
+                filename=f"6POL010{i}.mp4",
+                file_type="mp4",
+                media_id=f"6POL010{i}",
+                prefix="6POL",
+                first_seen_at=ts,
+            )
+
+    results = await _call_recent(db_path, since="2000-01-01T00:00:00", limit=2)
+    text_out = results[0].text
+    assert "showing 2" in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 9 — list_recent_mmingest_assets same results as HTTP /recent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_same_results_as_http(migrated_engine):
+    """Gate 9: MCP recent returns same media_ids as the HTTP router for a given window."""
+    import importlib
+
+    engine, db_path = migrated_engine
+
+    # Use naive UTC timestamps (no +00:00 offset) so the URL query param is clean.
+    now = datetime.now(timezone.utc)
+    ts_new = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    ts_old = (now - timedelta(hours=48)).strftime("%Y-%m-%dT%H:%M:%S")
+    # since_str: 3 hours ago, naive format — safe in URLs and accepted by both paths
+    since_str = (now - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%S")
+
+    async with engine.begin() as conn:
+        for mid, ts in [("6POL0101", ts_new), ("6POL0102", ts_new), ("2WLI0101", ts_old)]:
+            await _insert_file(
+                conn,
+                remote_url=f"http://mmingest.example/{mid}.mp4",
+                filename=f"{mid}.mp4",
+                file_type="mp4",
+                media_id=mid,
+                prefix=mid[:4],
+                first_seen_at=ts,
+            )
+
+    # MCP results
+    mcp_results = await _call_recent(db_path, since=since_str)
+    mcp_text = mcp_results[0].text
+    # Extract media_ids from bold labels (lines starting with "- **")
+    mcp_media_ids = set()
+    for line in mcp_text.splitlines():
+        if line.startswith("- **"):
+            # "- **6POL0101 — Wisconsin Politics**" -> "6POL0101"
+            label = line[4:].split("**")[0].strip()
+            mid_part = label.split(" ")[0].split("—")[0].strip()
+            if mid_part:
+                mcp_media_ids.add(mid_part)
+
+    # HTTP router results
+    os.environ["DATABASE_PATH"] = db_path
+    from api.services.airtable import get_airtable_client
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(return_value={})
+
+    importlib.reload(importlib.import_module("api.routers.mmingest"))
+    importlib.reload(importlib.import_module("api.main"))
+
+    import api.main
+
+    api.main.app.dependency_overrides[get_airtable_client] = lambda: mock_at
+
+    from fastapi.testclient import TestClient
+
+    client = TestClient(api.main.app, raise_server_exceptions=True)
+    resp = client.get(f"/api/mmingest/recent?since={since_str}")
+    assert resp.status_code == 200
+    http_media_ids = {r["media_id"] for r in resp.json()["results"]}
+
+    assert mcp_media_ids == http_media_ids, (
+        f"MCP and HTTP returned different media_ids:\n" f"  MCP:  {mcp_media_ids}\n" f"  HTTP: {http_media_ids}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 10 — search_mmingest empty-query guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query(migrated_engine):
+    """Gate 10: Empty or whitespace-only query returns an error TextContent."""
+    _, db_path = migrated_engine
+
+    for bad_query in ["", "   "]:
+        results = await _call_search(db_path, query=bad_query)
+        assert len(results) == 1
+        assert "Error" in results[0].text
+
+
+# ---------------------------------------------------------------------------
+# Gate 11 — search_mmingest FTS5 syntax error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_fts5_syntax_error(migrated_engine):
+    """Gate 11: Malformed FTS5 query returns friendly error, does not propagate exception."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        fid = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+        )
+        await _insert_sidecar(conn, file_id=fid, body_text="wisconsin politics")
+
+    # Unbalanced quote — malformed FTS5 syntax
+    results = await _call_search(db_path, query='"unclosed phrase')
+    assert len(results) == 1
+    text_out = results[0].text
+    # Must be a friendly error, not a traceback
+    assert "Error" in text_out or "error" in text_out
+    assert "Traceback" not in text_out
+    assert "Exception" not in text_out
+
+
+# ---------------------------------------------------------------------------
+# Gate 12 — list_recent_mmingest_assets empty result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_empty_result(migrated_engine):
+    """Gate 12: No rows in window returns friendly 'no new arrivals' message."""
+    _, db_path = migrated_engine
+
+    # No seed data — nothing in the last 24h
+    results = await _call_recent(db_path)
+    assert len(results) == 1
+    text_out = results[0].text
+    assert "no new arrivals" in text_out.lower() or "No new arrivals" in text_out


### PR DESCRIPTION
## Summary

- **Runbook** (`planning/sprint-5-staging-soak.md`) — six-section operational guide covering one-time setup, 24h background monitoring, 30-min smoke testing, acceptance envelope, end-of-soak report generation, and per-failure-mode rollback guidance.
- **Monitor script** (`scripts/sprint5_soak_monitor.sh`) — drives hourly `MmingestIndexer` passes against `/wisconsinlife/` at depth 1; instruments HTTP telemetry (req total/5xx/errors, latency p50/p95/p99, peak in-flight); parity checks every 6h; honours pause window 11:00–15:00 UTC (= 06:00–10:00 CDT broadcast peak); logs JSONL to `/tmp/sprint5-soak-log.jsonl`.
- **Smoke script** (`scripts/sprint5_smoke_search.sh`) — three search queries + two regression checks every 30 min via cron; logs to `/tmp/sprint5-smoke-log.jsonl`.
- **Report generator** (`scripts/sprint5_soak_report.py`) — reads both JSONL files, evaluates all five Section D criteria, writes `planning/sprint-5-soak-report.md` with GO/NO-GO verdict; optional matplotlib plots.

## Acceptance envelope (Section D)

| Criterion | Threshold |
|-----------|-----------|
| **D1 Politeness** | avg req rate ≤ 1 req/s per 5-min window; peak inflight ≤ 4; error rate < 1%; zero requests during pause window |
| **D2 FTS Parity** | `fts_parity_delta()` = 0 at T+0h, T+6h, T+12h, T+18h, T+24h |
| **D3 Latency** | `/api/mmingest/search` p95 < 50ms, p99 < 200ms over 48 smoke calls |
| **D4 Coverage** | `mmingest_files` MP4 count for prefix `2WLI` within ±5% of manual baseline |
| **D5 Regression** | `/api/jobs` and `/api/system/health` return 200 throughout; no new ERROR-level log entries |

All five pass → **GO**. Any failure → **NO-GO** with the specific failure pinned.

## Discovery note

`start_mmingest_scheduler()` is not yet wired into `api/main.py` lifespan (the scheduler was added in S2 but the lifespan startup path only starts the legacy `ingest_scheduler`). The soak monitor drives `MmingestIndexer` directly (Option B in runbook) so the soak doesn't depend on this gap. Post-GO production wiring is a follow-up task.

## Soak config

- Directory: `/wisconsinlife/`, depth 1 (prefix `2WLI` — fresh directory, not the `/IWP/` used during S1B/S2 smoke tests)
- `max_concurrent=4`, `rate_per_second=1.0`
- Pause window: 11:00–15:00 UTC (06:00–10:00 CDT)

## Test plan

- [ ] Verify `scripts/sprint5_soak_monitor.sh` executes and emits `soak_start` JSONL event
- [ ] Verify `scripts/sprint5_smoke_search.sh` runs and emits smoke/regression events
- [ ] Verify `scripts/sprint5_soak_report.py --help` runs without error
- [ ] Vet acceptance envelope thresholds in Section D against the plan spec
- [ ] Confirm Section F rollback instructions are actionable

**DO NOT MERGE** — soak harness is reviewed before use; Mark starts the 24h soak when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)