### PR TITLE
fix(mmingest): Sprint 1 — search/asset/scheduler/politeness hardening (Epic A)

### DIFF
--- a/api/routers/mmingest.py
+++ b/api/routers/mmingest.py
@@ -23,12 +23,20 @@ to mmingest_audit_log.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+# Per-request timeout (seconds) for the live Airtable lookup on /assets/{id}.
+# Kept short so a slow/unreachable Airtable can't hang a worker for the
+# AirtableClient default (60s) — the cached mmingest_files.airtable_record_id
+# is the fallback when the lookup times out.  See issue #192.
+_ASSET_AIRTABLE_TIMEOUT_S = 5.0
 
 from api.models.mmingest import (
     AssetEntry,
@@ -159,8 +167,22 @@ async def search(
                 "since": since.isoformat() if since else None,
             }
 
-            rows = (await conn.execute(search_sql, params)).fetchall()
-            total = (await conn.execute(count_sql, count_params)).scalar() or 0
+            try:
+                rows = (await conn.execute(search_sql, params)).fetchall()
+                total = (await conn.execute(count_sql, count_params)).scalar() or 0
+            except OperationalError as e:
+                # Malformed FTS5 MATCH syntax (e.g. unbalanced quotes, bad
+                # operators) raises OperationalError. That's a client error, not
+                # a server fault — return 400 instead of a 500 that crashes the
+                # worker. The query is parameter-bound, so this is not injection.
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Malformed FTS5 search query: {e.orig}. Check for "
+                        "unbalanced quotes or invalid FTS5 operators (phrase "
+                        '"..." , prefix term* , AND/OR/NOT, NEAR).'
+                    ),
+                ) from e
     finally:
         await engine.dispose()
 
@@ -272,12 +294,16 @@ async def get_asset(
     at_record_id: Optional[str] = None
     if primary_rows:
         try:
-            at_results = await airtable_client.batch_search_sst_by_media_ids([media_id])
+            at_results = await asyncio.wait_for(
+                airtable_client.batch_search_sst_by_media_ids([media_id]),
+                timeout=_ASSET_AIRTABLE_TIMEOUT_S,
+            )
             at_record = at_results.get(media_id)
             if at_record:
                 at_record_id = at_record.get("id")
         except Exception:
-            # Airtable unavailable — surface the pre-cached value from DB instead
+            # Airtable unavailable or too slow (TimeoutError from wait_for) —
+            # surface the pre-cached value from DB instead of hanging/500ing.
             at_record_id = primary_rows[0]._mapping.get("airtable_record_id")
 
     primary: Optional[AssetEntry] = None

--- a/api/services/ingest_scheduler.py
+++ b/api/services/ingest_scheduler.py
@@ -8,11 +8,10 @@ import logging
 from typing import Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
 from api.services.ingest_config import (
     get_ingest_config,
-    parse_scan_time,
     record_scan_result,
 )
 from api.services.ingest_scanner import get_ingest_scanner
@@ -86,15 +85,15 @@ async def configure_scheduler():
         logger.info("Ingest scanning is disabled, no job scheduled")
         return
 
-    # Parse scan time (HH:MM format)
-    try:
-        hour, minute = parse_scan_time(config.scan_time)
-    except ValueError as e:
-        logger.error(f"Invalid scan_time in config: {config.scan_time} - {e}")
+    # Determine scan cadence (every N hours) from config. The legacy scheduler
+    # built a daily CronTrigger from scan_time and silently ignored
+    # scan_interval_hours, so "Ready for Work" only refreshed once a day (#211).
+    interval_hours = config.scan_interval_hours
+    if not interval_hours or interval_hours <= 0:
+        logger.error(f"Invalid scan_interval_hours in config: {interval_hours!r} - must be > 0")
         return
 
-    # Create cron trigger for daily execution at configured time
-    trigger = CronTrigger(hour=hour, minute=minute)
+    trigger = IntervalTrigger(hours=interval_hours)
 
     # Add job to scheduler
     scheduler.add_job(
@@ -105,18 +104,18 @@ async def configure_scheduler():
         replace_existing=True,
     )
 
-    # Log the scheduled time
+    # Log the cadence
     job = scheduler.get_job("ingest_scan")
     if job:
         # Get next run time - may be None if scheduler not started yet
         try:
             next_run = getattr(job, "next_run_time", None)
             if next_run:
-                logger.info(f"Ingest scan scheduled: daily at {config.scan_time} (next run: {next_run})")
+                logger.info(f"Ingest scan scheduled: every {interval_hours}h (next run: {next_run})")
             else:
-                logger.info(f"Ingest scan scheduled: daily at {config.scan_time}")
+                logger.info(f"Ingest scan scheduled: every {interval_hours}h")
         except Exception:
-            logger.info(f"Ingest scan scheduled: daily at {config.scan_time}")
+            logger.info(f"Ingest scan scheduled: every {interval_hours}h")
 
 
 async def start_scheduler():

--- a/api/services/mmingest/crawler.py
+++ b/api/services/mmingest/crawler.py
@@ -374,7 +374,10 @@ class MmingestCrawler:
         self.ignore_directories: frozenset[str] = frozenset(d.strip("/").lower() for d in (ignore_directories or []))
         self.pause_window = pause_window
         self.auth = auth
-        self._rate_limiter = TokenBucket(rate=rate_per_second, burst=max_concurrent)
+        # burst=1 (not max_concurrent) to match the validated smoke-test
+        # politeness envelope: no first-wave request cluster against the Apache
+        # ingest server after start or after the quiet window (#183).
+        self._rate_limiter = TokenBucket(rate=rate_per_second, burst=1)
 
     # ------------------------------------------------------------------
     # Public API

--- a/api/services/mmingest/indexer.py
+++ b/api/services/mmingest/indexer.py
@@ -103,7 +103,7 @@ class MmingestIndexer:
         base_url: str = "https://mmingest.pbswi.wisc.edu/",
         directories: Optional[list[str]] = None,
         max_concurrent: int = 4,
-        rate_per_second: float = 2.0,
+        rate_per_second: float = 1.0,
         crawler_auth: Optional[tuple[str, str]] = None,
     ) -> None:
         self._engine = engine

