### PR TITLE
ci: post Claude Code Review findings as PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # needed to post the review's inline comments back to the PR
       issues: read
       id-token: write
 
@@ -38,7 +38,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment posts the findings as inline PR comments. Without it the
+          # /code-review skill computes a review but never writes it back, so the
+          # job goes green with no visible feedback.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           claude_args: '--model claude-sonnet-4-6'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Problem
The Claude Code Review workflow (#251) runs on every PR and executes `/code-review`, but **the review never lands on the PR**. Confirmed on this session's PRs: `claude-review` ran green for 2–6 min on #253/#254 and posted **zero** reviews/comments (verified via the issues/reviews API).

Two causes in `.github/workflows/claude-code-review.yml`:
1. The prompt was `/code-review:code-review <pr>` with **no `--comment`** — that skill only writes inline PR comments when `--comment` is passed; otherwise the review is computed and discarded (`use_sticky_comment`/`display_report` are also false).
2. `permissions: pull-requests: read` — no write access to post comments back.

## Change
- Add `--comment` to the review prompt.
- `pull-requests: read` → `write`.

(Sibling to #256, which granted the same write scope to the on-demand `@claude` workflow.)

## After this merges
PRs opened/synced afterward get inline review comments automatically. Existing open PRs (#247–#250, #253, #254) will get reviewed on their next `synchronize` — e.g. a `gh pr update-branch`.

YAML validated. No code paths touched.