### PR TITLE
fix(cost): Epic F — app_version plumbing + secrets hygiene + cost-doc (#119, #118, #121, #120)

### DIFF
--- a/api/models/events.py
+++ b/api/models/events.py
@@ -60,6 +60,9 @@ class SessionEvent(BaseModel):
     timestamp: datetime
     event_type: EventType
     data: Optional[EventData] = None
+    # Cost-epoch tag (migration 011). Exposed so API consumers can filter events
+    # by epoch without dropping to raw SQL (#118).
+    app_version: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/api/services/database.py
+++ b/api/services/database.py
@@ -61,7 +61,16 @@ def _default_app_version() -> str:
 # Source of truth: git tag → setuptools_scm → api/__version__ → here.
 # Override at runtime via CARDIGAN_VERSION env var (set in docker-compose.yml).
 # See docs/VERSIONING.md for release/bump policy.
-APP_VERSION = os.getenv("CARDIGAN_VERSION") or _default_app_version()
+#
+# Read at call time (not captured as a module constant) so tests can vary it with
+# monkeypatch.setenv alone, without importlib.reload + manual engine save/restore (#119).
+def get_app_version() -> str:
+    """Return the cost-epoch tag for rows written by this process.
+
+    CARDIGAN_VERSION env override, else derived from the package version.
+    """
+    return os.getenv("CARDIGAN_VERSION") or _default_app_version()
+
 
 from api.models.config import ConfigItem, ConfigValueType
 from api.models.events import EventCreate, EventData, EventType, SessionEvent
@@ -359,7 +368,7 @@ async def create_job(job: JobCreate, app_version: Optional[str] = None) -> Job:
             "phases": json.dumps(initial_phases),
             "retry_count": 0,
             "max_retries": 3,
-            "app_version": app_version if app_version is not None else APP_VERSION,
+            "app_version": app_version if app_version is not None else get_app_version(),
         }
 
         # Insert job
@@ -1214,7 +1223,7 @@ async def log_event(event: EventCreate, app_version: Optional[str] = None) -> Se
             "timestamp": datetime.now(timezone.utc),
             "event_type": event.event_type.value,
             "data": data_json,
-            "app_version": app_version if app_version is not None else APP_VERSION,
+            "app_version": app_version if app_version is not None else get_app_version(),
         }
 
         stmt = session_stats_table.insert().values(**values)
@@ -1456,6 +1465,7 @@ def _row_to_event(row) -> SessionEvent:
         timestamp=row.timestamp,
         event_type=EventType(row.event_type),
         data=event_data,
+        app_version=getattr(row, "app_version", None),
     )
 
 

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -18,6 +18,7 @@ import httpx
 from api.models.events import EventCreate, EventData, EventType
 from api.services.database import log_event
 from api.services.langfuse_client import get_langfuse_client
+from api.services.secrets import get_secret
 
 # Cost cap and safety configuration - can be overridden via environment
 DEFAULT_RUN_COST_CAP = 1.0  # $1 per run max
@@ -534,10 +535,16 @@ class LLMClient:
     # phase_backends -> phase_models consolidation.
 
     def get_api_key(self, backend_config: Dict[str, Any]) -> Optional[str]:
-        """Get API key for a backend from environment."""
+        """Get API key for a backend via the centralized secrets resolver.
+
+        Resolves through api.services.secrets.get_secret (Docker secret file -> env
+        -> macOS Keychain) instead of a bare os.getenv, so a key delivered only as a
+        Docker secret or only in the Keychain still resolves even if bootstrap hasn't
+        populated os.environ for this call path (#121).
+        """
         key_env = backend_config.get("api_key_env")
         if key_env:
