### PR TITLE
refactor(llm): Epic L increment 1 — remove dead tier-escalation machinery (#233)

### DIFF
--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -525,39 +525,13 @@ class LLMClient:
         phase_backends = self.config.get("phase_backends", {})
         return phase_backends.get(phase, self.config.get("primary_backend", "openrouter"))
 
-    def get_next_tier(self, current_tier: int) -> Optional[int]:
-        """Get the next escalation tier, or None if at max.
-
-        Args:
-            current_tier: Current tier index
-
-        Returns:
-            Next tier index, or None if already at max
-        """
-        routing_config = self.config.get("routing", {})
-        tiers = routing_config.get("tiers", ["openrouter-cheapskate", "openrouter", "openrouter-big-brain"])
-
-        if current_tier < len(tiers) - 1:
-            return current_tier + 1
-        return None
-
-    def get_escalation_config(self) -> Dict[str, Any]:
-        """Get escalation configuration.
-
-        Returns:
-            Dict with escalation settings (enabled, on_failure, on_timeout, etc.)
-        """
-        routing_config = self.config.get("routing", {})
-        return routing_config.get(
-            "escalation",
-            {
-                "enabled": True,
-                "on_failure": True,
-                "on_timeout": True,
-                "timeout_seconds": 120,
-                "max_retries_per_tier": 1,
-            },
-        )
+    # NOTE: The auto-escalation tier ladder (get_next_tier / get_escalation_config)
+    # was removed in Epic L. Sprint 3 replaced automatic tier escalation with
+    # user-driven retry (POST .../retry with an explicit model_override), so the
+    # "cheapskate -> default -> big-brain" walk had no callers. Per-phase model
+    # selection is now direct via the phase_models config (see _resolve_model in
+    # generate()). See planning/epic-l-consolidation-plan.md for the remaining
+    # phase_backends -> phase_models consolidation.
 
     def get_api_key(self, backend_config: Dict[str, Any]) -> Optional[str]:
         """Get API key for a backend from environment."""

--- a/planning/epic-l-consolidation-plan.md
+++ b/planning/epic-l-consolidation-plan.md
@@ -1,0 +1,76 @@
+# Epic L — Preset-tier removal: consolidation plan
+
+**Status:** Increment 1 done (this PR). Increment 2 (the heavy part) is scoped
+here for a **dedicated session** — it needs a cost rewire, a config migration,
+and the deferred single-model-dropdown frontend.
+
+## What Epic L actually is (investigation, 2026-06-20)
+
+The "cheapskate / default / big-brain" preset tiers are **not** a load-bearing
+runtime abstraction. The runtime already does direct per-phase model selection:
+
+- **Model resolution** (`api/services/llm.py`, `generate()`): precedence is
+  `force_model` (e.g. local-dougie) → explicit `model` override → **`phase_models[phase]`**
+  → backend `model`/`fallback_model`. So `config/llm-config.json`'s `phase_models`
+  (phase → concrete model id) already drives the model.
+- **`phase_backends`** (phase → tier-named backend) now only supplies the
+  *transport* (endpoint/type/api_key) and a flat `cost_per_project` estimate.
+- **Auto-escalation is gone.** `get_next_tier` / `get_escalation_config` had zero
+  callers (Sprint 3 replaced auto-escalation with user-driven retry +
+  `model_override`). Removed in Increment 1.
+
+## Increment 1 (this PR) — safe, done
+
+- Removed dead `get_next_tier` + `get_escalation_config` (the tier ladder).
+- Closed **#103** (stale `tier`/`tier_label`/`tier_reason` in `retry_single_phase`
+  — already cleaned by Sprint 3; verified no code refs remain).
+
+## Increment 2 (dedicated session) — the consolidation
+
+**Goal:** make `phase_models` the single source of truth; delete `phase_backends`
+and the tier-named backends; derive cost from the model, not the tier.
+
+### Steps (in order)
+1. **Cost rewire (the risk).** Today `cost_per_project` is per-backend
+   (cheapskate 0.0 / openrouter 0.02 / big-brain 0.1). With direct model
+   selection, cost must come from the model. Decide: per-model `cost_per_1k`
+   (config has `safety.max_cost_per_1k_tokens`) computed from actual token
+   usage, or a per-model `cost_per_project` table. Verify the `run_cost_cap`
+   (`safety.run_cost_cap`) and `_backend_cost` path still hold. **This is the
+   step that can mis-bill jobs — do it first, with tests, against real
+   `session_stats` rows.**
+2. **Collapse backends.** Point every phase at one transport backend
+   (`openrouter` / `openrouter-direct`); keep `local-dougie` (force_model) and
+   the disabled ollama entries. Delete `openrouter-cheapskate` /
+   `openrouter-big-brain` once nothing references them.
+3. **Config migration + back-compat shim.** A migration that maps any existing
+   `phase_backends` value → the equivalent `phase_models` entry on load, so
+   deployed `llm-config.json` files (incl. the homelab's) don't break. Keep the
+   shim for one release, then remove.
+4. **API contract.** Remove `PhaseBackendsUpdate` / `get_phase_backends` /
+   `update_phase_backends` and the `0≤tier≤2` validation in
+   `api/routers/config.py` once the frontend no longer calls them. The
+   `phase_models` endpoints already exist and are the replacement.
+5. **#92 roster narrowing** (pairs with the frontend). The `model_families`
+   glob patterns pull ~25 models (old Gemini, image models, lite variants) into
+   the Settings dropdown. Tighten to version-specific globs and/or add an
+   `exclude` list. Validate against a live OpenRouter roster call. Belongs with
+   the dropdown frontend because it shapes that dropdown's contents.
+6. **Frontend (#69)** — single model dropdown replacing the tier dropdowns
+   (Settings, JobDetail retry, TranscriptUploader). Deferred to the frontend
+   session; the dropdowns already read `routing.tier_labels` dynamically, so the
+   swap is contained. Needs browser verification.
+7. **Remove per-model `tier` / `min_tier`.** Once nothing reads them
+   (`available_models[].tier`, `model_families[].tier`, `routing.chunking.min_tier`
+   — check the chunking path first), drop them from config.
+
+### Test anchors
+- `tests/api/test_llm.py`, `tests/api/test_worker.py` (model resolution).
+- New: cost-from-model test against known token counts.
+- Config round-trip: a legacy `phase_backends`-only config still resolves models
+  via the shim.
+
+### Sequencing
+Cost rewire (1) → backend collapse (2) → migration/shim (3) → API + frontend
+(4,6) → roster (5) → tier-field removal (7). Don't skip the shim — the homelab
+runs a hand-trimmed `llm-config.json` (see memory: cardigan-lxc-deployment).


### PR DESCRIPTION
## Epic L (#233) — preset-tier removal, increment 1 (safe)

After deep investigation, the 'cheapskate/default/big-brain' tiers turned out **not** to be a load-bearing runtime abstraction. The runtime already does direct per-phase model selection via `phase_models` (`llm.py` `generate()`: force_model → explicit override → `phase_models[phase]` → backend fallback). The tier machinery was mostly dead.

### This PR (no behavior change)
- **Removed dead `get_next_tier` + `get_escalation_config`** — the auto-escalation ladder had **zero callers**. Sprint 3 replaced auto-escalation with user-driven retry (explicit `model_override`).
- **Closed #103** — stale `tier`/`tier_label`/`tier_reason` in `retry_single_phase` were already cleaned by Sprint 3 (the issue said it would be); verified no code refs remain.
- **Added `planning/epic-l-consolidation-plan.md`** — scopes increment 2.

### Why not the full removal here
The remaining consolidation (collapse `phase_backends`→`phase_models`, delete the tier-named backends) requires a **cost rewire** — the tier backends carry `cost_per_project` (0.0/0.02/0.1); direct selection must derive cost from the *model*, not the tier. That plus a **config migration** (the homelab runs a hand-trimmed `llm-config.json`) and the **deferred single-model dropdown frontend** (#69) + roster narrowing (#92) make it a dedicated-session task. Rushing a cost rewire at the tail of a long session is how jobs get mis-billed. The plan doc sequences it cost-first, with test anchors.

89 llm/worker tests pass; `ruff`/`black` clean.

Refs #233. Closes #103.