### PR TITLE
fix(system): DB-backed cross-container observability (#158, #179)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ Cardigan v4.0 - FastAPI Application
 Main entry point for the API server.
 """
 
+import json
 import os
 
 from dotenv import load_dotenv
@@ -145,21 +146,41 @@ async def health():
         "in_progress": len(in_progress_jobs),
     }
 
-    # Get LLM status
+    # Get LLM status. Config-derived fields (primary_backend, fallback_model,
+    # phase_backends) are valid from the in-process client. But active_backend,
+    # active_model and last_run_totals are runtime state set by whichever process
+    # actually ran the job — in the multi-container deployment that's the worker,
+    # not this API process, so they're null here. Prefer the worker-published
+    # snapshot from the shared DB, falling back to in-process state for the
+    # single-process dev case (#158).
     llm_client = get_llm_client()
     llm_status = llm_client.get_status()
+
+    active_backend = llm_status.get("active_backend")
+    active_model = llm_status.get("active_model")
+    last_run = llm_status.get("last_run_totals")
+
+    runtime_item = await database.get_config("llm_runtime_status")
+    if runtime_item and runtime_item.value:
+        try:
+            runtime = json.loads(runtime_item.value)
+            active_backend = runtime.get("active_backend") or active_backend
+            active_model = runtime.get("active_model") or active_model
+            last_run = runtime.get("last_run_totals") or last_run
+        except (json.JSONDecodeError, TypeError):
+            pass
 
     return {
         "status": "ok",
         "queue": queue_stats,
         "llm": {
-            "active_backend": llm_status.get("active_backend"),
-            "active_model": llm_status.get("active_model"),
+            "active_backend": active_backend,
+            "active_model": active_model,
             "primary_backend": llm_status.get("primary_backend"),
             "fallback_model": llm_status.get("fallback_model"),
             "phase_backends": llm_status.get("phase_backends"),
         },
-        "last_run": llm_status.get("last_run_totals"),
+        "last_run": last_run,
     }
 
 

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -13,6 +13,8 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from api.services import database
+
 router = APIRouter()
 
 
@@ -22,6 +24,9 @@ class ComponentStatus(BaseModel):
     name: str
     running: bool
     pid: Optional[int] = None
+    # Seconds since the component's last DB heartbeat (None for API, which is
+    # detected by port, or if the component has never heartbeated).
+    heartbeat_age_seconds: Optional[float] = None
 
 
 class SystemStatus(BaseModel):
@@ -96,18 +101,47 @@ def _start_component(command: str, log_file: str) -> bool:
 
 @router.get("/status", response_model=SystemStatus)
 async def get_system_status():
-    """Get status of all system components."""
+    """Get status of all system components.
 
-    # Use port check for API since pgrep can't reliably detect itself
+    A component is reported running if EITHER a fresh DB heartbeat exists
+    (works across container boundaries — the prod/LXC case, #179) OR a local
+    process is found via pgrep/lsof (works in single-host dev). The OR means
+    neither deployment shape reports a false "down".
+    """
+    # API check: port probe — the API answers its own request in-container.
     api_pid = _check_port_in_use(8000)
+
+    # Worker/watcher: same-host process probe (dev) plus shared-DB heartbeat (prod).
     worker_pid = _find_process("run_worker.py")
     watcher_pid = _find_process("watch_transcripts.py")
+    worker_age = await database.get_heartbeat_age_seconds("worker")
+    watcher_age = await database.get_heartbeat_age_seconds("watcher")
+
+    worker_running = worker_pid is not None or database.heartbeat_is_fresh(worker_age)
+    watcher_running = watcher_pid is not None or database.heartbeat_is_fresh(watcher_age)
 
     return SystemStatus(
         api=ComponentStatus(name="API Server", running=api_pid is not None, pid=api_pid),
-        worker=ComponentStatus(name="Worker", running=worker_pid is not None, pid=worker_pid),
-        watcher=ComponentStatus(name="Transcript Watcher", running=watcher_pid is not None, pid=watcher_pid),
+        worker=ComponentStatus(name="Worker", running=worker_running, pid=worker_pid, heartbeat_age_seconds=worker_age),
+        watcher=ComponentStatus(
+            name="Transcript Watcher",
+            running=watcher_running,
+            pid=watcher_pid,
+            heartbeat_age_seconds=watcher_age,
+        ),
     )
+
+
+@router.post("/watcher/heartbeat", response_model=RestartResponse)
+async def watcher_heartbeat():
+    """Record a liveness heartbeat for the transcript watcher.
+
+    The watcher runs in its own container and reaches the API over HTTP (it has
+    no direct DB access), so it pings this endpoint each scan loop. /status reads
+    the resulting DB heartbeat to detect the watcher across container boundaries.
+    """
+    await database.record_heartbeat("watcher")
+    return RestartResponse(success=True, message="Watcher heartbeat recorded")
 
 
 @router.post("/worker/restart", response_model=RestartResponse)

--- a/api/services/database.py
+++ b/api/services/database.py
@@ -1344,6 +1344,48 @@ async def set_config(
         return _row_to_config(row)
 
 
+# A component is considered alive if its heartbeat is newer than this. The worker
+# heartbeats every poll loop (~30s) and the watcher every scan loop, so 120s gives
+# ~3-4 missed beats of slack before we report it down. Cross-container safe: the
+# heartbeat lives in the shared DB, unlike pgrep/lsof which can't see other
+# containers (#179).
+HEARTBEAT_STALE_SECONDS = 120
+
+
+async def record_heartbeat(component: str) -> None:
+    """Record a liveness heartbeat for a system component (e.g. 'worker', 'watcher').
+
+    Writes the current UTC time to a `<component>_heartbeat` config key so other
+    containers (notably the API serving /system/status) can observe liveness via
+    shared DB state rather than same-host process probes.
+    """
+    await set_config(
+        f"{component}_heartbeat",
+        datetime.now(timezone.utc).isoformat(),
+        value_type="string",
+        description=f"Last liveness heartbeat for the {component} process",
+    )
+
+
+async def get_heartbeat_age_seconds(component: str) -> Optional[float]:
+    """Return seconds since `component` last heartbeat, or None if never/unparseable."""
+    item = await get_config(f"{component}_heartbeat")
+    if item is None or not item.value:
+        return None
+    try:
+        ts = datetime.fromisoformat(item.value)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - ts).total_seconds()
+
+
+def heartbeat_is_fresh(age_seconds: Optional[float]) -> bool:
+    """True if a heartbeat age (from get_heartbeat_age_seconds) is within the stale window."""
+    return age_seconds is not None and age_seconds < HEARTBEAT_STALE_SECONDS
+
+
 async def list_config() -> List[ConfigItem]:
     """List all configuration items.
 

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -19,6 +19,8 @@ from api.services.database import (
     clear_defer_state,
     defer_job,
     log_event,
+    record_heartbeat,
+    set_config,
     update_job_heartbeat,
     update_job_phase,
     update_job_status,
@@ -200,6 +202,24 @@ class JobWorker:
 
         while self.running:
             try:
+                # Publish liveness + LLM runtime status to the shared DB so the
+                # API container can observe this worker across container boundaries
+                # (#179 worker detection, #158 active backend/model/last_run).
+                # Best-effort: never let observability break the polling loop.
+                try:
+                    await record_heartbeat("worker")
+                    await set_config(
+                        "llm_runtime_status",
+                        json.dumps(self.llm.get_status(), default=str),
+                        value_type="json",
+                        description="Last-known LLM backend/model/run totals, published by the worker",
+                    )
+                except Exception as hb_error:
+                    logger.debug(
+                        "Heartbeat/status publish failed",
+                        extra={"worker_id": worker_id, "error": str(hb_error)},
+                    )
+
                 # Clean up completed tasks
                 done_tasks = {t for t in active_tasks if t.done()}
                 for task in done_tasks:

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -19,14 +19,17 @@ from api.services.database import (
     get_app_version,
     get_config,
     get_events_for_job,
+    get_heartbeat_age_seconds,
     get_job,
     get_next_pending_job,
     get_session,
     get_stale_jobs,
+    heartbeat_is_fresh,
     init_db,
     list_config,
     list_jobs,
     log_event,
+    record_heartbeat,
     reset_stuck_jobs,
     run_stuck_job_cleanup,
     sanitize_path_component,
@@ -233,6 +236,26 @@ async def test_update_job_clears_error_timestamp_on_retry(test_db):
     retried = await update_job(job.id, JobUpdate(status=JobStatus.pending, error_message=""))
     assert retried.error_message == ""
     assert retried.error_timestamp is None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_record_and_age(test_db):
+    """record_heartbeat writes a timestamp that get_heartbeat_age_seconds reads back fresh (#179)."""
+    # No heartbeat yet -> age is None, not fresh
+    assert await get_heartbeat_age_seconds("worker") is None
+    assert heartbeat_is_fresh(None) is False
+
+    await record_heartbeat("worker")
+    age = await get_heartbeat_age_seconds("worker")
+    assert age is not None
+    assert age < 5  # just written
+    assert heartbeat_is_fresh(age) is True
+
+    # A stale age is not fresh
+    assert heartbeat_is_fresh(10_000) is False
+
+    # Components are tracked independently
+    assert await get_heartbeat_age_seconds("watcher") is None
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_system_observability.py
+++ b/tests/api/test_system_observability.py
@@ -1,0 +1,148 @@
+"""Tests for cross-container observability (#158, #179).
+
+The API container cannot see the worker/watcher containers via pgrep/lsof, so
+/system/status falls back to shared-DB heartbeats and /system/health reads a
+worker-published LLM snapshot. These tests exercise that fallback logic with the
+local process probes forced to "not found" (the prod/LXC shape).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+class TestSystemStatusHeartbeat:
+    """GET /api/system/status worker/watcher detection via DB heartbeat (#179)."""
+
+    def test_worker_up_via_fresh_heartbeat_without_local_process(self):
+        """A fresh DB heartbeat reports the worker running even when pgrep finds nothing."""
+        with (
+            patch("api.routers.system._check_port_in_use", return_value=1234),
+            patch("api.routers.system._find_process", return_value=None),
+            patch(
+                "api.routers.system.database.get_heartbeat_age_seconds",
+                new_callable=AsyncMock,
+            ) as mock_age,
+        ):
+            # worker fresh (5s), watcher stale-missing (None)
+            mock_age.side_effect = [5.0, None]
+            response = client.get("/api/system/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["worker"]["running"] is True
+        assert data["worker"]["pid"] is None  # cross-container: no local pid
+        assert data["worker"]["heartbeat_age_seconds"] == 5.0
+        assert data["watcher"]["running"] is False
+
+    def test_worker_down_when_no_process_and_no_heartbeat(self):
+        """No local process and no heartbeat -> reported down (no false green)."""
+        with (
+            patch("api.routers.system._check_port_in_use", return_value=1234),
+            patch("api.routers.system._find_process", return_value=None),
+            patch(
+                "api.routers.system.database.get_heartbeat_age_seconds",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            response = client.get("/api/system/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["worker"]["running"] is False
+        assert data["watcher"]["running"] is False
+
+    def test_stale_heartbeat_reports_down(self):
+        """A heartbeat older than the stale window is not considered alive."""
+        with (
+            patch("api.routers.system._check_port_in_use", return_value=1234),
+            patch("api.routers.system._find_process", return_value=None),
+            patch(
+                "api.routers.system.database.get_heartbeat_age_seconds",
+                new_callable=AsyncMock,
+                return_value=9999.0,
+            ),
+        ):
+            response = client.get("/api/system/status")
+
+        assert response.json()["worker"]["running"] is False
+
+    def test_local_process_still_reports_up_in_dev(self):
+        """Single-host dev: pgrep finds the process even with no heartbeat."""
+        with (
+            patch("api.routers.system._check_port_in_use", return_value=1234),
+            patch("api.routers.system._find_process", return_value=4321),
+            patch(
+                "api.routers.system.database.get_heartbeat_age_seconds",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            response = client.get("/api/system/status")
+
+        data = response.json()
+        assert data["worker"]["running"] is True
+        assert data["worker"]["pid"] == 4321
+
+
+class TestWatcherHeartbeatEndpoint:
+    """POST /api/system/watcher/heartbeat records watcher liveness (#179)."""
+
+    def test_records_heartbeat(self):
+        with patch("api.routers.system.database.record_heartbeat", new_callable=AsyncMock) as mock_record:
+            response = client.post("/api/system/watcher/heartbeat")
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_record.assert_awaited_once_with("watcher")
+
+
+class TestHealthLLMSnapshot:
+    """GET /api/system/health prefers the worker-published DB snapshot (#158)."""
+
+    def test_health_uses_db_runtime_when_inprocess_null(self):
+        """active_backend/model/last_run come from the DB snapshot when the API
+        process has none (the multi-container case)."""
+        in_process_status = {
+            "active_backend": None,
+            "active_model": None,
+            "primary_backend": "openrouter",
+            "fallback_model": "anthropic/claude-sonnet-4",
+            "phase_backends": {"analyst": "openrouter"},
+            "last_run_totals": None,
+        }
+        runtime_snapshot = MagicMock()
+        runtime_snapshot.value = json.dumps(
+            {
+                "active_backend": "openrouter",
+                "active_model": "anthropic/claude-opus-4",
+                "last_run_totals": {"cost": 0.1359},
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_status.return_value = in_process_status
+
+        async def fake_get_config(key):
+            return runtime_snapshot if key == "llm_runtime_status" else None
+
+        with (
+            patch("api.main.get_llm_client", return_value=mock_client),
+            patch("api.main.database.get_config", side_effect=fake_get_config),
+            patch("api.main.database.list_jobs", new_callable=AsyncMock, return_value=[]),
+        ):
+            response = client.get("/api/system/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["llm"]["active_backend"] == "openrouter"
+        assert data["llm"]["active_model"] == "anthropic/claude-opus-4"
+        assert data["last_run"] == {"cost": 0.1359}
+        # config-derived fields still come from the in-process client
+        assert data["llm"]["primary_backend"] == "openrouter"

--- a/watch_transcripts.py
+++ b/watch_transcripts.py
@@ -37,6 +37,19 @@ def get_queued_files() -> set:
     return queued
 
 
+def send_heartbeat() -> None:
+    """Ping the API so it can record watcher liveness in the shared DB.
+
+    The watcher has no direct DB access (it talks to the API over HTTP), so this
+    is how /api/system/status detects it across container boundaries (#179).
+    Best-effort: a failed ping must never interrupt the watch loop.
+    """
+    try:
+        httpx.post(f"{API_BASE}/api/system/watcher/heartbeat", timeout=5)
+    except Exception:
+        pass
+
+
 def get_transcript_files() -> list:
     """Get all transcript files in the transcripts folder."""
     files = []
@@ -128,6 +141,7 @@ def watch_loop():
         seen_files = get_queued_files() | set(get_transcript_files())
 
         while True:
+            send_heartbeat()
             current_files = set(get_transcript_files())
             new_files = current_files - seen_files
 


### PR DESCRIPTION
Both bugs are the same architectural issue: the **API container observes the worker/watcher through process-local channels** that are blind across container boundaries. The fix routes liveness + LLM runtime state through the **shared DB**.

## #179 — /api/system/status all-down in Docker
`pgrep`/`lsof` can't see other containers, so worker & watcher always showed red in prod.
- **Worker** writes `worker_heartbeat` to DB config every poll loop (always-on, not just during jobs).
- **Watcher** (HTTP-only — no DB access) pings a new `POST /api/system/watcher/heartbeat` each scan loop.
- `/status` reports a component up if a **fresh DB heartbeat (<120s) OR a local process** is found — so prod (heartbeat) and dev (pgrep) both report correctly with no false 'down'. `ComponentStatus` gains `heartbeat_age_seconds`.

## #158 — /api/system/health null fields after successful jobs
`active_backend`/`active_model`/`last_run` are runtime state held in the *worker's* memory; the API process never runs a job so they were forever null.
- Worker publishes its `get_status()` snapshot to DB config (`llm_runtime_status`) each loop.
- `/health` prefers that snapshot, falling back to in-process state for single-process dev. Config-derived fields (primary_backend, phase_backends) still come from the in-process client.

## New shared helpers
`record_heartbeat` / `get_heartbeat_age_seconds` / `heartbeat_is_fresh` in `database.py`.

## Tests
- `tests/api/test_database.py` — heartbeat round-trip + freshness
- `tests/api/test_system_observability.py` (new) — status fallback matrix (fresh/stale/missing/dev-pid) + watcher heartbeat endpoint + health DB-override
- Full suite: **767 passed, 5 xfailed**; black + ruff clean (CI-pinned).

## Deployment note
The worker now writes to DB config every poll loop (~30s) — a tiny, idempotent upsert. No schema change (uses existing config table). Worker behavior change is additive and best-effort (wrapped so it never breaks the polling loop).

Closes #158
Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)