-            return os.getenv(key_env)
+            return get_secret(key_env)
         return None
 
     async def chat(

--- a/docs/COST_DATA_VERSIONING.md
+++ b/docs/COST_DATA_VERSIONING.md
@@ -131,6 +131,21 @@ GROUP BY app_version, phase
 ORDER BY app_version, cost DESC;
 ```
 
+### Note on cost rollups (per-job vs per-event)
+
+The two queries above measure different things and can disagree for the same
+epoch. The v2.1 archive is the canonical example:
+
+- **`$1.70`** — `SUM(jobs.actual_cost)`, the per-job rollup.
+- **`$2.26`** — `SUM(json_extract(session_stats.data,'$.cost'))` summed across
+  `phase_completed` events, the per-event total.
+
+They differ because in v2.1 only 33 of 152 jobs had `actual_cost` populated
+(job-level cost tracking was less reliable then), whereas the per-event sum
+captures phase costs even when the job-level rollup was missed. **The per-event
+number is the more complete measurement;** prefer it when reconciling dashboards,
+and don't expect the two totals to match for older epochs.
+
 ## What `app_version` does *not* capture
 
 Quality. Cost is half the picture; whether the cost was worth it is

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -16,10 +16,12 @@ from api.services.database import (
     create_job,
     defer_job,
     delete_job,
+    get_app_version,
     get_config,
     get_events_for_job,
     get_job,
     get_next_pending_job,
+    get_session,
     get_stale_jobs,
     init_db,
     list_config,
@@ -737,26 +739,20 @@ async def test_create_job_with_explicit_path_no_sanitization(test_db):
 
 
 @pytest.mark.asyncio
+async def test_get_app_version_reads_env_at_call_time(monkeypatch):
+    """get_app_version() honors CARDIGAN_VERSION read at call time (#119)."""
+    monkeypatch.setenv("CARDIGAN_VERSION", "v9.9-probe")
+    assert get_app_version() == "v9.9-probe"
+
+
+@pytest.mark.asyncio
 async def test_create_job_sets_default_app_version(test_db, monkeypatch):
     """Newly created jobs are tagged with CARDIGAN_VERSION env (default v4.1)."""
     monkeypatch.setenv("CARDIGAN_VERSION", "v4.2-test")
-    # APP_VERSION is read at module import, so we re-read from os.environ via a helper
-    import importlib
-
-    import api.services.database as db_mod
-
-    # Save current engine state (set up by test_db fixture)
-    saved_engine = db_mod._engine
-    saved_factory = db_mod._async_session_factory
-
-    importlib.reload(db_mod)  # picks up the patched env var; resets engine globals
-
-    # Restore engine state so the reloaded module can reach the test DB
-    db_mod._engine = saved_engine
-    db_mod._async_session_factory = saved_factory
-
-    job = await db_mod.create_job(
-        db_mod.JobCreate(
+    # get_app_version() reads the env at call time, so monkeypatch.setenv alone
+    # suffices — no importlib.reload + engine save/restore needed (#119).
+    job = await create_job(
+        JobCreate(
             project_name="ver-test",
             project_path="/projects/ver-test",
             transcript_file="/transcripts/ver-test.txt",
@@ -768,30 +764,16 @@ async def test_create_job_sets_default_app_version(test_db, monkeypatch):
 @pytest.mark.asyncio
 async def test_log_event_sets_default_app_version(test_db, monkeypatch):
     monkeypatch.setenv("CARDIGAN_VERSION", "v4.2-test")
-    import importlib
+    job = await create_job(JobCreate(project_name="ev", project_path="/p/ev", transcript_file="/t/ev.txt"))
+    event = await log_event(EventCreate(job_id=job.id, event_type=EventType.job_started, data=None))
 
-    import api.services.database as db_mod
+    # The SessionEvent model now exposes app_version directly (#118), no raw SQL needed.
+    assert event.app_version == "v4.2-test"
 
-    # Save current engine state (set up by test_db fixture)
-    saved_engine = db_mod._engine
-    saved_factory = db_mod._async_session_factory
-
-    importlib.reload(db_mod)  # picks up the patched env var; resets engine globals
-
-    # Restore engine state so the reloaded module can reach the test DB
-    db_mod._engine = saved_engine
-    db_mod._async_session_factory = saved_factory
-
-    job = await db_mod.create_job(
-        db_mod.JobCreate(project_name="ev", project_path="/p/ev", transcript_file="/t/ev.txt")
-    )
-    event = await db_mod.log_event(
-        db_mod.EventCreate(job_id=job.id, event_type=db_mod.EventType.job_started, data=None)
-    )
-    # Read raw row to inspect column
+    # Belt-and-braces: the column itself carries the tag too.
     from sqlalchemy import text
 
-    async with db_mod.get_session() as s:
+    async with get_session() as s:
         row = (
             await s.execute(
                 text("SELECT app_version FROM session_stats WHERE id = :id"),


### PR DESCRIPTION
## Summary

Epic F (#227) — a batch of four small cost/observability hygiene fixes from the cost-data-preservation review. (Originally delegated to a teammate that failed to launch — its spawn pointed at a missing `claude` binary — so handled directly.)

## Changes

### #119 — `get_app_version()` instead of a module constant
`api/services/database.py` defined `APP_VERSION = os.getenv("CARDIGAN_VERSION") or _default_app_version()` at import time, forcing tests that vary the value to `importlib.reload(db_mod)` with manual `_engine`/`_async_session_factory` save+restore. Replaced with `get_app_version()`, read at call time — identical runtime behavior, and the two reload-based tests in `tests/api/test_database.py` collapse to plain `monkeypatch.setenv`. No external references to the old constant existed (verified repo-wide).

### #118 — `SessionEvent.app_version`
The `app_version` column (migration 011) wasn't exposed on the `SessionEvent` model — only `Job`/`ChatSession` were updated. Added the field to `api/models/events.py` and populated it in `_row_to_event` (`getattr(row, "app_version", None)`, matching the existing pattern). API consumers can now filter session events by cost epoch without raw SQL.

### #121 — `get_api_key` via the secrets resolver
`LLMClient.get_api_key()` used a bare `os.getenv(key_env)`, bypassing the three-tier `api/services/secrets.get_secret` (Docker secret file → env → macOS Keychain). Routed it through `get_secret` so a key delivered only as a Docker secret or only in the Keychain still resolves on call paths where `bootstrap_secrets()` hasn't populated `os.environ`. None-contract preserved.

### #120 — cost-rollups doc note
Added a "Note on cost rollups" subsection to `docs/COST_DATA_VERSIONING.md` explaining the v2.1 `$1.70` (per-job `SUM(jobs.actual_cost)`) vs `$2.26` (per-event `SUM(json_extract(...'$.cost'))`) discrepancy — only 33/152 v2.1 jobs had `actual_cost`, so the per-event sum is the more complete figure.

## Verification
- `ruff check .` ✅ · `black --check` ✅
- Isolated (pollution-free): `test_database.py` 36 passed (incl. a new call-time `get_app_version` test + the simplified app_version tests), `test_llm.py` 60 passed, `test_app_version_migration.py` + `tests/mcp_server` 18 passed.
- Against the `origin/main` baseline, this branch **adds one passing test and zero failures** (the broader-dir 32 failed / 35 errors are the pre-existing #200 `DATABASE_PATH` pollution fixed in PR #247, not introduced here).

## Notes
- Independent of PRs #247/#248 (different files). Do not merge until reviewed.

Closes #119, closes #118, closes #121, closes #120
