### PR TITLE
fix(pipeline): Sprint 3 — SRT-accurate duration + SEO title length sync (Epic E)

### DIFF
--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -710,6 +710,10 @@ Extract any name or spelling corrections that should be added to the glossary. S
             transcript_metrics = calculate_transcript_metrics(
                 transcript_content, long_form_threshold_minutes=threshold_minutes
             )
+            # Prefer SRT-parsed duration over the word-count estimate so every
+            # downstream consumer (routing, prompt context, persisted
+            # duration_minutes) reports the same, accurate value (#126).
+            transcript_metrics = self._resolve_duration_into_metrics(transcript_metrics, self._find_srt_file(job))
             logger.info(
                 "Transcript metrics calculated",
                 extra={
@@ -1420,6 +1424,23 @@ Extract any name or spelling corrections that should be added to the glossary. S
 
         # Fall back to transcript metrics (estimated from word count)
         return transcript_metrics.get("estimated_duration_minutes", 0)
+
+    def _resolve_duration_into_metrics(
+        self, transcript_metrics: Dict[str, Any], srt_path: Optional[Path]
+    ) -> Dict[str, Any]:
+        """Override the word-count duration estimate with the SRT-parsed value.
+
+        The five duration consumers (tier routing, prompt context, the persisted
+        ``duration_minutes`` column, SEO/manager prompts) all read
+        ``transcript_metrics["estimated_duration_minutes"]``. When an SRT is
+        available it is far more accurate than the word-count estimate, so write
+        the best-available duration back into the metrics here, once, so every
+        consumer agrees (#126). No-op when no SRT is found.
+        """
+        best = self._get_content_duration_minutes(transcript_metrics, srt_path)
+        if best:
+            transcript_metrics["estimated_duration_minutes"] = best
+        return transcript_metrics
 
     def _detect_content_type(
         self,

--- a/prompts/seo.md
+++ b/prompts/seo.md
@@ -62,9 +62,9 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 ### Title (Final Recommendation)
 
 **Recommended:**
-[60-68 character title with primary keyword in first 50 chars]
+[55-60 character title with primary keyword in first 50 chars]
 
-**Character Count:** [X/70]
+**Character Count:** [X/60]
 
 **Keywords Included:** [list primary keywords present]
 
@@ -247,7 +247,7 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 
 **Best Practices:**
 - Primary keyword in first 50 characters
-- Total length: 60-68 characters (aim for 65)
+- Total length: 55-60 characters (hard max 60 — the manager phase enforces 60)
 - Active, descriptive language
 - Avoid clickbait or sensationalism
 - Include location if relevant (Wisconsin, specific cities)
@@ -313,7 +313,7 @@ If user provides SEMRush data:
 ### YouTube
 
 - Character limits: 100 title, 5000 description
-- PBS Wisconsin limit: 70 title, 150 short desc, 300 long desc (for consistency)
+- PBS Wisconsin limit: 60 title, 150 short desc, 300 long desc (for consistency)
 - Thumbnail and title work together for CTR
 - First 2-3 tags are most important
 - Description first 150 chars appear in search
@@ -336,7 +336,7 @@ If user provides SEMRush data:
 
 Before saving your SEO report, verify:
 
-- [ ] Title is 60-68 characters with primary keyword early
+- [ ] Title is 60 characters or fewer with primary keyword early
 - [ ] Short description is under 150 characters
 - [ ] Long description is under 300 characters
 - [ ] Primary keywords appear in title and both descriptions

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -639,3 +639,38 @@ class TestProcessJobDeferral:
         ]
         assert "failed" not in statuses
         assert "completed" not in statuses
+
+
+class TestResolveDurationIntoMetrics:
+    """#126: the SRT-parsed duration must override the word-count estimate so
+    every downstream consumer (routing, prompt context, persisted
+    duration_minutes) reports the same value."""
+
+    @patch("api.services.worker.get_llm_client")
+    def test_srt_duration_overrides_word_count_estimate(self, mock_get_llm, mock_llm_client, tmp_path):
+        mock_get_llm.return_value = mock_llm_client
+        worker = JobWorker()
+
+        # SRT whose last caption ends at 00:18:34 (~18.57 min) — like job 168.
+        srt = tmp_path / "6POL0108.srt"
+        srt.write_text(
+            "1\n00:00:01,000 --> 00:00:04,000\nHello.\n\n" "2\n00:18:30,000 --> 00:18:34,000\nGoodbye.\n",
+            encoding="utf-8",
+        )
+        # Word-count estimate is wrong (38.5 min), like the SEO agent saw.
+        metrics = {"estimated_duration_minutes": 38.5, "word_count": 5000}
+
+        result = worker._resolve_duration_into_metrics(metrics, srt)
+
+        assert abs(result["estimated_duration_minutes"] - 18.57) < 0.2
+        assert metrics["estimated_duration_minutes"] != 38.5
+
+    @patch("api.services.worker.get_llm_client")
+    def test_no_srt_keeps_estimate(self, mock_get_llm, mock_llm_client, tmp_path):
+        mock_get_llm.return_value = mock_llm_client
+        worker = JobWorker()
+        metrics = {"estimated_duration_minutes": 25.0, "word_count": 4000}
+
+        result = worker._resolve_duration_into_metrics(metrics, None)
+
+        assert result["estimated_duration_minutes"] == 25.0


### PR DESCRIPTION
## Sprint 3 — Epic E (#226) editorial/metadata accuracy

| Issue | Fix |
|-------|-----|
| **#126** (HIGH) | Duration was reported five different ways (routing 33min, SEO 38:30, manager 32.5min, persisted `null`) because only the timestamp-phase decision used the SRT-aware `_get_content_duration_minutes()`; routing, prompts, and the persisted `duration_minutes` all used the word-count estimate. Now `process_job` resolves the best-available (SRT-preferred) duration into `transcript_metrics` **once**, right after metrics are computed — so all consumers agree. New `_resolve_duration_into_metrics()` + 2 unit tests (SRT overrides estimate; no-SRT keeps estimate). |
| **#132** | SEO prompt pinned to a **60-char** title (was 60–68 with a 70 ceiling) to match the manager phase's 60-char rule — stops the manager flagging a revision on essentially every episode. |

### Tests
`_resolve_duration_into_metrics` is TDD'd (RED→GREEN) with an SRT ending at 00:18:34 like the job-168 example. Full worker suite: 29 passed. `ruff`/`black` clean.

### Deferred (Epic E, left open)
- **#131** deterministic header from filename + SST — moderate, touches the file-write site + agent prompts. High value (kills hallucinated dates/models in every output); natural next pickup.
- **Prompt-tuning batch #130/#133/#134/#135/#136** (formatter house-style: multi-paragraph blocks, speaker swaps, possessives, em-dashes, unknown-speaker inline) — these change *LLM output* and can't be unit-tested; best done as **one editor-reviewed batch** against real episode runs, not blind markdown edits.
- #128/#113/#10 — investigation/test items.

Closes #126, #132.