### PR TITLE
chore(release): bump web/package.json to 4.3.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cardigan-dashboard",
   "private": true,
-  "version": "4.2.0",
+  "version": "4.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Aligns `web/package.json` MAJOR.MINOR with the **v4.3.0** release tag (escalation #268 + seam fix #270 + validator→Sonnet), satisfying the Version Consistency check.

The `v4.3.0` tag is on `342cd1e` (current main / deployed prod). This is the routine web-version alignment that follows a MINOR tag per docs/VERSIONING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)