### PR TITLE
feat(ingest): persist + surface last scan error detail (#75 backend)

### DIFF
--- a/api/models/ingest.py
+++ b/api/models/ingest.py
@@ -202,6 +202,9 @@ class IngestConfig(BaseModel):
     scan_time: str = Field("00:00", description="Time of day to run scan (HH:MM)")
     last_scan_at: Optional[datetime] = Field(None, description="When last scan completed")
     last_scan_success: Optional[bool] = Field(None, description="Whether last scan succeeded")
+    last_scan_error: Optional[str] = Field(
+        None, description="Error detail from the last scan if it failed; cleared on the next successful scan"
+    )
     server_url: str = Field("https://mmingest.pbswi.wisc.edu/", description="Base URL of ingest server")
     directories: List[str] = Field(
         default_factory=lambda: ["/"], description="Root directories to scan (recurses into subdirectories)"

--- a/api/routers/ingest.py
+++ b/api/routers/ingest.py
@@ -301,8 +301,8 @@ async def trigger_scan(
         )
         result = await scanner.scan()
 
-        # Record scan result in config
-        await record_scan_result(success=result.success)
+        # Record scan result in config (persists error detail on partial failure)
+        await record_scan_result(success=result.success, error=result.error_message)
 
         return ScanResponse(
             success=result.success,
@@ -316,8 +316,8 @@ async def trigger_scan(
         )
     except Exception as e:
         logger.error(f"Scan failed: {e}")
-        # Record failed scan
-        await record_scan_result(success=False)
+        # Record failed scan with the error detail so the Ready screen can show why.
+        await record_scan_result(success=False, error=str(e))
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/api/services/ingest_config.py
+++ b/api/services/ingest_config.py
@@ -28,6 +28,7 @@ KEY_SCAN_INTERVAL_HOURS = f"{INGEST_PREFIX}scan_interval_hours"
 KEY_SCAN_TIME = f"{INGEST_PREFIX}scan_time"
 KEY_LAST_SCAN_AT = f"{INGEST_PREFIX}last_scan_at"
 KEY_LAST_SCAN_SUCCESS = f"{INGEST_PREFIX}last_scan_success"
+KEY_LAST_SCAN_ERROR = f"{INGEST_PREFIX}last_scan_error"
 KEY_SERVER_URL = f"{INGEST_PREFIX}server_url"
 KEY_DIRECTORIES = f"{INGEST_PREFIX}directories"
 KEY_IGNORE_DIRECTORIES = f"{INGEST_PREFIX}ignore_directories"
@@ -95,6 +96,7 @@ async def get_ingest_config() -> IngestConfig:
     time_item = await get_config(KEY_SCAN_TIME)
     last_scan_item = await get_config(KEY_LAST_SCAN_AT)
     last_success_item = await get_config(KEY_LAST_SCAN_SUCCESS)
+    last_error_item = await get_config(KEY_LAST_SCAN_ERROR)
     server_url_item = await get_config(KEY_SERVER_URL)
     directories_item = await get_config(KEY_DIRECTORIES)
     ignore_dirs_item = await get_config(KEY_IGNORE_DIRECTORIES)
@@ -116,6 +118,9 @@ async def get_ingest_config() -> IngestConfig:
     last_scan_success = None
     if last_success_item:
         last_scan_success = last_success_item.get_typed_value()
+
+    # Empty string is stored on success to clear a prior error; treat it as None.
+    last_scan_error = last_error_item.value if last_error_item and last_error_item.value else None
 
     server_url = server_url_item.value if server_url_item else DEFAULT_CONFIG.server_url
 
@@ -139,6 +144,7 @@ async def get_ingest_config() -> IngestConfig:
         scan_time=scan_time,
         last_scan_at=last_scan_at,
         last_scan_success=last_scan_success,
+        last_scan_error=last_scan_error,
         server_url=server_url,
         directories=directories,
         ignore_directories=ignore_directories,
@@ -183,13 +189,18 @@ async def update_ingest_config(updates: IngestConfigUpdate) -> IngestConfig:
     return await get_ingest_config()
 
 
-async def record_scan_result(success: bool) -> None:
+async def record_scan_result(success: bool, error: Optional[str] = None) -> None:
     """Record the result of a scan operation.
 
-    Updates last_scan_at timestamp and last_scan_success flag.
+    Updates last_scan_at timestamp, last_scan_success flag, and last_scan_error
+    detail. On success the error is cleared (stored as an empty string) so a stale
+    failure message never lingers on the Ready screen after a good scan (#75).
 
     Args:
         success: Whether the scan completed successfully
+        error: Failure detail to persist when ``success`` is False (truncated to a
+            sane length so a giant traceback can't bloat the config row). Ignored
+            on success.
     """
     now = datetime.utcnow()
 
@@ -197,6 +208,16 @@ async def record_scan_result(success: bool) -> None:
 
     await set_config(
         KEY_LAST_SCAN_SUCCESS, str(success).lower(), value_type="bool", description="Whether last scan succeeded"
+    )
+
+    # Persist the failure detail (cleared on success). Cap length so a stack trace
+    # can't blow up the config value.
+    error_value = "" if success else (error or "Scan failed (no detail captured)")[:2000]
+    await set_config(
+        KEY_LAST_SCAN_ERROR,
+        error_value,
+        value_type="string",
+        description="Detail from the last failed scan; empty when the last scan succeeded",
     )
 
 

--- a/api/services/ingest_scheduler.py
+++ b/api/services/ingest_scheduler.py
@@ -50,8 +50,8 @@ async def run_scheduled_scan():
         # Run scan
         result = await scanner.scan()
 
-        # Record result
-        await record_scan_result(success=result.success)
+        # Record result (persists error detail on partial failure)
+        await record_scan_result(success=result.success, error=result.error_message)
 
         if result.success:
             logger.info(
@@ -64,7 +64,7 @@ async def run_scheduled_scan():
 
     except Exception as e:
         logger.error(f"Scheduled scan error: {e}", exc_info=True)
-        await record_scan_result(success=False)
+        await record_scan_result(success=False, error=str(e))
 
 
 async def configure_scheduler():

--- a/tests/api/test_ingest_config.py
+++ b/tests/api/test_ingest_config.py
@@ -1,0 +1,53 @@
+"""Service-level tests for ingest scan-result persistence (#75).
+
+Exercises the real config-table round-trip for record_scan_result -> get_ingest_config
+so a failed scan's detail is queryable (and cleared on the next success), rather than
+being swallowed by a broad except and lost to container logs.
+"""
+
+import pytest
+
+from api.services.ingest_config import get_ingest_config, record_scan_result
+
+
+@pytest.mark.asyncio
+async def test_record_scan_result_persists_error_on_failure():
+    """A failed scan stores its error detail and flips last_scan_success to False."""
+    await record_scan_result(success=False, error="UNIQUE constraint failed: available_files.remote_url")
+
+    cfg = await get_ingest_config()
+    assert cfg.last_scan_success is False
+    assert cfg.last_scan_error == "UNIQUE constraint failed: available_files.remote_url"
+    assert cfg.last_scan_at is not None
+
+
+@pytest.mark.asyncio
+async def test_record_scan_result_clears_error_on_success():
+    """A subsequent successful scan clears the stale error (no lingering message)."""
+    await record_scan_result(success=False, error="SkyCloud timeout")
+    # Sanity: error is set before the success clears it.
+    assert (await get_ingest_config()).last_scan_error == "SkyCloud timeout"
+
+    await record_scan_result(success=True)
+
+    cfg = await get_ingest_config()
+    assert cfg.last_scan_success is True
+    assert cfg.last_scan_error is None
+
+
+@pytest.mark.asyncio
+async def test_record_scan_result_supplies_default_message_when_no_detail():
+    """A failure with no detail still records a non-empty, queryable message."""
+    await record_scan_result(success=False, error=None)
+
+    assert (await get_ingest_config()).last_scan_error == "Scan failed (no detail captured)"
+
+
+@pytest.mark.asyncio
+async def test_record_scan_result_truncates_oversized_error():
+    """A giant traceback is capped so it can't bloat the config row."""
+    await record_scan_result(success=False, error="x" * 5000)
+
+    error = (await get_ingest_config()).last_scan_error
+    assert error is not None
+    assert len(error) <= 2000


### PR DESCRIPTION
## Summary

Epic H (#229), backend half of #75 (priority: high). A failed ingest scan used to swallow its cause — the error was logged inside the container and `last_scan_success` flipped to false, but *why* never reached anywhere queryable, so users saw an empty Ready screen with no diagnosis (the SkyCloud timeout and the UNIQUE-constraint crash were the motivating incidents).

## Change
- **New config key `ingest.last_scan_error`**, loaded into `IngestConfig.last_scan_error` — so it rides along on `GET /api/ingest/config` for the Ready screen to read.
- **`record_scan_result(success, error=None)`** persists the detail on failure and **clears it on the next success** (empty string → None) so a stale message never lingers. Capped at 2000 chars so a stack trace can't bloat the config row.
- Threaded the error through all four call sites: the `POST /api/ingest/scan` endpoint and the scheduler each pass `result.error_message` on partial failure and `str(e)` on a hard exception.

## Verification
- `ruff` ✅ · `black` ✅
- New `tests/api/test_ingest_config.py` (real config-table round-trip): persists on failure, clears on success, default message when no detail, truncates oversized input — **4 passed**.
- Regression: `test_ingest_api.py` + `test_ingest_scheduler.py` **14 passed**.

## Scope
Backend half only — the data is now persisted and exposed via the API. The **Ready-screen UI wiring** and **per-directory error breakdown** (parts 2–3 of #75) are follow-ups, so this PR leaves #75 open.

Refs #75