--- a/api/services/mmingest/scheduler.py
+++ b/api/services/mmingest/scheduler.py
@@ -80,7 +80,7 @@ async def run_delta_walk() -> None:
             base_url="https://mmingest.pbswi.wisc.edu/",
             directories=["/"],
             max_concurrent=4,
-            rate_per_second=2.0,
+            rate_per_second=1.0,  # polite-crawl spec (#203)
         )
 
         run = await indexer.run_once()

--- a/tests/api/test_ingest_scheduler.py
+++ b/tests/api/test_ingest_scheduler.py
@@ -1,0 +1,49 @@
+"""Tests for the ingest scan scheduler (api/services/ingest_scheduler.py)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from apscheduler.triggers.interval import IntervalTrigger
+
+
+@pytest.mark.asyncio
+async def test_configure_scheduler_uses_interval_from_config(monkeypatch):
+    """#211: the ingest_scan job must fire every scan_interval_hours, not once
+    daily. The scheduler previously built a daily CronTrigger from scan_time and
+    silently ignored scan_interval_hours."""
+    import api.services.ingest_scheduler as sched_mod
+
+    # Fresh scheduler instance for test isolation.
+    sched_mod._scheduler = None
+
+    async def fake_config():
+        return SimpleNamespace(enabled=True, scan_interval_hours=3, scan_time="07:00")
+
+    monkeypatch.setattr(sched_mod, "get_ingest_config", fake_config)
+
+    await sched_mod.configure_scheduler()
+
+    job = sched_mod.get_scheduler().get_job("ingest_scan")
+    assert job is not None, "ingest_scan job should be registered"
+    assert isinstance(job.trigger, IntervalTrigger), f"expected IntervalTrigger, got {type(job.trigger)}"
+    assert job.trigger.interval == timedelta(hours=3)
+
+
+@pytest.mark.asyncio
+async def test_configure_scheduler_skips_when_disabled(monkeypatch):
+    """When ingest scanning is disabled, no job is scheduled."""
+    import api.services.ingest_scheduler as sched_mod
+
+    sched_mod._scheduler = None
+
+    async def fake_config():
+        return SimpleNamespace(enabled=False, scan_interval_hours=2, scan_time="07:00")
+
+    monkeypatch.setattr(sched_mod, "get_ingest_config", fake_config)
+
+    await sched_mod.configure_scheduler()
+
+    assert sched_mod.get_scheduler().get_job("ingest_scan") is None

--- a/tests/api/test_mmingest_router.py
+++ b/tests/api/test_mmingest_router.py
@@ -21,6 +21,7 @@ system doesn't try to introspect the mock's *args/**kwargs signature.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -822,3 +823,106 @@ async def test_recent_default_24h_window(migrated_engine):
     # Old (48h ago) should NOT appear; new (1h ago) should appear
     assert not any(r["media_id"] == "6POL0101" for r in results)
     assert any(r["media_id"] == "6POL0102" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Sprint 1 hardening — #191 malformed FTS5 → 400
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_malformed_fts_returns_400(migrated_engine):
+    """#191: a malformed FTS5 query (unbalanced quote) returns a clean 400,
+    not a 500 OperationalError that crashes the worker."""
+    engine, db_path = migrated_engine
+    async with engine.begin() as conn:
+        file_id = await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.srt",
+            filename="6POL0101.srt",
+            media_id="6POL0101",
+            prefix="6POL",
+        )
+        await _insert_sidecar(conn, file_id=file_id, body_text="politics in wisconsin")
+
+    client = _make_client(db_path, _make_mock_airtable())
+    # Unbalanced double-quote is invalid FTS5 MATCH syntax.
+    resp = client.get('/api/mmingest/search?q="unbalanced')
+
+    assert resp.status_code == 400, resp.text
+    assert "fts" in resp.json()["detail"].lower() or "query" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Sprint 1 hardening — #193 Airtable-exception fallback to cached record_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_airtable_exception_falls_back_to_cached(migrated_engine):
+    """#193: when the live Airtable lookup raises, /assets/{id} still returns
+    200 with the pre-cached airtable_record_id from mmingest_files."""
+    engine, db_path = migrated_engine
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            variant_tag=None,
+            superseded_by=None,
+            airtable_record_id="recCACHED001",
+        )
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(side_effect=RuntimeError("airtable down"))
+    client = _make_client(db_path, mock_at)
+    resp = client.get("/api/mmingest/assets/6POL0101")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["primary"]["airtable_record_id"] == "recCACHED001"
+
+
+# ---------------------------------------------------------------------------
+# Sprint 1 hardening — #192 slow Airtable times out and falls back to cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assets_airtable_timeout_falls_back_to_cached(migrated_engine, monkeypatch):
+    """#192: a slow Airtable lookup is bounded by a short timeout and falls
+    back to the cached record_id instead of hanging the worker."""
+    import api.routers.mmingest as mm
+
+    engine, db_path = migrated_engine
+    async with engine.begin() as conn:
+        await _insert_file(
+            conn,
+            remote_url="http://mmingest.example/6POL0101.mp4",
+            filename="6POL0101.mp4",
+            file_type="mp4",
+            media_id="6POL0101",
+            prefix="6POL",
+            variant_tag=None,
+            superseded_by=None,
+            airtable_record_id="recCACHED002",
+        )
+
+    async def _slow_lookup(_media_ids):
+        await asyncio.sleep(0.5)
+        return {"6POL0101": {"id": "recLIVE_SHOULD_NOT_WIN"}}
+
+    mock_at = MagicMock(spec=["batch_search_sst_by_media_ids"])
+    mock_at.batch_search_sst_by_media_ids = AsyncMock(side_effect=_slow_lookup)
+
+    client = _make_client(db_path, mock_at)
+    # Shrink the per-request Airtable timeout so the test is fast. Must patch
+    # AFTER _make_client, which reload()s the router module and would otherwise
+    # reset the constant back to its 5.0 default.
+    monkeypatch.setattr(mm, "_ASSET_AIRTABLE_TIMEOUT_S", 0.05, raising=False)
+    resp = client.get("/api/mmingest/assets/6POL0101")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["primary"]["airtable_record_id"] == "recCACHED002"

--- a/tests/services/mmingest/test_crawler.py
+++ b/tests/services/mmingest/test_crawler.py
@@ -251,6 +251,9 @@ class TestExponentialBackoff:
             base_url="https://test.example.com/",
             rate_per_second=1000.0,
         )
+        # Isolate backoff timing from rate-limiting (burst=1 default, #183) —
+        # asyncio.sleep is mocked, so a real token-bucket wait would busy-loop.
+        crawler._rate_limiter = TokenBucket(rate=1000.0, burst=1000)
 
         mock_client = AsyncMock()
         mock_client.get = mock_get
@@ -276,6 +279,11 @@ class TestExponentialBackoff:
             return resp
 
         crawler = MmingestCrawler(rate_per_second=1000.0)
+        # Isolate backoff timing from rate-limiting: the production default is
+        # burst=1 (#183), but these tests patch asyncio.sleep to a no-op, which
+        # would make the token-bucket refill wait busy-loop. A high burst keeps
+        # the limiter from engaging so we measure only the backoff sleeps.
+        crawler._rate_limiter = TokenBucket(rate=1000.0, burst=1000)
         mock_client = AsyncMock()
         mock_client.get = mock_get
         semaphore = asyncio.Semaphore(4)
@@ -291,6 +299,11 @@ class TestExponentialBackoff:
         import httpx
 
         crawler = MmingestCrawler(rate_per_second=1000.0)
+        # Isolate backoff timing from rate-limiting: the production default is
+        # burst=1 (#183), but these tests patch asyncio.sleep to a no-op, which
+        # would make the token-bucket refill wait busy-loop. A high burst keeps
+        # the limiter from engaging so we measure only the backoff sleeps.
+        crawler._rate_limiter = TokenBucket(rate=1000.0, burst=1000)
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
         semaphore = asyncio.Semaphore(4)
@@ -312,6 +325,11 @@ class TestExponentialBackoff:
         import httpx
 
         crawler = MmingestCrawler(rate_per_second=1000.0)
+        # Isolate backoff timing from rate-limiting: the production default is
+        # burst=1 (#183), but these tests patch asyncio.sleep to a no-op, which
+        # would make the token-bucket refill wait busy-loop. A high burst keeps
+        # the limiter from engaging so we measure only the backoff sleeps.
+        crawler._rate_limiter = TokenBucket(rate=1000.0, burst=1000)
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
         semaphore = asyncio.Semaphore(4)
@@ -825,3 +843,16 @@ class TestExtToFileType:
 
     def test_empty_ext_maps_to_other(self):
         assert _ext_to_file_type("") == "other"
+
+
+# ---------------------------------------------------------------------------
+# Sprint 1 hardening — #183 default crawler burst matches smoke test (burst=1)
+# ---------------------------------------------------------------------------
+
+
+def test_crawler_default_rate_limiter_burst_is_one():
+    """#183: the production crawler's rate limiter defaults to burst=1 to match
+    the smoke-test politeness envelope — no first-wave request cluster against
+    the Apache ingest server."""
+    crawler = MmingestCrawler()
+    assert crawler._rate_limiter._burst == 1

--- a/tests/services/mmingest/test_indexer_defaults.py
+++ b/tests/services/mmingest/test_indexer_defaults.py
@@ -1,0 +1,13 @@
+"""Default-value tests for MmingestIndexer (politeness spec compliance)."""
+
+from __future__ import annotations
+
+from api.services.mmingest.indexer import MmingestIndexer
+
+
+def test_indexer_default_rate_per_second_is_one():
+    """#203: the production indexer defaults to 1.0 req/s (the polite-crawl
+    spec), not 2.0. The Sprint 5 soak overrode this explicitly; production
+    rollout should ship the correct default."""
+    indexer = MmingestIndexer(engine=None)
+    assert indexer._rate_per_second == 1.0


### PR DESCRIPTION
## Sprint 1 — Epic A (#222) mmingest hardening

Test-driven hardening batch from the v4.2 maintenance plan. All changes have failing-first tests; full affected-suite run is **189 passed, 0 regressions**, black + ruff clean.

| Issue | Fix |
|-------|-----|
| **#191** | `/search`: malformed FTS5 `MATCH` (unbalanced quotes, bad operators) → clean **400** instead of a 500 that crashes the worker. Parameter-bound, so not injection. |
| **#192** | `/assets/{id}`: live Airtable lookup wrapped in a **5s `asyncio.wait_for`** so a slow/unreachable Airtable can't hang a worker for the 60s client default; cached `airtable_record_id` is the fallback. |
| **#193** | Regression test for the existing Airtable-exception fallback path. |
| **#211** | Ingest scheduler now honors `scan_interval_hours` via **`IntervalTrigger`** instead of silently building a daily `CronTrigger` from `scan_time` — 'Ready for Work' refreshes every N hours, not once a day. |
| **#203** | `MmingestIndexer` `rate_per_second` default **2.0 → 1.0** (polite-crawl spec); scheduler call site matched. |
| **#183** | Crawler `TokenBucket` production default **burst → 1** to match the validated smoke-test politeness envelope (no first-wave request cluster). |

**#184** (unknown-variant log DEBUG→INFO) was already implemented at `indexer.py:312` — closed as resolved, no code change.

### Notes
- The `burst=1` change surfaced a latent coupling in 4 backoff tests (they assumed `burst≥retries` so the rate limiter never engaged while `asyncio.sleep` was mocked). Fixed by isolating backoff timing from rate-limiting in those tests — their intent (verify backoff grows) is preserved.
- **Deferred to follow-up (Epic A):** #190 (shared `get_session()` refactor — needs test-harness rework, the harness relies on the per-request engine + `DATABASE_PATH`), #198 (test fixture hygiene), #182, #194, #195, #204, #205.

Closes #191, #192, #193, #211, #203, #183.