### PR TITLE
fix(ui): stop queue blink on refetch (#160) + restart progress indicator (#219)

### DIFF
--- a/web/src/pages/JobDetail.tsx
+++ b/web/src/pages/JobDetail.tsx
@@ -169,6 +169,9 @@ export default function JobDetail() {
   const [sstMetadata, setSstMetadata] = useState<SSTMetadata | null>(null)
   const [sstLoading, setSstLoading] = useState(false)
   const [retryingPhase, setRetryingPhase] = useState<string | null>(null)
+  // Tracks an in-flight job-level action (retry/pause/resume/cancel) so the
+  // button can show a spinner instead of only a transient toast (#219).
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [retryModal, setRetryModal] = useState<{ outputKey: string; label: string } | null>(null)
   const [retryFeedback, setRetryFeedback] = useState('')
   const [retryModel, setRetryModel] = useState<string>('')
@@ -301,13 +304,15 @@ export default function JobDetail() {
       cancel: { success: 'Job cancelled successfully', error: 'Failed to cancel job' },
     }
 
+    setActionLoading(action)
     try {
       const response = await fetch(`/api/jobs/${id}/${action}`, {
         method: 'POST',
       })
       if (response.ok) {
         toast(actionLabels[action]?.success || `Job ${action}ed successfully`, 'success')
-        // Refresh job data
+        // Refresh job data — the new status drives the persistent indicator
+        // (e.g. "Queued — waiting to start…") and re-arms the polling effect.
         const updated = await fetch(`/api/jobs/${id}`)
         if (updated.ok) {
           setJob(await updated.json())
@@ -318,6 +323,8 @@ export default function JobDetail() {
     } catch (err) {
       console.error(`Failed to ${action} job:`, err)
       toast(actionLabels[action]?.error || `Failed to ${action} job`, 'error')
+    } finally {
+      setActionLoading(null)
     }
   }
 
@@ -556,6 +563,13 @@ export default function JobDetail() {
                 • Processing {job.current_phase}...
               </span>
             )}
+            {/* Persistent indicator for the gap between a restart and the worker
+                picking the job up — otherwise the only feedback is a toast (#219). */}
+            {job.status === 'pending' && (
+              <span className="ml-2 text-pbs-400 animate-pulse">
+                • Queued — waiting to start…
+              </span>
+            )}
           </p>
         </div>
 
@@ -580,10 +594,14 @@ export default function JobDetail() {
           {(job.status === 'failed' || (job.status === 'paused' && job.error_message?.includes('TRUNCATION'))) && (
             <button
               onClick={() => handleAction('retry')}
-              className="px-3 py-1.5 bg-green-600 hover:bg-green-500 text-white rounded-md text-sm"
+              disabled={actionLoading === 'retry'}
+              className="px-3 py-1.5 bg-green-600 hover:bg-green-500 text-white rounded-md text-sm disabled:opacity-60 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
               title="Retry this job"
             >
-              Retry
+              {actionLoading === 'retry' && (
+                <span className="inline-block w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+              )}
+              {actionLoading === 'retry' ? 'Retrying…' : 'Retry'}
             </button>
           )}
           {['pending', 'paused'].includes(job.status) && (

--- a/web/src/pages/Queue.tsx
+++ b/web/src/pages/Queue.tsx
@@ -372,7 +372,10 @@ export default function Queue() {
       </div>
 
       {/* Jobs Table */}
-      {loading ? (
+      {/* Skeleton only on the very first load (no data yet). Background polls
+          and action-triggered refetches set loading=true too, and showing the
+          skeleton then would tear the list down and back — the blink in #160. */}
+      {loading && jobs.length === 0 ? (
         <SkeletonQueue />
       ) : (
         <div className="bg-surface-800 rounded-lg border border-surface-700 overflow-hidden">

--- a/web/src/pages/ReadyForWork.tsx
+++ b/web/src/pages/ReadyForWork.tsx
@@ -355,7 +355,9 @@ export default function ReadyForWork() {
 
         {/* File List */}
         <div className="divide-y divide-surface-700">
-          {loading ? (
+          {/* Skeleton only on first load — refetches after scan/queue/ignore set
+              loading=true too, and showing the loader then is the blink in #160. */}
+          {loading && files.length === 0 ? (
             <div className="py-12 text-center">
               <p className="text-surface-400 animate-pulse">Loading available files...</p>
             </div>


### PR DESCRIPTION
Two frontend polling/feedback fixes.

## #160 — Queue / Ready-for-Work blink
Both pages gate their skeleton on a single `loading` flag that flips `true` on **every** fetch — initial load, the 5–30s background poll, and post-action refetches. So each poll tore the populated list down to a skeleton and rebuilt it: the blink. Now the skeleton renders only when there's **no data yet** (`loading && length === 0`); background refetches update the list in place.

## #219 — no progress indicator after restart
After a retry the job becomes `pending` with `current_phase = null`, but the 'Processing…' indicator only renders for `in_progress` — so the queued window had no feedback beyond a vanishing toast. Added:
- a persistent **'Queued — waiting to start…'** indicator for the pending state, and
- a spinner + **'Retrying…'** on the Retry button while the POST is in flight.

## Verification
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean, `vite build` succeeds.
- ⚠️ #219 is a UX change best confirmed visually — worth a quick look in the running app before/after a restart.
- Note: a pre-existing `useWebSocket.test.tsx` vitest failure reproduces identically on `main` (untouched here, not a required CI check) — filing separately.

Closes #160
Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)