### PR TITLE
fix(ingest-scanner): Epic H — last_seen_at scope + cross-directory dedup (#168, #165)

### DIFF
--- a/api/services/ingest_scanner.py
+++ b/api/services/ingest_scanner.py
@@ -195,11 +195,15 @@ class IngestScanner:
         """
         matching_files: List[RemoteFile] = []
 
+        # One shared visited-URL set across configured directories so overlapping
+        # roots don't re-walk a shared subtree (mirrors scan(); #165 item 1).
+        visited_urls: set = set()
+
         # Scan configured directories for files matching this Media ID
         for directory in self.directories:
             try:
                 dir_url = f"{self.base_url}{directory}"
-                all_files = await self._scan_directory(dir_url, directory)
+                all_files = await self._scan_directory(dir_url, directory, visited_urls=visited_urls)
 
                 # Filter to files matching this Media ID
                 for remote_file in all_files:
@@ -239,11 +243,17 @@ class IngestScanner:
         try:
             all_files: List[RemoteFile] = []
 
+            # Share one visited-URL set across all configured top-level directories
+            # so a subdirectory reachable from more than one root (symlink, bind
+            # mount, Apache Alias) is walked only once per scan. Previously each
+            # top-level call got a fresh set, re-fetching shared targets per root (#168).
+            visited_urls: set = set()
+
             # Scan each configured directory
             for directory in self.directories:
                 dir_url = f"{self.base_url}{directory}"
                 try:
-                    files = await self._scan_directory(dir_url, directory)
+                    files = await self._scan_directory(dir_url, directory, visited_urls=visited_urls)
                     all_files.extend(files)
                 except Exception as e:
                     logger.warning(f"Failed to scan {directory}: {e}")
@@ -359,19 +369,28 @@ class IngestScanner:
                 ]
                 await session.execute(insert_query, params_list)
 
-            # Step 3: Update last_seen_at for existing files (single UPDATE)
-            if existing_urls:
-                update_query = text("""
+            # Step 3: Update last_seen_at for the existing files we actually saw
+            # this scan. Scope by remote_url, batched under the same SQLite
+            # parameter limit as the Step 1 existence check.
+            #
+            # #168: the previous implementation issued an unscoped
+            # `UPDATE available_files SET last_seen_at = :now` with NO WHERE
+            # clause, stamping every row in the table — including files from
+            # other directories not seen this scan — and corrupting the
+            # staleness signal. New files already get last_seen_at = now from the
+            # INSERT above, so only the existing rows need updating here.
+            existing_list = list(existing_urls)
+            for i in range(0, len(existing_list), batch_size):
+                batch_urls = existing_list[i : i + batch_size]
+                placeholders = ",".join([f":url{j}" for j in range(len(batch_urls))])
+                update_query = text(f"""
                     UPDATE available_files
                     SET last_seen_at = :now
-                    WHERE remote_url IN (SELECT remote_url FROM available_files WHERE 1=1)
+                    WHERE remote_url IN ({placeholders})
                 """)
-                # Actually, let's just update all records to current timestamp
-                # This is simpler and still fast
-                update_query = text("""
-                    UPDATE available_files SET last_seen_at = :now
-                """)
-                await session.execute(update_query, {"now": now})
+                params = {f"url{j}": url for j, url in enumerate(batch_urls)}
+                params["now"] = now
+                await session.execute(update_query, params)
 
             await session.commit()
 

--- a/tests/test_ingest_scanner.py
+++ b/tests/test_ingest_scanner.py
@@ -1257,3 +1257,162 @@ class TestBatchedUpsert:
             500,
             1,
         ], f"Expected INSERT batch sizes [500, 500, 1], got {insert_batch_sizes}"
