### PR TITLE
fix(deploy,migrations): Sprint 2 — reversible migrations + dead nginx conf (Epic B/C)

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -14,6 +14,12 @@ RUN npm run build
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 
+# Remove the stock conf.d/default.conf — it is never loaded (the entrypoint
+# templates nginx.conf over /etc/nginx/nginx.conf, which defines its own
+# server block and does not include conf.d/). Shipping it sends prod debugging
+# down a false "nginx has no /api proxy" path. (#181)
+RUN rm -f /etc/nginx/conf.d/default.conf
+
 COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/alembic/versions/008_add_chat_tables.py
+++ b/alembic/versions/008_add_chat_tables.py
@@ -63,9 +63,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index('ix_chat_messages_created_at', table_name='chat_messages')
-    op.drop_index('ix_chat_messages_session_id', table_name='chat_messages')
-    op.drop_table('chat_messages')
-    op.drop_index('ix_chat_sessions_status', table_name='chat_sessions')
-    op.drop_index('ix_chat_sessions_job_id', table_name='chat_sessions')
-    op.drop_table('chat_sessions')
+    # 012 (remove chat tables) has a no-op downgrade, so chat_messages /
+    # chat_sessions may already be gone when we downgrade through 008. Guard on
+    # existence so `alembic downgrade base` doesn't crash (#206). Dropping a
+    # table also drops its indexes, so explicit drop_index calls aren't needed.
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table('chat_messages'):
+        op.drop_table('chat_messages')
+    if insp.has_table('chat_sessions'):
+        op.drop_table('chat_sessions')

--- a/alembic/versions/011_add_app_version.py
+++ b/alembic/versions/011_add_app_version.py
@@ -26,6 +26,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column('chat_sessions', 'app_version')
+    # 012's downgrade is a no-op (the chat feature was removed in v4.1 with no
+    # restore path), so chat_sessions no longer exists when we downgrade through
+    # 011 from anything at/above 012. Guard the column drop on the table's
+    # presence so `alembic downgrade base` works below 013 (#206).
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table('chat_sessions'):
+        op.drop_column('chat_sessions', 'app_version')
     op.drop_column('session_stats', 'app_version')
     op.drop_column('jobs',          'app_version')

--- a/tests/integration/test_migration_roundtrip.py
+++ b/tests/integration/test_migration_roundtrip.py
@@ -1,0 +1,43 @@
+"""Migration round-trip: `upgrade head` then `downgrade base` must both succeed.
+
+Regression test for #206: migration 011's downgrade dropped a column from
+chat_sessions, but 012's downgrade is a no-op (the table is never recreated),
+so `alembic downgrade base` failed at 011 with "no such table: chat_sessions".
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _alembic(args: list[str], db_path: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "DATABASE_PATH": db_path}
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_full_upgrade_then_downgrade_to_base_succeeds():
+    """#206: a full upgrade head -> downgrade base round-trip must not fail."""
+    fd, db_path = tempfile.mkstemp(suffix="_migration_roundtrip.db")
+    os.close(fd)
+    try:
+        up = _alembic(["upgrade", "head"], db_path)
+        assert up.returncode == 0, f"upgrade head failed:\n{up.stdout}\n{up.stderr}"
+
+        down = _alembic(["downgrade", "base"], db_path)
+        assert down.returncode == 0, f"downgrade base failed:\n{down.stdout}\n{down.stderr}"
+    finally:
+        try:
+            os.unlink(db_path)
+        except OSError:
+            pass


### PR DESCRIPTION
## Sprint 2 — Epic B (#223 deployment) + Epic C (#224 migrations)

Most of Epic B turned out to be **already fixed in later sprints but never closed** — triaged and closed those, leaving two real code fixes.

### Code fixes
| Issue | Fix |
|-------|-----|
| **#206** | `alembic downgrade base` is now reversible. 012's downgrade is a no-op (chat feature removed in v4.1), so 011's and 008's downgrades crashed dropping a column/indexes on the already-gone `chat_sessions`/`chat_messages`. Both now guard on `sa.inspect(bind).has_table(...)`. The issue named only 011; 008 was the same latent break (same root cause), so both are fixed to make the full round-trip work. **New integration test** runs `upgrade head → downgrade base` and reproduced the failure first. |
| **#181** | Remove the stock `conf.d/default.conf` from the web image (`Dockerfile.web`) — never loaded, but it sent prod debugging down a false 'nginx has no /api proxy' path. |

### Closed during triage (already resolved on `main`, verified)
- **#71** — `alembic/env.py` already reads `DATABASE_PATH` and overrides the URL.
- **#72** — `entrypoint.sh` already guards `[ -d alembic ]`; the worker skips migrations.
- **#73** — compose already uses `${CARDIGAN_API_KEY:-}`.

### Deferred (needs a design call — left open under Epic B)
- **#158** (health `active_backend`/`active_model`/`last_run` null) and **#179** (process detection reports everything down) share one root cause: state that's **in-memory on the worker's `LLMRouter`/per-container**, invisible to the API container serving `/health`. Both should be designed together — persist run-state + use DB heartbeats for cross-container truth, or gate the panel behind a `CARDIGAN_DEPLOYMENT=docker` flag. Not a one-liner; deliberately not rushed.

Closes #206, #181.

🤖 Tests: migration round-trip + existing alembic suites pass (20), `ruff`/`black` clean.