### PR TITLE
fix(ci,tests): Epic I — un-hang the suite, clear #200 backlog, pin lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install lint tools
-        run: pip install ruff black
+        run: pip install -r requirements-dev.txt
       - name: Ruff check
         run: ruff check .
       - name: Black check
@@ -65,23 +65,18 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Create required directories
         run: mkdir -p OUTPUT transcripts logs
       - name: Run database migrations
         run: alembic upgrade head
       - name: Run tests
-        run: |
-          # Exit code 2 = KeyboardInterrupt during cleanup (all tests pass but async teardown hangs).
-          # This is safe to ignore when the test summary shows 0 failures.
-          set +e
-          timeout 60 pytest --tb=short -q
-          rc=$?
-          set -e
-          if [ $rc -eq 0 ] || [ $rc -eq 2 ] || [ $rc -eq 124 ]; then
-            exit 0
-          fi
-          exit $rc
+        # Per-test timeout (pytest-timeout) guards against a single hung test stalling
+        # the job: that test is killed and reported as a failure, so a real hang turns
+        # CI red instead of being masked. The old `timeout 60` + swallow-exit-2/124 hack
+        # is gone now that the mid-suite hang (#102) and the teardown KeyboardInterrupt
+        # leak are fixed — the suite exits 0 cleanly.
+        run: pytest --tb=short -q --timeout=60 --timeout-method=thread
 
   build-frontend:
     name: Frontend Build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Pinned developer / CI tooling — keeps lint behavior reproducible between
+# local checkouts and the CI `Python Lint` job. Unpinned `pip install ruff black`
+# let a tool release flip CI green->red with no code change (see #196, #210, #186:
+# an unpinned black 26.5.1 bump rotted a previously-green PR, and a ruff-format vs
+# black disagreement forced a two-round lint fix on #186).
+#
+# Bump deliberately: update the version here, run `ruff check .` + `black --check .`
+# locally, and reformat in the same PR so local and CI never skew.
+black==26.5.1
+ruff==0.15.15
+
+# Per-test hang guard for CI. A single test that hangs now fails loudly (that test
+# is killed and reported) instead of stalling the whole job — which previously forced
+# the `timeout 60 pytest` + swallow-exit-124 hack that masked real hangs (see #102).
+pytest-timeout==2.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,10 @@ import pytest
 
 from api.services import database
 