+
+
+class TestIngestScannerDataIntegrity:
+    """Regression tests for #168 (data corruption + scope gap from PR #162).
+
+    Bug 1: the last_seen_at UPDATE ran table-wide (no WHERE), resetting the
+    staleness signal for every row instead of only files seen in the current
+    scan. Bug 2: scan() gave each top-level directory a fresh visited_urls set,
+    so a subdir shared by two configured roots was re-fetched per root. The same
+    fresh-set gap existed on the per-Media-ID entry point (#165 item 1).
+    """
+
+    def _make_files(self, n: int) -> list[RemoteFile]:
+        return [
+            RemoteFile(
+                filename=f"2WLI{i:04d}HD.srt",
+                url=f"https://test.com/2WLI{i:04d}HD.srt",
+                directory_path="/",
+                file_type="transcript",
+                media_id=f"2WLI{i:04d}HD",
+                file_size_bytes=1024,
+                modified_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+            for i in range(n)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_last_seen_update_is_scoped_to_files_seen_this_scan(self):
+        """The last_seen_at UPDATE must carry a WHERE clause bound to the seen URLs.
+
+        Before #168's fix the surviving statement was
+        ``UPDATE available_files SET last_seen_at = :now`` with no WHERE, so a
+        scan of one directory stamped every row in the table — corrupting the
+        staleness signal for files from unrelated directories/scans.
+        """
+        files = self._make_files(3)
+        # Two of the three already exist in the DB; one is new.
+        existing = {files[0].url, files[1].url}
+
+        update_statements: list[tuple[str, dict]] = []
+
+        async def mock_execute(query, params=None):
+            sql = str(query)
+            mock_result = MagicMock()
+            if "SELECT remote_url" in sql:
+                rows = []
+                for url in existing:
+                    row = MagicMock()
+                    row.remote_url = url
+                    rows.append(row)
+                mock_result.fetchall.return_value = rows
+            else:
+                mock_result.fetchall.return_value = []
+            if "UPDATE available_files" in sql:
+                update_statements.append((sql, params if isinstance(params, dict) else {}))
+            return mock_result
+
+        mock_session = AsyncMock()
+        mock_session.execute = mock_execute
+        mock_session.commit = AsyncMock()
+
+        with patch("api.services.ingest_scanner.get_session") as mock_get_session:
+            mock_get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_get_session.return_value.__aexit__ = AsyncMock()
+
+            scanner = IngestScanner()
+            await scanner._track_files_batch(files)
+
+        assert update_statements, "expected a last_seen_at UPDATE for the existing files"
+        for sql, params in update_statements:
+            lowered = sql.lower()
+            assert "where" in lowered, f"last_seen_at UPDATE has no WHERE clause (table-wide!): {sql}"
+            assert "remote_url" in lowered
+            bound_urls = {v for k, v in params.items() if k.startswith("url")}
+            assert bound_urls, "expected remote_url params bound to the UPDATE"
+            assert bound_urls <= existing, f"UPDATE touched URLs not seen this scan: {bound_urls - existing}"
+
+    @pytest.mark.asyncio
+    async def test_visited_urls_shared_across_top_level_directories(self):
+        """A subdir reachable from two configured roots is fetched once, not per-root."""
+        scanner = IngestScanner(base_url="https://test.com", directories=["/a/", "/b/"])
+
+        a_html = (
+            '<html><body><a href="https://test.com/shared/">shared/</a>'
+            '<a href="a_file.srt">a_file.srt</a></body></html>'
+        )
+        b_html = (
+            '<html><body><a href="https://test.com/shared/">shared/</a>'
+            '<a href="b_file.srt">b_file.srt</a></body></html>'
+        )
+        shared_html = '<html><body><a href="shared_file.srt">shared_file.srt</a></body></html>'
+
+        mock_responses = {
+            "https://test.com/a/": a_html,
+            "https://test.com/b/": b_html,
+            "https://test.com/shared/": shared_html,
+        }
+        get_call_counts: dict[str, int] = {}
+
+        async def mock_get(url, auth=None):
+            get_call_counts[url] = get_call_counts.get(url, 0) + 1
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with patch.object(scanner, "_track_files_batch", return_value=(0, 0, 0)):
+                result = await scanner.scan()
+
+        assert result.success is True
+        assert get_call_counts.get("https://test.com/shared/", 0) == 1, (
+            "shared/ reachable from both /a/ and /b/ should be fetched once across the scan, "
+            f"got {get_call_counts.get('https://test.com/shared/', 0)} fetches"
+        )
+
+    @pytest.mark.asyncio
+    async def test_visited_urls_shared_across_media_id_directories(self):
+        """check_ingest_server_for_media_id shares one visited set across directories (#165)."""
+        scanner = IngestScanner(base_url="https://test.com", directories=["/a/", "/b/"])
+
+        a_html = (
+            '<html><body><a href="https://test.com/shared/">shared/</a>'
+            '<a href="2WLI1209HD.srt">2WLI1209HD.srt</a></body></html>'
+        )
+        b_html = '<html><body><a href="https://test.com/shared/">shared/</a></body></html>'
+        shared_html = '<html><body><a href="other.srt">other.srt</a></body></html>'
+
+        mock_responses = {
+            "https://test.com/a/": a_html,
+            "https://test.com/b/": b_html,
+            "https://test.com/shared/": shared_html,
+        }
+        get_call_counts: dict[str, int] = {}
+
+        async def mock_get(url, auth=None):
+            get_call_counts[url] = get_call_counts.get(url, 0) + 1
+            resp = MagicMock()
+            resp.text = mock_responses.get(url, "<html></html>")
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get = mock_get
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            files = await scanner.check_ingest_server_for_media_id("2WLI1209HD")
+
+        assert any(f.filename == "2WLI1209HD.srt" for f in files)
+        assert get_call_counts.get("https://test.com/shared/", 0) == 1


### PR DESCRIPTION
## Summary

Epic H (#229) — fixes the two post-merge bugs an automated review caught after PR #162 landed in `main` (#168), plus the related cross-directory dedup gap (#165 item 1). All in `api/services/ingest_scanner.py`.

## Bug 1 — Critical: `last_seen_at` overwritten table-wide every scan (#168)

`_track_files_batch` Step 3 had a dead first `update_query` overwritten by an unscoped statement:

```sql
UPDATE available_files SET last_seen_at = :now   -- no WHERE clause
```

Every scan stamped **every row** in `available_files`, not just the files seen in that scan — corrupting the staleness signal for files from other directories and prior scans (the `# Actually, let's just update all records...` comment shows it was a quick simplification that wasn't thought through).

**Fix:** scope the UPDATE to `existing_urls` (the current scan's files already in the DB), batched under the same SQLite parameter limit as the Step-1 existence check. New rows already receive `last_seen_at = now` from the INSERT, so only existing rows need this UPDATE.

## Bug 2 — `visited_urls` not shared across top-level directories (#168)

`scan()` called `_scan_directory(dir_url, directory)` per configured directory with no `visited_urls`, so each root got a fresh set. A subdir reachable from two configured roots (symlink / bind mount / Apache Alias) was re-walked once per root.

**Fix:** declare one `visited_urls` set before the loop and thread it into each call.

## #165 item 1 — same gap on the per-Media-ID path

`check_ingest_server_for_media_id` had the identical fresh-set-per-directory issue; fixed the same way so the interactive Media-ID lookup shares one visited set too.

## Tests (TDD: RED before, GREEN after)

New `TestIngestScannerDataIntegrity`:
- `test_last_seen_update_is_scoped_to_files_seen_this_scan` — the UPDATE carries a `WHERE remote_url IN (...)` bound only to the seen URLs (fails on the old table-wide statement).
- `test_visited_urls_shared_across_top_level_directories` — a subdir shared by `/a/` and `/b/` is fetched once via `scan()`.
- `test_visited_urls_shared_across_media_id_directories` — same, via `check_ingest_server_for_media_id`.

## Verification
- `ruff check .` ✅ · `black --check` ✅
- New tests: 3 passed (were 3 failed before the fix).
- No regressions: scanner suite 55 passed / 1 xfailed (smart-scan tests deselected — they hang on `main` per #102, fixed separately in the Epic I PR #247); `TestBatchedUpsert` + `TestRecursiveScanning` 13 passed.

## Coordination
- Touches `tests/test_ingest_scanner.py`, which Epic I PR #247 also edits (the #102 `xfail(run=False)` markers). Different regions — expect a trivial rebase between them. #247 is the one that un-hangs the full suite.
- Do not merge until reviewed.

Closes #168, closes #165
