### PR TITLE
feat(auth)+docs: WS X-API-Key fix, post-launch test plan, onboarding, QoL catalog

### DIFF
--- a/api/routers/websocket.py
+++ b/api/routers/websocket.py
@@ -105,8 +105,11 @@ async def websocket_jobs_endpoint(websocket: WebSocket, token: str = Query(defau
     Clients connect to this endpoint to receive real-time notifications
     when jobs are created, updated, or completed.
 
-    When CARDIGAN_API_KEY is set, the `token` query parameter must match.
-    When the env var is empty/absent, all connections are allowed (dev mode).
+    When CARDIGAN_API_KEY is set, the request must present the key via either
+    the ``X-API-Key`` header (preferred — the nginx WS proxy injects it, so the
+    browser never has to carry the key in client-side JS) or the ``token`` query
+    parameter (fallback for direct connections that cannot set headers). When the
+    env var is empty/absent, all connections are allowed (dev mode).
 
     Message format:
         {
@@ -116,9 +119,13 @@ async def websocket_jobs_endpoint(websocket: WebSocket, token: str = Query(defau
         }
     """
     api_key = os.environ.get("CARDIGAN_API_KEY", "")
-    if api_key and token != api_key:
-        await websocket.close(code=1008, reason="Policy Violation")
-        return
+    if api_key:
+        # Header (set by the nginx WS proxy) takes precedence; query token is a
+        # fallback for clients that cannot send headers on the WS handshake.
+        provided = websocket.headers.get("x-api-key") or token
+        if provided != api_key:
+            await websocket.close(code=1008, reason="Policy Violation")
+            return
 
     await manager.connect(websocket)
 

--- a/docs/POST_LAUNCH_TEST_PLAN.md
+++ b/docs/POST_LAUNCH_TEST_PLAN.md
@@ -48,25 +48,41 @@ are `Up`; `api` is `healthy`. The health JSON returns:
 
 ## §2 — Auth & access gate  *(smoke)*
 
-The dashboard is fronted by **Cloudflare Access** (email allowlist, magic-link)
-ahead of the Cloudflare Tunnel. The `web` image's internal nginx injects the
-shared `X-API-Key` toward the API, so the browser never handles a key.
+Two independent gates once access hardening is in place (see
+`PRODUCER_ONBOARDING.md` + the cardigan01 secure-access handoff note):
+**Cloudflare Access** at the edge (who reaches the box) and the **origin API key**
+(`CARDIGAN_API_KEY`) enforced by the app on every `/api/*` call and the WS.
 
+> Status (2026-06-10): the Cloudflare Tunnel + Access front door is being stood
+> up, and `CARDIGAN_API_KEY` is to be enabled once the API image carrying the WS
+> header-auth fix is deployed. Until then the API is reachable **unauthenticated
+> on the LAN/Tailscale** — a finding to close, not a passing state.
+
+**Origin API-key gate (once `CARDIGAN_API_KEY` is set):**
 ```bash
-# From inside the LXC, the API answers directly (no Access in front of localhost):
-curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8100/api/system/health   # 200
+# No key → 401 (proves the origin gate is live):
+curl -s -o /dev/null -w "%{http_code}\n" http://192.168.1.42:8100/api/jobs            # 401
+# With key → 200:
+curl -s -o /dev/null -w "%{http_code}\n" -H "X-API-Key: $CARDIGAN_API_KEY" \
+  http://192.168.1.42:8100/api/jobs                                                   # 200
+# Health stays exempt either way:
+curl -s -o /dev/null -w "%{http_code}\n" http://192.168.1.42:8100/api/system/health   # 200
 ```
 
-Then, from a normal browser **outside** the LXC:
+**Dashboard + live updates:** open the dashboard, confirm it loads **and** that
+job status updates stream without a manual refresh (the WebSocket authenticates
+via the `X-API-Key` header the nginx WS proxy injects — regression-critical after
+enabling the key).
 
-1. Visit `https://cardigan.bymarkriechers.com` with an email **not** on the Access allowlist → expect the Cloudflare login wall to block you.
-2. Visit again with an **allowlisted** email → complete the magic-link → the dashboard loads and live job updates stream (WebSocket connects).
+**Cloudflare Access edge gate (once the tunnel is up):** from a browser outside
+the homelab, an un-allowlisted email is blocked at the Cloudflare login wall; an
+allowlisted email completes the magic-link and reaches the dashboard.
 
 | Check | Result |
 |-------|--------|
-| `localhost:8100` health returns 200 inside the LXC | ☐ |
-| Un-allowlisted email is blocked at the Access wall | ☐ |
-| Allowlisted email reaches the dashboard, WS connects | ☐ |
+| No-key `/api/jobs` → 401; with-key → 200; health → 200 | ☐ |
+| Dashboard loads **and** live updates stream (WS authenticated) | ☐ |
+| Un-allowlisted email blocked at Access; allowlisted reaches dashboard | ☐ |
 
 ---
 

--- a/docs/POST_LAUNCH_TEST_PLAN.md
+++ b/docs/POST_LAUNCH_TEST_PLAN.md
@@ -1,0 +1,251 @@
+# Cardigan — Post-Launch Test Plan
+
+A repeatable acceptance runbook for the Cardigan deployment now running in an
+**LXC container** on the homelab Proxmox host via **`docker-compose.prod.yml`**
+(images pulled from `ghcr.io/mriechers/cardigan-*`).
+
+Run the whole thing once right after launch to prove the stack works
+end-to-end. Re-run §1–§3 (the **smoke subset**) as a quick canary after any
+`watchtower` auto-update or manual `docker compose pull && up -d`.
+
+**Conventions**
+- Run host-side commands from the LXC where the stack lives (the compose project dir).
+- The API is published on host port **8100** (`api` container → `:8000`), the web dashboard on **3100**, the optional MCP server on **8180**.
+- ✅ = pass, ❌ = fail. Record the date and the running image digest at the top of each run: `docker compose -f docker-compose.prod.yml images`.
+
+---
+
+## §1 — Container & health gate  *(smoke)*
+
+```bash
+# All long-running services Up; api + diarization show "healthy"
+docker compose -f docker-compose.prod.yml ps
+
+# Direct health probe (this is the same URL the container healthcheck hits)
+curl -s http://localhost:8100/api/system/health | python3 -m json.tool
+```
+
+**Expected:** `api`, `worker`, `web` (and `tunnel` if the `tunnel` profile is up)
+are `Up`; `api` is `healthy`. The health JSON returns:
+
+```json
+{ "status": "ok",
+  "queue": { "pending": <int>, "in_progress": <int> },
+  "llm": { "primary_backend": "...", "phase_backends": { ... } },
+  "last_run": ... }
+```
+
+> ⚠️ Known-noisy fields: `llm.active_backend`, `llm.active_model`, and
+> `last_run` can read `null`/stale even on a healthy system (project memory).
+> Judge health on `status: "ok"` + the container being `healthy`, **not** on those fields.
+
+| Check | Result |
+|-------|--------|
+| All expected containers `Up`, `api` healthy | ☐ |
+| `/api/system/health` → `status: ok` | ☐ |
+
+---
+
+## §2 — Auth & access gate  *(smoke)*
+
+The dashboard is fronted by **Cloudflare Access** (email allowlist, magic-link)
+ahead of the Cloudflare Tunnel. The `web` image's internal nginx injects the
+shared `X-API-Key` toward the API, so the browser never handles a key.
+
+```bash
+# From inside the LXC, the API answers directly (no Access in front of localhost):
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8100/api/system/health   # 200
+```
+
+Then, from a normal browser **outside** the LXC:
+
+1. Visit `https://cardigan.bymarkriechers.com` with an email **not** on the Access allowlist → expect the Cloudflare login wall to block you.
+2. Visit again with an **allowlisted** email → complete the magic-link → the dashboard loads and live job updates stream (WebSocket connects).
+
+| Check | Result |
+|-------|--------|
+| `localhost:8100` health returns 200 inside the LXC | ☐ |
+| Un-allowlisted email is blocked at the Access wall | ☐ |
+| Allowlisted email reaches the dashboard, WS connects | ☐ |
+
+---
+
+## §3 — Ingest scan smoke  *(smoke)*
+
+This is the "Ready for Work" surface the scanner feeds (and the target of the
+QoL cron work — see `planning/QOL_CRON_CATALOG.md`).
+
+```bash
+# Trigger a manual scan of the mmingest server
+curl -s -X POST http://localhost:8100/api/ingest/scan | python3 -m json.tool
+
+# List what's discovered and still un-actioned
+curl -s "http://localhost:8100/api/ingest/available?status=new" | python3 -m json.tool
+
+# Confirm the scheduler/last-scan state
+curl -s http://localhost:8100/api/ingest/status | python3 -m json.tool
+```
+
+**Expected:** the scan returns counts (`new_files_found`, `new_transcripts`,
+`new_screengrabs`); `/available` lists transcripts with `status: "new"`;
+`last_scan_at` advances to ~now.
+
+| Check | Result |
+|-------|--------|
+| `POST /api/ingest/scan` succeeds, returns counts | ☐ |
+| `/api/ingest/available?status=new` lists files | ☐ |
+| `last_scan_at` updated to ~now | ☐ |
+
+---
+
+## §4 — Full-pipeline acceptance
+
+Proves OpenRouter routing + the `worker` container + the DB write path on real input.
+
+```bash
+# Pick one file_id from the /available output above, then queue it:
+curl -s -X POST http://localhost:8100/api/ingest/transcripts/queue \
+  -H "Content-Type: application/json" \
+  -d '{"file_ids": [<FILE_ID>]}' | python3 -m json.tool
+```
+
+Watch the job to completion in the dashboard (or poll `GET /api/jobs`). It runs
+all four LLM phases.
+
+**Expected:** job reaches `completed`; output contains Release Title, Short/Long
+Description, and Keywords that are coherent for the episode.
+
+| Check | Result |
+|-------|--------|
+| Job queued and picked up by the worker | ☐ |
+| All 4 phases complete; status `completed` | ☐ |
+| SEO metadata output is coherent | ☐ |
+
+---
+
+## §5 — AirTable write path
+
+The **only** sanctioned write route is `propose → review → confirm`, restricted
+to allowlisted fields (Release Title, Short/Long Description, Keywords, social).
+Exercise it against a throwaway / test SST record via the MCP server (Claude Desktop
+or the `mcp` compose service on :8180).
+
+1. `propose_sst_edit` — stage an edit on the test record.
+2. `review_proposed_edits` — preview old → new values.
+3. Confirm, then `commit_sst_edits` — writes, and posts an audit comment on the record.
+
+**Expected:** only allowlisted fields change; an audit comment with old/new
+values appears on the Airtable record; optimistic-concurrency refuses if the
+record changed underneath the proposal.
+
+| Check | Result |
+|-------|--------|
+| Propose → review shows correct old/new diff | ☐ |
+| Commit writes only allowlisted fields | ☐ |
+| Audit comment posted on the record | ☐ |
+
+---
+
+## §6 — mmingest search smoke
+
+Reuses the Sprint 5 smoke script. Needs a consumer key with `mmingest:read`.
+
+```bash
+# One-time: mint a key (prints plaintext once — copy it)
+python3 scripts/create_consumer_key.py --label postlaunch-smoke --scopes mmingest:read
+
+# Run the three canned queries + legacy-endpoint regression pings
+CONSUMER_KEY=<key> CARDIGAN_URL=http://localhost:8100 bash scripts/sprint5_smoke_search.sh
+cat /tmp/sprint5-smoke-log.jsonl   # inspect results
+```
+
+**Expected:** each query returns hits; legacy `/api/jobs` + `/api/system/health`
+still 200. Revoke the throwaway key afterwards:
+`python3 scripts/create_consumer_key.py --revoke <id>`.
+
+| Check | Result |
+|-------|--------|
+| Search queries return results | ☐ |
+| Legacy endpoints still 200 (no regression) | ☐ |
+
+---
+
+## §7 — Soak / acceptance envelope  *(optional, long-running)*
+
+For a deeper go/no-go, run the 24h soak harness (full runbook in
+`planning/sprint-5-staging-soak.md`):
+
+```bash
+CONSUMER_KEY=<key> bash scripts/sprint5_soak_monitor.sh    # 24h background monitor
+python3 scripts/sprint5_soak_report.py                     # GO/NO-GO report
+```
+
+**Acceptance envelope:** avg ≤ 1 req/s · peak inflight ≤ 4 · error rate < 1% ·
+crawl/DB parity delta = 0 every 6h · p95 search latency < 50 ms.
+
+| Check | Result |
+|-------|--------|
+| 24h soak completes within envelope | ☐ |
+| Report verdict = GO | ☐ |
+
+---
+
+## §8 — Backup / restore drill
+
+The data of record (`dashboard.db`) now lives only on the server — prove it's recoverable.
+
+```bash
+# Snapshot the live DB (online-backup API; safe while writing). Produces a
+# gzipped copy under .snapshots/.
+CARDIGAN_API_CONTAINER=cardigan-v4-api-1 scripts/snapshot_db.sh
+
+ls -lh .snapshots/                 # confirm a fresh dashboard-<ts>.db.gz exists
+```
+
+**Restore drill (do this against a scratch copy, not the live volume):**
+
+```bash
+gunzip -k .snapshots/dashboard-<ts>.db.gz
+# Inspect the restored copy — confirm row counts look sane:
+python3 -c "import sqlite3; c=sqlite3.connect('.snapshots/dashboard-<ts>.db'); \
+print('jobs:', c.execute('select count(*) from jobs').fetchone()[0])"
+```
+
+> Restore-to-live procedure: `docker compose stop api worker`, replace the file
+> inside the `db-data` volume with the unzipped snapshot, `up -d`. Document the
+> exact volume path the first time you do it.
+
+| Check | Result |
+|-------|--------|
+| Snapshot lands in `.snapshots/` | ☐ |
+| Restored copy opens and row counts are sane | ☐ |
+
+---
+
+## §9 — Restart resilience
+
+Proves the stack and the in-process scheduler come back cleanly.
+
+```bash
+docker compose -f docker-compose.prod.yml restart api
+sleep 15
+curl -s http://localhost:8100/api/system/health | python3 -c "import sys,json;print(json.load(sys.stdin)['status'])"
+docker compose -f docker-compose.prod.yml logs api | grep -i "scheduler started"
+```
+
+**Expected:** health returns `ok` within the `start_period`; the API log shows
+the ingest scheduler re-registering on startup (`api/main.py` lifespan →
+`start_scheduler()`).
+
+| Check | Result |
+|-------|--------|
+| Health returns `ok` after restart | ☐ |
+| "Ingest scheduler started" in logs | ☐ |
+
+---
+
+## Sign-off
+
+| Run date | Image digest | Smoke (§1–3) | Full (§4–6) | Soak (§7) | Backup (§8) | Restart (§9) | Notes |
+|----------|--------------|--------------|-------------|-----------|-------------|--------------|-------|
+|          |              |              |             |           |             |              |       |

--- a/docs/PRODUCER_ONBOARDING.md
+++ b/docs/PRODUCER_ONBOARDING.md
@@ -1,0 +1,91 @@
+# Getting Access to Cardigan — Producer Onboarding
+
+Cardigan (a.k.a. *The Metadata Neighborhood*) turns a well-edited transcript into
+SEO-ready metadata — Release Title, Short/Long Description, and Keywords — so you
+don't have to write all of that by hand. It runs as a web dashboard at
+**`https://cardigan.bymarkriechers.com`**.
+
+This guide has two parts: **admin steps** (done once per new producer by the
+person who runs the server) and a **producer guide** you can hand straight to a
+colleague.
+
+---
+
+## Part A — Admin steps (one-time per producer)
+
+Access is gated by **Cloudflare Access** (an email allowlist with magic-link
+login) sitting in front of the Cloudflare Tunnel. No API keys, passwords, or
+config touch the producer's machine — you just add their email.
+
+1. **Add the producer's email to the allowlist.**
+   In the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) →
+   **Access → Applications →** the `cardigan.bymarkriechers.com` application →
+   the "Email allowlist" policy → add their PBS Wisconsin email under the
+   **Emails** include rule. (Same policy described in `docs/REMOTE_ACCESS.md` §5.)
+
+2. **Confirm the tunnel is up.** In production the connector runs as the
+   `tunnel` service in the compose stack:
+   ```bash
+   docker compose -f docker-compose.prod.yml --profile tunnel ps tunnel
+   ```
+   It should be `Up`. (If you run the tunnel via `./scripts/start.sh` on a laptop
+   instead, `./scripts/status.sh` shows it.)
+
+3. **Send the producer** the dashboard URL and Part B below.
+
+> **Heads-up on identity:** today every dashboard user shares one backend API
+> key (injected by the web container's nginx). Cloudflare Access controls *who
+> can get in*, but the app itself doesn't yet attribute actions to individual
+> producers. Per-user identity/audit inside the app is a future enhancement. If
+> you need to revoke someone, remove their email from the Access policy.
+
+---
+
+## Part B — Producer guide (hand this to the new producer)
+
+### 1. Log in
+Open **`https://cardigan.bymarkriechers.com`**. You'll see a Cloudflare login
+page — enter your PBS Wisconsin email, then click the magic link sent to your
+inbox. You're in for 24 hours before it asks again. Nothing to install.
+
+### 2. What Cardigan does for you
+You feed it a finished transcript; it runs a four-phase AI pipeline and hands
+back polished, SEO-optimized metadata for our streaming platforms. Think of it
+as a calm, reliable workstation that does the tedious duplicative writing so you
+can review instead of draft from scratch.
+
+### 3. Ready for Work
+The **Ready for Work** page lists transcripts that have shown up on the ingest
+server and are waiting to be processed. Browse the list, pick the episode(s) you
+want, and **queue** them. (The system scans for new arrivals automatically, so
+this list refreshes on its own — but there's a manual "Check for New Files"
+button if you want to force a fresh look.)
+
+### 4. Run & monitor a job
+Once queued, a job runs through four phases. You'll see live status as it
+progresses. If a phase fails, you can **retry** just that phase — you don't have
+to start over. A finished job shows as **completed**.
+
+### 5. Review the output
+Open a completed job to read its generated metadata: Release Title, a short
+description, a long description, and keywords. Read it the way you'd read a
+colleague's first draft — it's good, but you have final say.
+
+### 6. Push to AirTable
+When you're happy, Cardigan can write the approved fields back to our AirTable
+Single Source of Truth. It always shows you a **preview of the exact changes**
+first (old value → new value) and waits for your confirmation before writing.
+Only the editorial fields are writable (Release Title, Short/Long Description,
+Keywords, social copy), and every write leaves an audit comment on the record —
+so nothing happens behind your back.
+
+### 7. Getting help
+Something looks off, or you can't get in? Ping **Mark Riechers** — include the
+episode/Media ID and a screenshot if you can.
+
+---
+
+> **Programmatic / MCP access** (consumer API keys with scopes, via
+> `scripts/create_consumer_key.py`) is a separate path for tools and Claude
+> Desktop integrations — not needed for dashboard producers. A future
+> `docs/API_ONBOARDING.md` will cover it.

--- a/docs/PRODUCER_ONBOARDING.md
+++ b/docs/PRODUCER_ONBOARDING.md
@@ -7,12 +7,12 @@ don't have to write all of it by hand.
 > **Access status (2026-06-10):** Cardigan runs on the `cardigan01` homelab
 > container. Today it's reachable only on the home LAN / Tailscale and has **no
 > login**. The producer-facing front door — a **Cloudflare Tunnel + Cloudflare
-> Access** (browser login, nothing to install) — is being stood up; see the
-> infra handoff in
+> Access** (browser login, nothing to install) exposing **only the web
+> dashboard** — is being stood up; see the infra handoff in
 > `homelab/proxmox-config/containers/cardigan01/planning/2026-06-10-secure-access-handoff.md`.
-> A longer-term option (Cardigan behind **WPM's official VPN**) is under
-> discussion with IT. This doc describes the **Cloudflare Access** experience the
-> near-term setup delivers.
+> This doc covers the **web-app** experience, which is all a collaborating
+> producer needs. (A future option — Cardigan behind WPM's official VPN — is a
+> maybe-someday with IT, not something to wait on.)
 
 ---
 
@@ -27,9 +27,11 @@ below). Those are tracked in the handoff note above.
    PBS Wisconsin email. They authenticate at Cloudflare's edge (magic-link /
    one-time PIN) — unauthenticated traffic never reaches the homelab.
 2. **Send them** the URL + Part B.
-3. **(If they run a local editing agent)** issue them a Cloudflare Access
-   **service token** *and* a scoped Cardigan **consumer key** — see "Agent
-   access" below.
+
+That's it — the dashboard is the whole job. Only the web service (`:3100`) is
+exposed through the tunnel; the raw API (`:8100`) stays private (the dashboard
+reaches it internally), so there are no API keys or tokens for the producer to
+handle.
 
 ### Defense in depth — the origin API key
 
@@ -83,21 +85,17 @@ episode / Media ID and a screenshot if you can.
 
 ---
 
-## Agent access (for the AI editing workflow)
+## Operator note — agent / API access (not part of producer onboarding)
 
-The agent-driven editing workflow calls the same API the dashboard uses, so a
-local agent on your machine may need API access alongside the GUI. Because that
-traffic isn't a browser, it authenticates differently:
-
-- **Through the Cloudflare front door:** a Cloudflare Access **service token**
-  (a `CF-Access-Client-Id` + `CF-Access-Client-Secret` header pair) gets the
-  agent past the edge without a human login, **plus** a Cardigan **consumer key**
-  (`X-API-Key`, scoped — e.g. `mmingest:read`) for the origin gate. Your admin
-  issues both; treat them as secrets.
-- **On the homelab LAN / Tailscale (operator machines):** no service token needed
-  — reach the API directly (`cardigan01:8100`) with just the consumer key.
+The producer path above is **web dashboard only**, so the API stays off the
+public internet. The agent-driven editing workflow (operators like Mark) reaches
+the API over **Tailscale** instead — `cardigan01:8100` with a scoped Cardigan
+consumer key, no Cloudflare service token needed:
 
 > Mint a consumer key with
 > `python scripts/create_consumer_key.py --label <who> --scopes mmingest:read`
-> (prints the key once; `--revoke <id>` to disable). Cloudflare service tokens
-> are created in Zero Trust → Access → Service Auth.
+> (prints the key once; `--revoke <id>` to disable).
+
+If a producer ever needs agent/API access from a non-Tailscale machine, *then*
+add a Cloudflare Access service token + expose the API hostname — deferred until
+there's a real need (see the secure-access handoff note).

--- a/docs/PRODUCER_ONBOARDING.md
+++ b/docs/PRODUCER_ONBOARDING.md
@@ -1,91 +1,103 @@
 # Getting Access to Cardigan — Producer Onboarding
 
-Cardigan (a.k.a. *The Metadata Neighborhood*) turns a well-edited transcript into
-SEO-ready metadata — Release Title, Short/Long Description, and Keywords — so you
-don't have to write all of that by hand. It runs as a web dashboard at
-**`https://cardigan.bymarkriechers.com`**.
+Cardigan (a.k.a. *The Metadata Neighborhood*) turns a finished transcript into
+SEO-ready metadata — Release Title, Short/Long Description, Keywords — so you
+don't have to write all of it by hand.
 
-This guide has two parts: **admin steps** (done once per new producer by the
-person who runs the server) and a **producer guide** you can hand straight to a
-colleague.
+> **Access status (2026-06-10):** Cardigan runs on the `cardigan01` homelab
+> container. Today it's reachable only on the home LAN / Tailscale and has **no
+> login**. The producer-facing front door — a **Cloudflare Tunnel + Cloudflare
+> Access** (browser login, nothing to install) — is being stood up; see the
+> infra handoff in
+> `homelab/proxmox-config/containers/cardigan01/planning/2026-06-10-secure-access-handoff.md`.
+> A longer-term option (Cardigan behind **WPM's official VPN**) is under
+> discussion with IT. This doc describes the **Cloudflare Access** experience the
+> near-term setup delivers.
 
 ---
 
 ## Part A — Admin steps (one-time per producer)
 
-Access is gated by **Cloudflare Access** (an email allowlist with magic-link
-login) sitting in front of the Cloudflare Tunnel. No API keys, passwords, or
-config touch the producer's machine — you just add their email.
+Prerequisite (one-time, infra): the Cloudflare Tunnel + Access application for
+`cardigan.<domain>` exist, and the origin API key is set (see "Defense in depth"
+below). Those are tracked in the handoff note above.
 
-1. **Add the producer's email to the allowlist.**
-   In the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) →
-   **Access → Applications →** the `cardigan.bymarkriechers.com` application →
-   the "Email allowlist" policy → add their PBS Wisconsin email under the
-   **Emails** include rule. (Same policy described in `docs/REMOTE_ACCESS.md` §5.)
+1. **Add the producer to the Access policy.** Cloudflare Zero Trust → **Access →
+   Applications →** the Cardigan app → the "Email allowlist" policy → add their
+   PBS Wisconsin email. They authenticate at Cloudflare's edge (magic-link /
+   one-time PIN) — unauthenticated traffic never reaches the homelab.
+2. **Send them** the URL + Part B.
+3. **(If they run a local editing agent)** issue them a Cloudflare Access
+   **service token** *and* a scoped Cardigan **consumer key** — see "Agent
+   access" below.
 
-2. **Confirm the tunnel is up.** In production the connector runs as the
-   `tunnel` service in the compose stack:
-   ```bash
-   docker compose -f docker-compose.prod.yml --profile tunnel ps tunnel
-   ```
-   It should be `Up`. (If you run the tunnel via `./scripts/start.sh` on a laptop
-   instead, `./scripts/status.sh` shows it.)
+### Defense in depth — the origin API key
 
-3. **Send the producer** the dashboard URL and Part B below.
-
-> **Heads-up on identity:** today every dashboard user shares one backend API
-> key (injected by the web container's nginx). Cloudflare Access controls *who
-> can get in*, but the app itself doesn't yet attribute actions to individual
-> producers. Per-user identity/audit inside the app is a future enhancement. If
-> you need to revoke someone, remove their email from the Access policy.
+Cloudflare Access is the *edge* gate (who reaches the box). Cardigan also
+enforces an *origin* gate: when `CARDIGAN_API_KEY` is set, every `/api/*` call
+(and the live-updates WebSocket) must carry the key. The web container's nginx
+injects it automatically, so **producers never see or handle it** — the
+dashboard just works. This also closes the current LAN/Tailscale "no auth" hole.
+(Enabling it requires the API image that includes the WS header-auth fix — see
+the handoff note.)
 
 ---
 
 ## Part B — Producer guide (hand this to the new producer)
 
 ### 1. Log in
-Open **`https://cardigan.bymarkriechers.com`**. You'll see a Cloudflare login
-page — enter your PBS Wisconsin email, then click the magic link sent to your
-inbox. You're in for 24 hours before it asks again. Nothing to install.
+Open the Cardigan URL your admin sent you. You'll see a Cloudflare login page —
+enter your PBS Wisconsin email, then click the magic link (or enter the one-time
+code) sent to your inbox. You're in for the session. **Nothing to install.**
 
 ### 2. What Cardigan does for you
-You feed it a finished transcript; it runs a four-phase AI pipeline and hands
-back polished, SEO-optimized metadata for our streaming platforms. Think of it
-as a calm, reliable workstation that does the tedious duplicative writing so you
-can review instead of draft from scratch.
+You feed it a finished transcript; it runs a four-phase AI pipeline and returns
+polished, SEO-optimized metadata for our streaming platforms. Think of it as a
+calm, reliable workstation that does the tedious drafting so you can review.
 
 ### 3. Ready for Work
-The **Ready for Work** page lists transcripts that have shown up on the ingest
-server and are waiting to be processed. Browse the list, pick the episode(s) you
-want, and **queue** them. (The system scans for new arrivals automatically, so
-this list refreshes on its own — but there's a manual "Check for New Files"
-button if you want to force a fresh look.)
+The **Ready for Work** page lists transcripts that have arrived on the ingest
+server and are waiting. Pick the episode(s) you want and **queue** them. The list
+refreshes on its own; there's also a manual "Check for New Files" button.
 
 ### 4. Run & monitor a job
-Once queued, a job runs through four phases. You'll see live status as it
-progresses. If a phase fails, you can **retry** just that phase — you don't have
-to start over. A finished job shows as **completed**.
+A queued job runs through four phases with live status. If a phase fails, you can
+**retry just that phase** — no need to start over. A finished job shows as
+**completed**.
 
 ### 5. Review the output
-Open a completed job to read its generated metadata: Release Title, a short
-description, a long description, and keywords. Read it the way you'd read a
-colleague's first draft — it's good, but you have final say.
+Open a completed job to read its metadata: Release Title, short description, long
+description, keywords. Read it like a colleague's first draft — you have final
+say.
 
 ### 6. Push to AirTable
 When you're happy, Cardigan can write the approved fields back to our AirTable
-Single Source of Truth. It always shows you a **preview of the exact changes**
-first (old value → new value) and waits for your confirmation before writing.
-Only the editorial fields are writable (Release Title, Short/Long Description,
-Keywords, social copy), and every write leaves an audit comment on the record —
-so nothing happens behind your back.
+Single Source of Truth. It always shows a **preview of the exact changes** (old →
+new) and waits for your confirmation. Only the editorial fields are writable
+(Release Title, Short/Long Description, Keywords, social), and every write leaves
+an audit comment on the record.
 
 ### 7. Getting help
-Something looks off, or you can't get in? Ping **Mark Riechers** — include the
-episode/Media ID and a screenshot if you can.
+Can't get in, or something looks off? Ping **Mark Riechers** — include the
+episode / Media ID and a screenshot if you can.
 
 ---
 
-> **Programmatic / MCP access** (consumer API keys with scopes, via
-> `scripts/create_consumer_key.py`) is a separate path for tools and Claude
-> Desktop integrations — not needed for dashboard producers. A future
-> `docs/API_ONBOARDING.md` will cover it.
+## Agent access (for the AI editing workflow)
+
+The agent-driven editing workflow calls the same API the dashboard uses, so a
+local agent on your machine may need API access alongside the GUI. Because that
+traffic isn't a browser, it authenticates differently:
+
+- **Through the Cloudflare front door:** a Cloudflare Access **service token**
+  (a `CF-Access-Client-Id` + `CF-Access-Client-Secret` header pair) gets the
+  agent past the edge without a human login, **plus** a Cardigan **consumer key**
+  (`X-API-Key`, scoped — e.g. `mmingest:read`) for the origin gate. Your admin
+  issues both; treat them as secrets.
+- **On the homelab LAN / Tailscale (operator machines):** no service token needed
+  — reach the API directly (`cardigan01:8100`) with just the consumer key.
+
+> Mint a consumer key with
+> `python scripts/create_consumer_key.py --label <who> --scopes mmingest:read`
+> (prints the key once; `--revoke <id>` to disable). Cloudflare service tokens
+> are created in Zero Trust → Access → Service Auth.

--- a/planning/QOL_CRON_CATALOG.md
+++ b/planning/QOL_CRON_CATALOG.md
@@ -1,0 +1,157 @@
+# Cardigan — Quality-of-Life & Cron Catalog (post-LXC)
+
+**Status:** decision menu — nothing here is built yet. Pick items and we'll
+schedule them into a sprint.
+
+**Context:** Cardigan now runs as an always-on server (LXC + `docker-compose.prod.yml`)
+instead of a laptop dev tool. That unlocks scheduled background work to keep it
+*fresher* (data updates itself) and *more reliable* (it looks after itself). This
+catalog ranks the candidates.
+
+### Where a scheduled job should live
+
+| Home | Use for | Survives if `api` container is down? |
+|------|---------|--------------------------------------|
+| **In-process APScheduler** (already running inside the `api` container — see `api/services/ingest_scheduler.py`) | Jobs that need app/DB context: scanning, attaching, digests | ❌ no — dies with the container |
+| **LXC host cron** (or a small compose sidecar) | Infra jobs that must run *even when the app is sick*: backups, health alerts, log rotation | ✅ yes |
+
+Rule of thumb: **data-pipeline freshness → APScheduler; safety nets → host cron.**
+
+---
+
+## Ranked candidates
+
+| # | Item | Home | Effort | Recommendation |
+|---|------|------|--------|----------------|
+| 1 | Make the auto-scan actually periodic | APScheduler | **S** | **Do first** |
+| 2 | Notify on new Ready-for-Work | APScheduler + Slack | S–M | High value |
+| 3 | Nightly DB backup with retention + offsite | Host cron | **S** | **Strongly recommend** |
+| 4 | Health-down alerting | Host cron | S | Recommend |
+| 5 | Auto-attach screengrabs | APScheduler | M | Nice-to-have |
+| 6 | Scheduled search-smoke canary | Host cron | S | Optional |
+| 7 | Weekly cost/usage digest | APScheduler | M | Optional |
+| 8 | Log rotation / disk hygiene | Host cron | S | Hygiene |
+
+---
+
+### 1. Make the auto-scan actually periodic  *(the headline)*  — **S, do first**
+
+**Today it's half-built — and not in the way you'd expect.** The config default
+*looks* like it scans every 2 hours:
+
+```python
+# api/services/ingest_config.py
+scan_interval_hours=2
+```
+
+…but the scheduler never reads that field. `configure_scheduler()` only ever
+builds a daily cron from `scan_time`:
+
+```python
+# api/services/ingest_scheduler.py — configure_scheduler()
+hour, minute = parse_scan_time(config.scan_time)   # "07:00"
+trigger = CronTrigger(hour=hour, minute=minute)    # fires ONCE a day, 07:00
+```
+
+So **Ready-for-Work currently refreshes once a day at 07:00**, despite PR #176's
+title ("drop scan cadence to 2h"). `scan_interval_hours` is dead config.
+
+**Fix:** swap the `CronTrigger` for an `IntervalTrigger(hours=config.scan_interval_hours)`
+(or fan out N daily cron fires). ~5 lines in `configure_scheduler()` + a test
+asserting the trigger interval matches config. This is exactly the
+"scan the Ready-for-Work part regularly so manual re-scans are less necessary"
+ask — and it's nearly free.
+
+*Politeness note:* mmingest crawl already has dedup + politeness (PR #186), so a
+2h cadence is well within budget. If you want it fresher than 2h, drop to 1h.
+
+---
+
+### 2. Notify on new Ready-for-Work  — S–M, high value
+
+When a scheduled scan finds *new* transcripts, push a heads-up instead of making
+producers poll the page. Two flavors (can do either or both):
+- **Slack message** to an editorial channel ("3 new transcripts ready: …").
+- **Dashboard badge / unread count** on the Ready-for-Work nav item.
+
+Hooks cleanly into `run_scheduled_scan()` (which already returns
+`new_files_found` / `new_transcripts`). Pairs naturally with #1 — once scans are
+frequent, a nudge is what makes "frequent" *useful* rather than just busy.
+
+---
+
+### 3. Nightly DB backup with retention + offsite  — **S, strongly recommend**
+
+`scripts/snapshot_db.sh` already exists and does the hard part right: it uses
+SQLite's online-backup API (safe while the app writes) and gzips the result.
+**What's missing for a server:** it's never *scheduled*, has **no retention**
+(snapshots pile up forever), and keeps everything **on the same box** as the DB.
+
+**Fix:** a host cron entry (nightly) that runs `snapshot_db.sh`, prunes copies
+older than N days, and `rclone`-copies the latest offsite (the workspace already
+uses rclone for Drive). `dashboard.db` is now the only home for jobs, cost data,
+and consumer keys — losing the LXC without this loses everything.
+
+```cron
+# example — 02:30 nightly
+30 2 * * * cd /path/to/cardigan-v4 && scripts/snapshot_db.sh && \
+  find .snapshots -name 'dashboard-*.db.gz' -mtime +14 -delete && \
+  rclone copy "$(ls -t .snapshots/*.db.gz | head -1)" gdrive-work:cardigan-backups/
+```
+
+---
+
+### 4. Health-down alerting  — S, recommend
+
+`watchtower` + the compose healthcheck will *restart* a sick `api` container, but
+**nothing tells you it happened** — a crash-loop could run for days unnoticed.
+
+**Fix:** a host cron (every few minutes) that curls `/api/system/health` and
+alerts (Slack/email) on non-`ok` or non-200, with a flap guard so a single blip
+doesn't page you. Lives on the host deliberately — it must work *when the app
+doesn't*.
+
+---
+
+### 5. Auto-attach screengrabs  — M, nice-to-have
+
+`api/services/screengrab_attacher.py` + the `/api/ingest/screengrabs/attach-all`
+endpoint already exist but are manual. A scheduled pass would let jobs pick up
+newly-arrived stills without anyone clicking "attach." Lower urgency than #1–#4;
+mostly removes a manual step. Home: APScheduler, right after the scan job.
+
+---
+
+### 6. Scheduled search-smoke canary  — S, optional
+
+Run `scripts/sprint5_smoke_search.sh` on a cron (e.g. hourly) as an ongoing
+mmingest health signal — it already logs JSONL and pings legacy endpoints for
+regression. Cheap early warning that search/index broke. Needs a long-lived
+`mmingest:read` consumer key in the crontab env.
+
+---
+
+### 7. Weekly cost/usage digest  — M, optional
+
+Roll up Langfuse cost + per-model usage into a weekly Slack/email summary so LLM
+spend stays visible now that jobs run unattended. Home: APScheduler. Builds on
+the existing `api/services/langfuse_client.py` REST integration.
+
+---
+
+### 8. Log rotation / disk hygiene  — S, hygiene
+
+A long-lived box accumulates container logs and SQLite WAL growth. Set Docker log
+rotation (`max-size`/`max-file` in the compose `logging` block) and a periodic
+`VACUUM`/WAL-checkpoint if the DB grows. Prevents the "disk full at 3am" class of
+outage. Home: compose config + optional host cron.
+
+---
+
+## Suggested first batch
+
+If you want a tight, high-leverage first sprint: **#1 + #3 + #4** — frequent
+fresh scans, real backups, and a heartbeat alert. That converts the three things
+that change most when a tool stops being a laptop script and becomes a server:
+freshness, durability, and observability. **#2** is the obvious fast-follow once
+#1 makes scans frequent enough to be worth announcing.

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,6 +1,8 @@
 """Tests for WebSocket endpoint."""
 
+import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from api.main import app
 from api.models.job import Job, JobStatus
@@ -19,6 +21,43 @@ def test_websocket_connection():
         # Receive pong
         data = websocket.receive_text()
         assert data == "pong"
+
+
+def test_websocket_auth_accepts_x_api_key_header(monkeypatch):
+    """When CARDIGAN_API_KEY is set, the X-API-Key header (injected by the nginx
+    WS proxy) authenticates the connection."""
+    monkeypatch.setenv("CARDIGAN_API_KEY", "secret-key")
+    client = TestClient(app)
+
+    with client.websocket_connect(
+        "/api/ws/jobs", headers={"X-API-Key": "secret-key"}
+    ) as websocket:
+        websocket.send_text("ping")
+        assert websocket.receive_text() == "pong"
+
+
+def test_websocket_auth_accepts_query_token_fallback(monkeypatch):
+    """The ?token= query param still authenticates (fallback for clients that
+    cannot set headers on the WS handshake)."""
+    monkeypatch.setenv("CARDIGAN_API_KEY", "secret-key")
+    client = TestClient(app)
+
+    with client.websocket_connect("/api/ws/jobs?token=secret-key") as websocket:
+        websocket.send_text("ping")
+        assert websocket.receive_text() == "pong"
+
+
+def test_websocket_auth_rejects_missing_or_wrong_key(monkeypatch):
+    """When CARDIGAN_API_KEY is set, a connection with no/incorrect credential
+    is closed with a policy-violation (1008)."""
+    monkeypatch.setenv("CARDIGAN_API_KEY", "secret-key")
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            "/api/ws/jobs", headers={"X-API-Key": "wrong"}
+        ) as websocket:
+            websocket.receive_text()
 
 
 def test_websocket_broadcast_job_update():


### PR DESCRIPTION
Post-launch access + ops work for Cardigan's move to the cardigan01 LXC.

## Code
- **`api/routers/websocket.py`** — `/ws/jobs` now authenticates via the `X-API-Key` header the nginx WS proxy already injects (`nginx.conf:35`), with the `?token=` query param as fallback. **Why it matters:** the WS endpoint previously read *only* a build-time `VITE_CARDIGAN_API_KEY` token, which is empty in the GHCR web image — so enabling `CARDIGAN_API_KEY` would have silently broken the dashboard's live job/stats updates. This makes turning on the origin API key safe. +3 auth tests (header / query-fallback / reject).

## Docs
- **`docs/POST_LAUNCH_TEST_PLAN.md`** — 9-section acceptance runbook against the live Docker-Compose stack (§1–§3 = re-runnable smoke). §2 corrected to test the **two real gates**: origin API key (401/200 + live-WS regression) and the Cloudflare Access edge wall.
- **`docs/PRODUCER_ONBOARDING.md`** — rewritten around the chosen access path: **Cloudflare Tunnel + Access** (browser login, nothing to install) + origin API key (defense in depth) + an **agent-access** section (Access service token + scoped consumer key), since the editing workflow uses the same API as the GUI.
- **`planning/QOL_CRON_CATALOG.md`** — ranked, costed cron menu (headline: `scan_interval_hours` is dead config — the scan fires once daily, not every 2h).

## Homelab infra (separate repo)
Tracked in `proxmox-config/containers/cardigan01/planning/2026-06-10-secure-access-handoff.md`: cloudflared tunnel, Access policies, setting `CARDIGAN_API_KEY` (depends on the API image from this PR), OPNsense segmentation of cardigan01, MCP exposure, and backup durability. Secure target: Cardigan behind WPM's official VPN + scoped consumer keys.

## Deploy note
Setting `CARDIGAN_API_KEY` on cardigan01 requires the `cardigan-api` image built from this PR (so live WS updates survive). Merge → image build → `docker compose pull && up -d` on the box → set key → verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)