+# Path of the shared, session-scoped test DB. Stashed at session init so the
+# per-test healing fixture below can restore it after a test swaps it out.
+_SHARED_DB_PATH: str | None = None
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _init_test_db():
@@ -20,9 +24,11 @@ def _init_test_db():
     Instead of using TestClient lifespan (which hangs on shutdown),
     directly initialize the database engine for tests.
     """
+    global _SHARED_DB_PATH
     fd, db_path = tempfile.mkstemp(suffix=".db")
     os.close(fd)
     os.environ["DATABASE_PATH"] = db_path
+    _SHARED_DB_PATH = db_path
 
     # Initialize DB engine and create tables
     loop = asyncio.new_event_loop()
@@ -31,10 +37,46 @@ def _init_test_db():
 
     yield
 
+    _SHARED_DB_PATH = None
     try:
         os.unlink(db_path)
     except Exception:
         pass
+
+
+@pytest.fixture(autouse=True)
+def _restore_shared_db():
+    """Heal the shared session DB after any test that points DATABASE_PATH at its
+    own migrated DB and nulls the database-module globals (e.g. the consumer-key
+    fixtures in test_consumer_key_auth.py / test_consumer_keys_service.py).
+
+    Those fixtures call ``close_db()`` and set ``_engine``/``_async_session_factory``
+    to ``None`` on teardown but never re-init the session DB. Because ``_init_test_db``
+    is session-scoped (runs once), the first such test leaves the factory ``None`` for
+    the rest of the run, so every later test that reaches ``get_session()`` fails with
+    "Database not initialized. Call init_db() first." — the dominant cause of the
+    full-sweep failures tracked in #200 (surfaced once #102's hang was fixed).
+
+    This is an autouse function-scoped fixture, so it sets up before any test-requested
+    fixture and therefore tears down *after* them — i.e. after the polluting fixture has
+    nulled the globals. It only re-inits when drift is detected, keeping the common path
+    cheap.
+    """
+    yield
+
+    if _SHARED_DB_PATH is None:
+        return
+
+    drifted = database._async_session_factory is None or os.environ.get("DATABASE_PATH") != _SHARED_DB_PATH
+    if not drifted:
+        return
+
+    os.environ["DATABASE_PATH"] = _SHARED_DB_PATH
+    database._engine = None
+    database._async_session_factory = None
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(database.init_db())
+    loop.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_backfill_v21.py
+++ b/tests/test_backfill_v21.py
@@ -91,10 +91,14 @@ async def test_backfill_inserts_v21_jobs_with_new_ids(live_and_source_dbs):
     assert summary["session_stats_inserted"] == 2
 
     c = sqlite3.connect(paths["live"]).cursor()
-    rows = list(c.execute("SELECT app_version, COUNT(*) FROM jobs GROUP BY app_version ORDER BY 1"))
-    # One v4.1 row (existing), two v2.1 rows (backfilled)
-    assert ("v2.1", 2) in rows
-    assert ("v4.1", 1) in rows
+    counts = dict(c.execute("SELECT app_version, COUNT(*) FROM jobs GROUP BY app_version"))
+    # Two backfilled rows tagged v2.1, plus exactly one pre-existing job that keeps
+    # its current-app version. Assert the invariant structurally rather than against a
+    # hardcoded version string: the ambient version is "v4.2-test" in CI (not "v4.1"),
+    # which made the old ("v4.1", 1) assertion a stable-but-broken full-sweep failure
+    # (#200). Decoupled from the app_version symbol so #119's rename can't break it.
+    assert counts.get("v2.1") == 2
+    assert sum(n for v, n in counts.items() if v != "v2.1") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -470,7 +470,14 @@ class TestFileSizeMetadataParsing:
 class TestSmartScanning:
     """Tests for smart scanning workflow."""
 
-    @pytest.mark.xfail(reason="Smart-scan flow not implemented in current scan() — uses directory scan instead")
+    @pytest.mark.xfail(
+        reason=(
+            "Smart-scan flow not implemented in current scan() — uses directory scan instead. "
+            "run=False: the unimplemented path falls through to the real directory scan, which "
+            "opens a live httpx connection to base_url and hangs the whole suite (#102)."
+        ),
+        run=False,
+    )
     @pytest.mark.asyncio
     async def test_smart_scan_queries_qc_passed_media_ids(self):
         """Test that smart scan queries QC-passed Media IDs first."""
@@ -483,7 +490,10 @@ class TestSmartScanning:
         # Should have called get_qc_passed_media_ids
         mock_qc.assert_called_once()
 
-    @pytest.mark.xfail(reason="Smart-scan flow not implemented in current scan() — uses directory scan instead")
+    @pytest.mark.xfail(
+        reason="Smart-scan flow not implemented in current scan(). run=False: unimplemented path hits a real network scan and hangs (#102).",
+        run=False,
+    )
     @pytest.mark.asyncio
     async def test_smart_scan_checks_each_media_id(self):
         """Test that smart scan checks ingest server for each Media ID."""
@@ -498,7 +508,10 @@ class TestSmartScanning:
         mock_check.assert_any_call("2WLI1209HD")
         mock_check.assert_any_call("9UNP2005HD")
 
-    @pytest.mark.xfail(reason="Smart-scan flow not implemented in current scan() — uses directory scan instead")
+    @pytest.mark.xfail(
+        reason="Smart-scan flow not implemented in current scan(). run=False: unimplemented path hits a real network scan and hangs (#102).",
+        run=False,
+    )
     @pytest.mark.asyncio
     async def test_smart_scan_tracks_new_files(self):
         """Test that smart scan tracks newly discovered files."""
@@ -522,7 +535,10 @@ class TestSmartScanning:
         assert result.new_files_found == 1
         assert result.new_transcripts == 1
 
-    @pytest.mark.xfail(reason="Smart-scan flow not implemented in current scan() — uses directory scan instead")
+    @pytest.mark.xfail(
+        reason="Smart-scan flow not implemented in current scan(). run=False: unimplemented path hits a real network scan and hangs (#102).",
+        run=False,
+    )
     @pytest.mark.asyncio
     async def test_smart_scan_returns_statistics(self):
         """Test that smart scan returns scan statistics."""

--- a/tests/test_watch_transcripts.py
+++ b/tests/test_watch_transcripts.py
@@ -440,8 +440,9 @@ class TestWatchLoop:
         """Test that watch loop sleeps between iterations."""
         mock_queued.return_value = set()
 
-        # Run two iterations then stop
-        mock_files.side_effect = [[], [], KeyboardInterrupt()]
+        # The initial startup scan consumes one get_transcript_files() call before the
+        # loop; then two full iterations (each sleeps), then interrupt on the third.
+        mock_files.side_effect = [[], [], [], KeyboardInterrupt()]
 
         watch_loop()
 

--- a/watch_transcripts.py
+++ b/watch_transcripts.py
@@ -120,10 +120,14 @@ def watch_loop():
     print(f"[Watch] Watching {TRANSCRIPTS_DIR} for new transcripts...")
     print("[Watch] Press Ctrl+C to stop")
 
-    seen_files = get_queued_files() | set(get_transcript_files())
+    # Guard the initial scan as well as the loop: a Ctrl+C during the very first
+    # get_transcript_files() (startup) must exit cleanly too. Previously this line
+    # sat outside the try, so an interrupt during startup escaped watch_loop (and,
+    # under test, leaked out of pytest as exit-code 2). See test_watch_loop_keyboard_interrupt.
+    try:
+        seen_files = get_queued_files() | set(get_transcript_files())
 
-    while True:
-        try:
+        while True:
             current_files = set(get_transcript_files())
             new_files = current_files - seen_files
 
@@ -134,9 +138,8 @@ def watch_loop():
             seen_files = seen_files | current_files
             time.sleep(POLL_INTERVAL)
 
-        except KeyboardInterrupt:
-            print("\n[Watch] Stopped.")
-            break
+    except KeyboardInterrupt:
+        print("\n[Watch] Stopped.")
 
 
 def main():


### PR DESCRIPTION
## Summary

Epic I (#230) — makes the Python test suite trustworthy as a whole-suite gate. Picks up the `planning/REMAINING_WORK.md` Cluster 1 backend sprint. Fixes the indefinite-hang that blocked the full `pytest` sweep (#102), then resolves the entire backlog of stable-but-broken failures it was hiding (#200), and modernizes CI lint/test reproducibility (#196).

**Net effect:** full sweep goes from *infinite hang* → **739 passed, 5 xfailed, exit 0 in ~51s**, with no exit-code masking in CI.

## What changed

### #102 — `test_ingest_scanner.py` hangs indefinitely
Root cause: the four `TestSmartScanning` tests are `xfail`'d for an unimplemented flow, but **xfail still executes the body**. They patch only the smart-scan helpers, then call the real `scan()`, which falls through to a live directory scan opening an `httpx` connection to `base_url` (`mmingest.pbswi.wisc.edu`) — hanging mid-suite. Fixed with `xfail(run=False)` (pytest's mechanism for expected-fail tests that must not run).

### #200 — 67 stable-but-broken failures, surfaced once the hang was gone
- **~66 failures, one systemic cause:** fixtures that point `DATABASE_PATH` at their own migrated DB null `database._engine` / `_async_session_factory` on teardown without restoring the session-scoped test DB. Since `conftest._init_test_db` is session-scoped, the first such test left the factory `None` for the rest of the run → every later `get_session()` test failed with *"Database not initialized."* Fixed with an autouse `_restore_shared_db` fixture in `conftest.py` that heals the shared DB on drift (autouse-before-requested ordering guarantees it runs after the polluter's teardown).
- **`test_backfill_v21`:** genuine stale assertion hardcoding `("v4.1", 1)`; ambient version is now `v4.2-test`. Rewritten to assert the invariant structurally (two `v2.1` rows + exactly one pre-existing row), decoupled from the version string.
- **Teardown interrupt leak / exit 2:** `watch_loop()` ran its initial scan outside `try/except KeyboardInterrupt`, so the Ctrl+C injected by `test_watch_loop_keyboard_interrupt` escaped pytest as exit code 2 (the very thing the old CI hack tolerated). Guarded the initial scan — a real bug fix (`watch_loop` now genuinely "exits cleanly on Ctrl+C"). Also corrected the previously-unreachable `test_watch_loop_sleep_interval`.

### #196 — pin lint/test tooling + drop the CI masking hack
- New pinned `requirements-dev.txt` (`ruff==0.15.15`, `black==26.5.1`, `pytest-timeout==2.4.0`), installed in the lint and test jobs. Stops tool releases flipping CI green→red (bit #210, #186).
- Test step drops `timeout 60 pytest` + swallow-exit-`2`/`124` (which **masked hangs as success**). A per-test `pytest-timeout` (`--timeout=60 --timeout-method=thread`) replaces it — a future hung test is killed and reported, turning CI red instead of hiding it.

### #198 — verify-and-close (already fixed)
The patterns #198 describes (`os.environ` mutation + `importlib.reload(api.main)` in `test_mmingest_tools.py`) no longer exist — the file was rewritten to be HTTP-backed (mocks `_mmingest_api_get`) during the MCP-over-HTTP refactor (#215). Closing as already-resolved.

## Verification (local, CI-equivalent)
- `ruff check .` ✅ clean · `black --check .` ✅ 118 files unchanged
- Full sweep with the new CI command: `pytest --tb=short -q --timeout=60 --timeout-method=thread` → **739 passed, 5 xfailed, exit 0**
- Per-fix: smart-scan tests no longer execute (no network); all previously-failing router/queue/backfill tests pass; no exit-2 leak.

## Notes
- Does not touch `api/services/ingest_scanner.py` runtime code — the #168 data-corruption fix lands in a separate Epic H PR (both edit `tests/test_ingest_scanner.py`, so expect a trivial rebase between them).
- Do not merge until reviewed — surfacing for the gate.

Closes #102, closes #200, closes #196, closes #198
