### PR TITLE
fix: quick wins — surface-token collision (#157) + retry error_timestamp (#159)

### DIFF
--- a/api/services/database.py
+++ b/api/services/database.py
@@ -595,7 +595,12 @@ async def update_job(job_id: int, job_update: JobUpdate) -> Optional[Job]:
 
         if job_update.error_message is not None:
             update_values["error_message"] = job_update.error_message
-            update_values["error_timestamp"] = datetime.now(timezone.utc)
+            # An empty error_message clears the error state (e.g. on job retry),
+            # so the stale failure timestamp must be cleared too — not re-stamped.
+            if job_update.error_message == "":
+                update_values["error_timestamp"] = None
+            else:
+                update_values["error_timestamp"] = datetime.now(timezone.utc)
 
         if job_update.estimated_cost is not None:
             update_values["estimated_cost"] = job_update.estimated_cost

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -211,6 +211,31 @@ async def test_update_job(test_db):
 
 
 @pytest.mark.asyncio
+async def test_update_job_clears_error_timestamp_on_retry(test_db):
+    """Clearing error_message to '' (retry path) must also clear error_timestamp.
+
+    Regression for #159: a successful retry left the stale failure timestamp in
+    place because update_job re-stamped error_timestamp whenever error_message
+    was not None — including the empty-string clear.
+    """
+    job = await create_job(
+        JobCreate(
+            project_name="test",
+            project_path="/projects/test",
+            transcript_file="/transcripts/test.txt",
+        )
+    )
+    # Fail the job — error_timestamp gets set
+    failed = await update_job(job.id, JobUpdate(status=JobStatus.failed, error_message="boom"))
+    assert failed.error_timestamp is not None
+
+    # Retry: status back to pending, error_message cleared to ""
+    retried = await update_job(job.id, JobUpdate(status=JobStatus.pending, error_message=""))
+    assert retried.error_message == ""
+    assert retried.error_timestamp is None
+
+
+@pytest.mark.asyncio
 async def test_delete_job(test_db):
     """Test deleting a job."""
     # Create job

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -18,7 +18,7 @@ export default {
           50:  '#f0f1f5',
           100: '#dfe1e9',
           200: '#c0c4d1',
-          300: '#9da2b5',
+          300: '#aeb3c3',  // distinct rung between 200/400 (was #9da2b5, collided with 400)
           400: '#9da2b5',  // bumped for WCAG AA (was #7a8098, 3.35:1 — failed)
           500: '#5c6380',
           600: '#464d68',


### PR DESCRIPTION
Two small, independent fixes bundled to minimize merge-queue churn against the strict-up-to-date ruleset.

## #157 — surface-300/400 token collision
`surface-300` and `surface-400` were both `#9da2b5` after #156 bumped 400 for WCAG AA. Lightened `surface-300` → `#aeb3c3` (a distinct rung between 200 `#c0c4d1` and 400 `#9da2b5`), restoring a monotonic scale. `surface-400` is unchanged — it keeps the WCAG-validated value.

## #159 — retry doesn't clear error_timestamp
`update_job` re-stamped `error_timestamp = now()` on *any* non-None `error_message`, including the empty-string clear the retry path uses. So a successful retry left a stale (re-stamped) failure timestamp instead of clearing it. Now an empty `error_message` clears `error_timestamp` to NULL. Added a regression test (`test_update_job_clears_error_timestamp_on_retry`).

## Tests
- `tests/api/test_database.py` — 37 passed (incl. new regression)
- black + ruff clean (CI-pinned versions)

Closes #157
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)