### PR TITLE
fix(formatter): tell chunk 0 it's a section, not the whole transcript (job 12 false truncation)

### DIFF
--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -1833,8 +1833,21 @@ If a caption is garbled or unclear, include your best reconstruction rather than
 SPELLING: Always use "partisan" (not "partizan"), "bipartisan" (not "bipartisan"). Program names like "Inside Wisconsin Politics" are NOT italicized."""
 
                 if chunk.index == 0:
-                    # First chunk: normal formatter prompt
+                    # First chunk: normal formatter prompt (generates the metadata header).
                     user_message = f"{verbatim_instruction}\n\n"
+                    if total_chunks > 1:
+                        # Chunk 0 only sees the first slice of a long transcript. Without
+                        # this it concludes the transcript is truncated and emits false
+                        # "incomplete / needs_review" review notes that survive the merge
+                        # and trip the validator into a spurious QA failure (job 12).
+                        user_message += (
+                            f"IMPORTANT: This is section 1 of {total_chunks} of a long transcript "
+                            "being processed in parts. Later sections cover the rest of the "
+                            "transcript. Your section legitimately ends partway through — do NOT "
+                            "assess overall transcript completeness, do NOT claim the transcript "
+                            "is truncated, incomplete, or cut off, and do NOT set a 'needs_review' "
+                            "status on that basis. Format only the dialogue in this section.\n\n"
+                        )
                     user_message += "Using the following analysis as guidance:\n\n"
                     if sst_section:
                         user_message += sst_section

--- a/tests/test_model_selection_integrity.py
+++ b/tests/test_model_selection_integrity.py
@@ -111,6 +111,72 @@ async def test_chunked_formatter_passes_model_override(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_chunked_formatter_first_chunk_told_it_is_a_section(monkeypatch, tmp_path):
+    """Chunk 0 of a multi-chunk run must be told it's 'section 1 of N'.
+
+    Regression for the job-12 bug: without this, chunk 0 sees its slice end
+    mid-transcript, concludes the transcript is truncated, and emits false
+    'incomplete / needs_review' review notes that trip the validator.
+    """
+    from types import SimpleNamespace
+
+    from api.services import worker as worker_mod
+    from api.services.chunking import TranscriptChunk
+    from api.services.worker import JobWorker
+
+    w = JobWorker.__new__(JobWorker)
+    w.llm = MagicMock()
+    w.llm.get_backend_for_phase = MagicMock(return_value="openrouter")
+    w.llm.get_backend_config = MagicMock(return_value={"timeout": 120})
+
+    captured = []
+
+    async def fake_chat(**kwargs):
+        captured.append(next(m["content"] for m in kwargs["messages"] if m["role"] == "user"))
+        return SimpleNamespace(
+            content="formatted", cost=0.01, total_tokens=10, input_tokens=6, output_tokens=4, model="m"
+        )
+
+    w.llm.chat = fake_chat
+    monkeypatch.setattr(worker_mod, "log_event", AsyncMock())
+    monkeypatch.setattr(w, "_load_agent_prompt", lambda phase: "system")
+
+    # --- multi-chunk: chunk 0 must carry the "section 1 of N" caveat ---
+    chunks = [
+        TranscriptChunk(index=0, content="a", start_timecode="0", end_timecode="1", word_count=1, overlap_prefix=""),
+        TranscriptChunk(index=1, content="b", start_timecode="1", end_timecode="2", word_count=1, overlap_prefix="a"),
+    ]
+    await w._run_formatter_chunked(
+        job_id=1,
+        chunks=chunks,
+        context={"analyst_output": ""},
+        project_path=tmp_path,
+        chunking_config={"max_parallel": 2},
+    )
+    # Identify chunk 0 by content: continuation chunks carry the "Continue formatting
+    # from where the previous section left off" phrase; chunk 0 does not.
+    chunk0_prompt = next(p for p in captured if "Continue formatting from where the previous" not in p)
+    assert "section 1 of 2" in chunk0_prompt
+    assert "do NOT assess overall transcript completeness" in chunk0_prompt
+    assert "needs_review" in chunk0_prompt
+
+    # --- single chunk: no caveat (it really is the whole transcript) ---
+    captured.clear()
+    solo = [
+        TranscriptChunk(index=0, content="a", start_timecode="0", end_timecode="1", word_count=1, overlap_prefix=""),
+    ]
+    await w._run_formatter_chunked(
+        job_id=2,
+        chunks=solo,
+        context={"analyst_output": ""},
+        project_path=tmp_path,
+        chunking_config={"max_parallel": 1},
+    )
+    assert len(captured) == 1
+    assert "section 1 of" not in captured[0]
+
+
+@pytest.mark.asyncio
 async def test_chunked_formatter_records_real_model(monkeypatch, tmp_path):
     """The chunked formatter result must report the model that ran, not 'chunked (...)'."""
     from types import SimpleNamespace


### PR DESCRIPTION
## Symptom (live, job 12 / 6POL0115 on cardigan01)
Validator returned `overall: fail`, flagging the formatter output as truncated — *"transcript is incomplete: ends at ~11:10 mark; content from Acts 3–5 (11:20–19:45)… missing"* and *"status field states 'needs_review'… incomplete coverage."*

**The artifact is actually complete.** `formatter_output.md` is a 2-chunk merge that reaches the real closing remarks (*"That's all the time we have for today… This has been Inside Wisconsin Politics"*). The 'missing' Acts 3–5 content is present. The false flag came from a `<!-- REVIEW NOTES -->` block at the **top** of the merged doc (chunk 0's output) asserting incompleteness.

## Root cause
In `_run_formatter_chunked.process_chunk`, continuation chunks (`index > 0`) are told *"This is section X of N of a long transcript being processed in parts."* — but **chunk 0 got the plain `Please format this transcript` prompt**, as if it were the whole transcript. Its slice ending mid-conversation at 11:10 looked truncated to the model, which emitted the incompleteness review notes + `Status: needs_review`. The merge keeps chunk 0's header/notes, and the validator faithfully reports them → spurious QA failure on a complete job.

## Fix
When `total_chunks > 1`, chunk 0 now gets a 'section 1 of N — later sections cover the rest; do not assess overall completeness or set needs_review on that basis' preamble (mirrors the continuation-chunk framing). Single-chunk runs are unchanged (it really *is* the whole transcript).

## Tests
- New regression `test_chunked_formatter_first_chunk_told_it_is_a_section` — chunk 0 carries the caveat for multi-chunk, omits it for single-chunk.
- Full suite **768 passed / 5 xfailed**; black + ruff clean.

## Related
Upstream cause of one class of false QA failures that #243 (Spec B auto-escalation) would otherwise chase. Found while drafting the #243 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)