### PR TITLE
ci: trigger Claude review on the `claude-review` label

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -12,6 +12,13 @@ on:
 
 jobs:
   claude-review:
+    # On `labeled` events only review when the label is exactly `claude-review`
+    # (lets you batch-trigger reviews by applying the label). All other events
+    # — opened/synchronize/ready_for_review/reopened — always run.
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'claude-review'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -42,4 +49,3 @@ jobs:
           claude_args: '--model claude-sonnet-4-6'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## What

Adds a **`claude-review` label trigger** to the automated Claude review workflow.

- `labeled` added to `on.pull_request.types`
- Job guard: label events only run when the label is exactly `claude-review`; all other PR events keep auto-reviewing on open/sync.

## Why

Reviews already fire on PR open, but a batchable *manual* re-trigger was wanted (e.g. re-review after addressing feedback, or sweep a backlog of PRs). Applying a label is bulk-friendly in the GitHub UI and via `gh pr edit N --add-label claude-review`. The `@claude` mention path is unchanged.

Part of a fleet-wide rollout (identical change across all claude-code-action repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtY2WvyU325TSHY5QcikEv