### PR TITLE
feat(ingest): Ready for Work — filter non-Media-ID file noise (#106)

### DIFF
--- a/api/routers/ingest.py
+++ b/api/routers/ingest.py
@@ -264,13 +264,16 @@ async def list_available_files(
             for row in rows
         ]
 
-        # Get total count of new files
-        count_query = text("""
+        # Get total count of new files. Apply the same Media-ID filter as the
+        # list query above so total_new matches what's actually shown (#106).
+        count_sql = """
             SELECT COUNT(*) as count
             FROM available_files
             WHERE status = 'new' AND file_type = :file_type
-        """)
-        result = await session.execute(count_query, {"file_type": file_type or "transcript"})
+        """
+        if has_media_id:
+            count_sql += " AND media_id IS NOT NULL AND TRIM(media_id) != ''"
+        result = await session.execute(text(count_sql), {"file_type": file_type or "transcript"})
         total_new = result.fetchone().count
 
     # Get last scan timestamp from config

--- a/api/routers/ingest.py
+++ b/api/routers/ingest.py
@@ -170,6 +170,11 @@ async def list_available_files(
         default=30, ge=1, le=365, description="Filter by first_seen_at within N days (default: 30)"
     ),
     exclude_with_jobs: bool = Query(default=True, description="Hide files that already have linked jobs"),
+    has_media_id: bool = Query(
+        default=True,
+        description="Only return files with a recognized PBS Media ID (default: true). "
+        "Set false to also show un-parsed files (notes, OS dupes), sorted below valid IDs.",
+    ),
 ) -> AvailableFilesResponse:
     """
     List files available for queueing.
@@ -184,6 +189,12 @@ async def list_available_files(
         search: Search term for filename or Media ID
         days: Filter to files seen within N days (default: 30)
         exclude_with_jobs: Hide files already linked to jobs (default: true)
+        has_media_id: Only return files whose filename parsed to a Media ID
+            (default: true). The scanner stores ``media_id`` only when
+            ``extract_media_id`` matches the PBS pattern, so a non-null value
+            means a recognized ID. Files like ``TLB CC IN WI.srt`` or
+            ``episode_notes.txt`` carry ``media_id = NULL`` and are noise on the
+            Ready-for-Work page; filtered out by default (#106).
 
     Returns:
         List of available files
@@ -220,8 +231,18 @@ async def list_available_files(
         if exclude_with_jobs:
             query += " AND job_id IS NULL"
 
-        # Sort by server modification time when available, otherwise first_seen
-        query += " ORDER BY COALESCE(remote_modified_at, first_seen_at) DESC LIMIT :limit"
+        # Media-ID filter: a non-null media_id means the filename parsed to a
+        # recognized PBS Media ID. Filtered in by default to keep the
+        # Ready-for-Work list free of notes / OS-duplicate noise (#106).
+        if has_media_id:
+            query += " AND media_id IS NOT NULL AND TRIM(media_id) != ''"
+
+        # Sort recognized Media IDs first (relevant when has_media_id is false),
+        # then by server modification time when available, otherwise first_seen.
+        query += (
+            " ORDER BY (media_id IS NULL OR TRIM(media_id) = '') ASC,"
+            " COALESCE(remote_modified_at, first_seen_at) DESC LIMIT :limit"
+        )
 
         result = await session.execute(text(query), params)
         rows = result.fetchall()

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -336,6 +336,49 @@ class TestAvailableFilesEndpoint:
         assert "media_id IS NOT NULL" not in sql, "has_media_id=false must not filter on media_id"
         assert "ORDER BY (media_id IS NULL" in sql
 
+    def _run_available_capturing_count_query(self, url: str) -> str:
+        """Hit GET /api/ingest/available and return the COUNT query's SQL text."""
+        captured = {}
+        with (
+            patch("api.routers.ingest.get_session") as mock_session,
+            patch("api.services.airtable.AirtableClient") as mock_airtable_class,
+            patch("api.routers.ingest.get_ingest_config", new_callable=AsyncMock) as mock_config,
+        ):
+            mock_db = MagicMock()
+            mock_result = MagicMock()
+            mock_result.fetchall.return_value = []
+            mock_count_result = MagicMock()
+            mock_count_row = MagicMock()
+            mock_count_row.count = 0
+            mock_count_result.fetchone.return_value = mock_count_row
+
+            async def execute_side_effect(query, params):
+                sql = str(query)
+                if "COUNT" in sql:
+                    captured["sql"] = sql
+                    return mock_count_result
+                return mock_result
+
+            mock_db.execute = AsyncMock(side_effect=execute_side_effect)
+            mock_session.return_value.__aenter__.return_value = mock_db
+            mock_airtable_class.return_value = MagicMock()
+            mock_config.return_value = MagicMock(last_scan_at=None)
+
+            response = client.get(url)
+            assert response.status_code == 200
+        return captured["sql"]
+
+    def test_count_query_filters_non_media_id_by_default(self):
+        """#106: total_new must apply the same Media-ID filter as the list, by default."""
+        sql = self._run_available_capturing_count_query("/api/ingest/available")
+        assert "media_id IS NOT NULL" in sql, "total_new must exclude null-media_id noise to match list"
+        assert "TRIM(media_id) != ''" in sql
+
+    def test_count_query_includes_non_media_id_when_disabled(self):
+        """#106: has_media_id=false must not filter the count, matching the list."""
+        sql = self._run_available_capturing_count_query("/api/ingest/available?has_media_id=false")
+        assert "media_id IS NOT NULL" not in sql, "has_media_id=false count must not filter on media_id"
+
 
 class TestTranscriptEndpoints:
     """Tests for transcript action endpoints."""

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -291,6 +291,51 @@ class TestAvailableFilesEndpoint:
 
             assert response.status_code == 200
 
+    def _run_available_capturing_query(self, url: str) -> str:
+        """Hit GET /api/ingest/available and return the main SELECT's SQL text."""
+        captured = {}
+        with (
+            patch("api.routers.ingest.get_session") as mock_session,
+            patch("api.services.airtable.AirtableClient") as mock_airtable_class,
+            patch("api.routers.ingest.get_ingest_config", new_callable=AsyncMock) as mock_config,
+        ):
+            mock_db = MagicMock()
+            mock_result = MagicMock()
+            mock_result.fetchall.return_value = []
+            mock_count_result = MagicMock()
+            mock_count_row = MagicMock()
+            mock_count_row.count = 0
+            mock_count_result.fetchone.return_value = mock_count_row
+
+            async def execute_side_effect(query, params):
+                sql = str(query)
+                if "COUNT" in sql:
+                    return mock_count_result
+                captured["sql"] = sql
+                return mock_result
+
+            mock_db.execute = AsyncMock(side_effect=execute_side_effect)
+            mock_session.return_value.__aenter__.return_value = mock_db
+            mock_airtable_class.return_value = MagicMock()
+            mock_config.return_value = MagicMock(last_scan_at=None)
+
+            response = client.get(url)
+            assert response.status_code == 200
+        return captured["sql"]
+
+    def test_list_available_filters_non_media_id_by_default(self):
+        """#106: GET /api/ingest/available hides files with no recognized Media ID by default."""
+        sql = self._run_available_capturing_query("/api/ingest/available")
+        assert "media_id IS NOT NULL" in sql, "default listing must exclude null-media_id noise"
+        # And valid Media IDs always sort ahead of un-parsed files.
+        assert "ORDER BY (media_id IS NULL" in sql
+
+    def test_list_available_includes_non_media_id_when_disabled(self):
+        """#106: has_media_id=false shows un-parsed files too (still sorted below valid IDs)."""
+        sql = self._run_available_capturing_query("/api/ingest/available?has_media_id=false")
+        assert "media_id IS NOT NULL" not in sql, "has_media_id=false must not filter on media_id"
+        assert "ORDER BY (media_id IS NULL" in sql
+
 
 class TestTranscriptEndpoints:
     """Tests for transcript action endpoints."""


### PR DESCRIPTION
## Summary

Epic H (#229), part 2 of #106 — keeps the Ready-for-Work page free of files that don't carry a recognized PBS Media ID (notes like `episode_notes.txt`, OS duplicates like `filename (1).srt`, `TLB CC IN WI.srt`, etc.). These were stored with `media_id = NULL` and shown as if queueable.

## Change
`GET /api/ingest/available` gains a **`has_media_id` param (default `true`)**:
- **true** → only rows with a non-null, non-blank `media_id`. The scanner sets `media_id` only when `extract_media_id` matches the PBS pattern, so non-null ⟺ recognized ID — no need to re-validate the regex in SQL.
- **false** → show everything, but recognized Media IDs always sort first (so the noise is surfaced deliberately, below the real work).

Sorting now leads with `(media_id IS NULL OR TRIM(media_id) = '') ASC` in both modes.

## Scope
Part 2 of #106 only. **Part 1** (the `POST /api/ingest/scan` 500 / scan errors) was the indefinite scanner hang fixed under #102; richer scan-error surfacing/persistence is tracked separately in #75. This PR does not close #106 outright — leaving it open for the part-1/#75 work — but resolves the data-quality half.

## Verification
- `ruff` ✅ · `black` ✅
- `tests/test_ingest_api.py` 14 passed (2 new: filter present by default; dropped when `has_media_id=false`).
- SQL validated against real sqlite: default excludes null/empty media_id; `false` returns all with valid IDs sorted first.

Refs #106 (part 2)