### PR TITLE
fix(mmingest): incremental persistence + crawl-run telemetry/status endpoint

### DIFF
--- a/alembic/versions/021_add_mmingest_crawl_runs.py
+++ b/alembic/versions/021_add_mmingest_crawl_runs.py
@@ -1,0 +1,67 @@
+"""Add mmingest_crawl_runs telemetry table.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-06-29
+
+Creates ``mmingest_crawl_runs`` — one row per delta-walk pass recording when it
+started/finished, its terminal status, and the counts from the IndexerRun
+summary.  This gives ``GET /api/mmingest/status`` a queryable last-run signal so
+a crawl that stalls or fails no longer hides behind an empty index with no
+external trace (issue: mmingest index empty on prod, 2026-06-29).
+
+Column notes
+------------
+started_at         When run_delta_walk recorded the run start (UTC ISO).
+finished_at        When the run reached a terminal state; NULL while running.
+status             'running'   — a pass is in flight (finished_at IS NULL)
+                   'completed' — run_once() returned normally
+                   'suppressed'— crawl paused (pause-window RuntimeError)
+                   'failed'    — run_once() raised; see ``error``
+files_seen         IndexerRun.files_seen (new/changed work items this pass).
+files_new          IndexerRun.files_new.
+sidecars_fetched   IndexerRun.sidecars_fetched.
+sidecars_persisted IndexerRun.sidecars_persisted.
+fts_parity_delta   IndexerRun.fts_parity_delta (0 = in sync; NULL = unchecked).
+elapsed_seconds    Wall-clock duration of the pass.
+error              repr() of the exception for failed runs; NULL otherwise.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "021"
+down_revision: Union[str, None] = "020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mmingest_crawl_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("files_seen", sa.Integer(), nullable=True),
+        sa.Column("files_new", sa.Integer(), nullable=True),
+        sa.Column("sidecars_fetched", sa.Integer(), nullable=True),
+        sa.Column("sidecars_persisted", sa.Integer(), nullable=True),
+        sa.Column("fts_parity_delta", sa.Integer(), nullable=True),
+        sa.Column("elapsed_seconds", sa.Float(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+    )
+
+    op.create_index(
+        "idx_mmingest_crawl_runs_started_at",
+        "mmingest_crawl_runs",
+        ["started_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_mmingest_crawl_runs_started_at", table_name="mmingest_crawl_runs")
+    op.drop_table("mmingest_crawl_runs")

--- a/api/models/mmingest.py
+++ b/api/models/mmingest.py
@@ -114,3 +114,45 @@ class RecentResponse(BaseModel):
 
     results: list[RecentEntry]
     total: int
+
+
+# ---------------------------------------------------------------------------
+# Status endpoint
+# ---------------------------------------------------------------------------
+
+
+class CrawlRun(BaseModel):
+    """Telemetry for one delta-walk pass (from mmingest_crawl_runs)."""
+
+    id: int
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    status: str  # 'running' | 'completed' | 'suppressed' | 'failed'
+    files_seen: Optional[int] = None
+    files_new: Optional[int] = None
+    sidecars_fetched: Optional[int] = None
+    sidecars_persisted: Optional[int] = None
+    fts_parity_delta: Optional[int] = None
+    elapsed_seconds: Optional[float] = None
+    error: Optional[str] = None
+
+
+class StatusCounts(BaseModel):
+    """Live row counts for the mmingest index."""
+
+    files: int  # total rows in mmingest_files
+    current_files: int  # rows with superseded_by IS NULL
+    sidecars: int  # total rows in mmingest_sidecars
+
+
+class StatusResponse(BaseModel):
+    """Response for GET /api/mmingest/status.
+
+    Surfaces the last crawl run + live index counts so an empty/stalled index
+    is diagnosable without shell access.  ``last_run`` is null before the first
+    scheduled pass (or before migration 021 applies).
+    """
+
+    last_run: Optional[CrawlRun] = None
+    running: bool = False
+    counts: StatusCounts

--- a/api/routers/mmingest.py
+++ b/api/routers/mmingest.py
@@ -42,14 +42,18 @@ from api.models.mmingest import (
     AssetEntry,
     AssetResponse,
     CaptionResponse,
+    CrawlRun,
     RecentEntry,
     RecentResponse,
     SearchResponse,
     SearchResult,
+    StatusCounts,
+    StatusResponse,
     UrlResponse,
 )
 from api.services.airtable import AirtableClient, get_airtable_client
 from api.services.database import get_db_url
+from api.services.mmingest.run_status import read_status
 
 router = APIRouter()
 
@@ -514,3 +518,59 @@ async def get_recent(
     ]
 
     return RecentResponse(results=results, total=total)
+
+
+# ---------------------------------------------------------------------------
+# 6. GET /status
+# ---------------------------------------------------------------------------
+
+
+@router.get("/status", response_model=StatusResponse)
+async def get_status(
+    _scope=_require_scope("mmingest:read"),
+) -> StatusResponse:
+    """Crawler health: last delta-walk run + live index counts.
+
+    Always returns 200 (never 500) so monitors can poll it through deploy
+    windows.  ``last_run`` is null before the first scheduled pass or before
+    migration 021 applies; ``counts`` is zeroed if the index tables are absent.
+
+    This is the signal that distinguishes a healthy-but-empty index (crawl never
+    completed) from a broken router — an empty index with a 'running' last_run
+    whose started_at is hours old means the walk is stalled, not missing.
+    """
+    engine = _get_engine()
+    try:
+        status = await read_status(engine)
+
+        # Live row counts.  Preflight sqlite_master so a pre-migration DB
+        # returns zeros instead of raising OperationalError.
+        async with engine.connect() as conn:
+            tables_present = (await conn.execute(text("""
+                SELECT COUNT(*) FROM sqlite_master
+                WHERE type = 'table' AND name IN ('mmingest_files', 'mmingest_sidecars')
+            """))).scalar_one()
+
+            if tables_present >= 2:
+                files = (await conn.execute(text("SELECT COUNT(*) FROM mmingest_files"))).scalar_one()
+                current = (
+                    await conn.execute(text("SELECT COUNT(*) FROM mmingest_files WHERE superseded_by IS NULL"))
+                ).scalar_one()
+                sidecars = (await conn.execute(text("SELECT COUNT(*) FROM mmingest_sidecars"))).scalar_one()
+            else:
+                files = current = sidecars = 0
+    finally:
+        await engine.dispose()
+
+    last_run = None
+    running = False
+    if status is not None:
+        running = status["running"]
+        if status["last_run"] is not None:
+            last_run = CrawlRun(**status["last_run"])
+
+    return StatusResponse(
+        last_run=last_run,
+        running=running,
+        counts=StatusCounts(files=files, current_files=current, sidecars=sidecars),
+    )

--- a/api/services/mmingest/crawler.py
+++ b/api/services/mmingest/crawler.py
@@ -31,7 +31,12 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from datetime import time as dtime
-from typing import Optional
+from typing import Awaitable, Callable, Optional
+
+# Streaming callback invoked once per directory with that directory's own file
+# work items, enabling incremental persistence (a partial walk still populates
+# the index before the full pass completes).
+OnDirectoryCallback = Callable[[list["FileWorkItem"]], Awaitable[None]]
 
 import httpx
 
@@ -387,6 +392,7 @@ class MmingestCrawler:
         self,
         directories: Optional[list[str]] = None,
         known: Optional[dict[str, ChangeTriple]] = None,
+        on_directory: Optional[OnDirectoryCallback] = None,
     ) -> list[FileWorkItem]:
         """Walk configured directories and return work items for new/changed files.
 
@@ -395,6 +401,11 @@ class MmingestCrawler:
                          Paths should start with "/" and may include trailing slash.
             known:       Dict mapping URL -> ChangeTriple for already-indexed files.
                          Files whose triple matches are skipped (no change).
+            on_directory: Optional async callback invoked once per directory with
+                         that directory's own new/changed file work items, as soon
+                         as the directory is parsed.  Enables incremental
+                         persistence so an interrupted walk still populates rows.
+                         The full list is still returned regardless.
 
         Returns:
             List of FileWorkItem for files that are new or have changed since
@@ -438,6 +449,7 @@ class MmingestCrawler:
                         known=known,
                         visited=visited,
                         ancestor_segments=set(),
+                        on_directory=on_directory,
                     )
                 )
                 tasks.append(task)
@@ -467,6 +479,7 @@ class MmingestCrawler:
         known: dict[str, ChangeTriple],
         visited: set[str],
         ancestor_segments: set[str],
+        on_directory: Optional[OnDirectoryCallback] = None,
     ) -> list[FileWorkItem]:
         """Recursively walk a single directory URL."""
         canonical = url.rstrip("/")
@@ -489,7 +502,7 @@ class MmingestCrawler:
         parser = AutoindexParser(base_url=url)
         entries = parser.parse(html)
 
-        work_items: list[FileWorkItem] = []
+        own_items: list[FileWorkItem] = []
         subdir_tasks: list[asyncio.Task] = []
 
         # Current directory's name for loop detection
@@ -525,14 +538,39 @@ class MmingestCrawler:
                         known=known,
                         visited=visited,
                         ancestor_segments=child_ancestor_segments,
+                        on_directory=on_directory,
                     )
                 )
                 subdir_tasks.append(task)
             else:
                 item = self._make_work_item(entry, path, known)
                 if item is not None:
-                    work_items.append(item)
+                    own_items.append(item)
 
+        # Per-directory progress heartbeat.  Logged at INFO so a stalled walk is
+        # visible in `docker logs` without guesswork (the whole point: a crawl
+        # that issues one request per hour now leaves a per-directory trail).
+        logger.info(
+            "mmingest crawl: dir=%s depth=%d entries=%d new_files=%d subdirs=%d visited=%d",
+            path,
+            depth,
+            len(entries),
+            len(own_items),
+            len(subdir_tasks),
+            len(visited),
+        )
+
+        # Stream this directory's own new/changed files for incremental
+        # persistence, BEFORE recursing into subdirs.  A failure in the callback
+        # must not abort the walk — the items will be retried on the next pass
+        # (they are not marked persisted) or by the indexer's final sweep.
+        if on_directory is not None and own_items:
+            try:
+                await on_directory(list(own_items))
+            except Exception:
+                logger.exception("mmingest crawl: on_directory callback failed for %s", path)
+
+        work_items: list[FileWorkItem] = list(own_items)
         if subdir_tasks:
             sub_results = await asyncio.gather(*subdir_tasks, return_exceptions=True)
             for sub_result in sub_results:

--- a/api/services/mmingest/indexer.py
+++ b/api/services/mmingest/indexer.py
@@ -208,14 +208,16 @@ class MmingestIndexer:
             if not batch:
                 return
 
-            # Upsert files (transactional)
-            async with self._engine.begin() as conn:
-                url_to_id = await self._upsert_files(conn, batch)
-
-            # Apply variant lineage (superseded_by) updates (transactional).
+            # Upsert files AND apply variant lineage in a SINGLE transaction.
+            # These must be atomic: committing the upsert without the lineage
+            # update would durably leave two superseded_by=NULL rows for one
+            # (media_id, variant_tag) group if the process dies between them, and
+            # that state does NOT self-heal (the next walk skips both rows as
+            # unchanged, so _apply_variant_lineage never revisits the group).
             # _apply_variant_lineage re-queries the DB for each affected group,
             # so it stays correct when groups span multiple incremental batches.
             async with self._engine.begin() as conn:
+                url_to_id = await self._upsert_files(conn, batch)
                 await self._apply_variant_lineage(conn, batch, url_to_id)
 
             # Fetch and persist sidecars for this batch

--- a/api/services/mmingest/indexer.py
+++ b/api/services/mmingest/indexer.py
@@ -23,6 +23,7 @@ superseded_by to the new winner.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
@@ -113,6 +114,12 @@ class MmingestIndexer:
         self._rate_per_second = rate_per_second
         self._crawler_auth = crawler_auth
 
+        # Per-run incremental-persistence state.  Reset at the top of each
+        # run_once() call; the crawler's on_directory callback drives them.
+        self._run: IndexerRun = IndexerRun()
+        self._persist_lock: asyncio.Lock = asyncio.Lock()
+        self._persisted_urls: set[str] = set()
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -122,16 +129,29 @@ class MmingestIndexer:
 
         Returns an IndexerRun summary.  Non-fatal errors are collected in
         IndexerRun.errors; fatal errors propagate as exceptions.
+
+        Persistence is incremental: the crawler invokes ``_persist_batch`` once
+        per directory as it walks, so an interrupted pass (e.g. a container
+        restart mid-crawl) still leaves the directories it reached in the DB.
+        The full returned list drives a final sweep for any items a non-streaming
+        crawler (or a test double) returned without invoking the callback.
         """
         start = time.monotonic()
         run = IndexerRun()
+
+        # Reset per-run incremental-persistence state.  The lock is recreated
+        # here so it binds to the currently running event loop.
+        self._run = run
+        self._persist_lock = asyncio.Lock()
+        self._persisted_urls = set()
 
         # Step 1: load known state from the DB (read-only, no transaction needed)
         async with self._engine.connect() as conn:
             known = await self.load_known_state(conn)
         logger.info("mmingest indexer: %d known files loaded from DB", len(known))
 
-        # Step 2: run the delta walk (S1B does the HTTP + parse work)
+        # Step 2: run the delta walk, persisting each directory's items as they
+        # are discovered (S1B does the HTTP + parse work).
         crawler = MmingestCrawler(
             base_url=self._base_url,
             max_concurrent=self._max_concurrent,
@@ -141,50 +161,20 @@ class MmingestIndexer:
         work_items = await crawler.delta_walk(
             directories=self._directories,
             known=known,
+            on_directory=self._persist_batch,
         )
         run.files_seen = len(work_items)
+        run.files_new = len(work_items)  # crawler only returns new/changed
         logger.info("mmingest indexer: %d new/changed work items from crawler", len(work_items))
 
-        if not work_items:
-            # Still run parity check even with no new work
-            async with self._engine.connect() as conn:
-                run.fts_parity_delta = await self._verify_parity_after_batch(conn)
-            run.elapsed_seconds = time.monotonic() - start
-            return run
+        # Final sweep: persist any returned items not already streamed via the
+        # callback.  No-op in production (the crawler streams every directory);
+        # covers tests and any crawler that ignores on_directory.
+        residual = [wi for wi in work_items if wi.url not in self._persisted_urls]
+        if residual:
+            await self._persist_batch(residual)
 
-        # Step 3: upsert files into mmingest_files (transactional)
-        async with self._engine.begin() as conn:
-            url_to_id = await self._upsert_files(conn, work_items)
-
-        run.files_new = len(work_items)  # crawler only returns new/changed
-
-        # Step 4: apply variant lineage (superseded_by) updates (transactional)
-        async with self._engine.begin() as conn:
-            await self._apply_variant_lineage(conn, work_items, url_to_id)
-
-        # Step 5: fetch and persist sidecars
-        sidecar_items = [wi for wi in work_items if wi.file_type in _SIDECAR_FILE_TYPES]
-        if sidecar_items:
-            fetcher = SidecarFetcher(auth=self._crawler_auth)
-            fetch_inputs = [(wi.url, url_to_id.get(wi.url)) for wi in sidecar_items]
-            results = await fetcher.fetch_many(
-                urls=fetch_inputs,
-                max_concurrent=self._max_concurrent,
-            )
-
-            run.sidecars_fetched = len(results)
-            ok_results = [r for r in results if r.ok]
-            run.sidecars_failed = len(results) - len(ok_results)
-
-            for r in results:
-                if not r.ok:
-                    run.errors.append(f"Sidecar fetch failed for {r.url}: {r.error}")
-
-            if ok_results:
-                async with self._engine.begin() as conn:
-                    run.sidecars_persisted = await self._persist_sidecars(conn, ok_results, url_to_id)
-
-        # Step 6: parity check after the sidecar batch (read-only)
+        # Parity check after all batches (read-only)
         async with self._engine.connect() as conn:
             run.fts_parity_delta = await self._verify_parity_after_batch(conn)
 
@@ -200,6 +190,60 @@ class MmingestIndexer:
             run.elapsed_seconds,
         )
         return run
+
+    async def _persist_batch(self, items: list[FileWorkItem]) -> None:
+        """Upsert one batch of work items and their sidecars, incrementally.
+
+        Invoked once per directory by the crawler's ``on_directory`` callback,
+        and once for any residual items by ``run_once``.  Serialised with a lock
+        so concurrent directory callbacks never collide on SQLite writes.
+
+        Idempotent: URLs already persisted in this run are skipped, and the
+        underlying INSERT OR IGNORE / REPLACE statements keep cross-run re-walks
+        safe.  Sidecar counts accumulate onto the active IndexerRun so the final
+        summary is correct regardless of how many batches ran.
+        """
+        async with self._persist_lock:
+            batch = [wi for wi in items if wi.url not in self._persisted_urls]
+            if not batch:
+                return
+
+            # Upsert files (transactional)
+            async with self._engine.begin() as conn:
+                url_to_id = await self._upsert_files(conn, batch)
+
+            # Apply variant lineage (superseded_by) updates (transactional).
+            # _apply_variant_lineage re-queries the DB for each affected group,
+            # so it stays correct when groups span multiple incremental batches.
+            async with self._engine.begin() as conn:
+                await self._apply_variant_lineage(conn, batch, url_to_id)
+
+            # Fetch and persist sidecars for this batch
+            sidecar_items = [wi for wi in batch if wi.file_type in _SIDECAR_FILE_TYPES]
+            if sidecar_items:
+                fetcher = SidecarFetcher(auth=self._crawler_auth)
+                fetch_inputs = [(wi.url, url_to_id.get(wi.url)) for wi in sidecar_items]
+                results = await fetcher.fetch_many(
+                    urls=fetch_inputs,
+                    max_concurrent=self._max_concurrent,
+                )
+
+                self._run.sidecars_fetched += len(results)
+                ok_results = [r for r in results if r.ok]
+                self._run.sidecars_failed += len(results) - len(ok_results)
+
+                for r in results:
+                    if not r.ok:
+                        self._run.errors.append(f"Sidecar fetch failed for {r.url}: {r.error}")
+
+                if ok_results:
+                    async with self._engine.begin() as conn:
+                        self._run.sidecars_persisted += await self._persist_sidecars(conn, ok_results, url_to_id)
+
+            # Mark this batch persisted so the final sweep / overlapping callbacks
+            # don't double-process it.
+            for wi in batch:
+                self._persisted_urls.add(wi.url)
 
     # ------------------------------------------------------------------
     # Load known state

--- a/api/services/mmingest/run_status.py
+++ b/api/services/mmingest/run_status.py
@@ -112,6 +112,36 @@ async def record_run_finish(
         logger.exception("mmingest telemetry: failed to record run finish for run_id=%s", run_id)
 
 
+async def reconcile_running_as_interrupted(engine: AsyncEngine) -> int:
+    """Mark any lingering ``running`` rows as ``interrupted``.
+
+    Called at the start of each delta-walk pass.  Because run_delta_walk runs
+    single-instance (APScheduler max_instances=1) and only one container is
+    live, any row still ``running`` at this point is an orphan from a process
+    that died mid-walk — exactly the deploy-restart failure this PR targets.
+    Reconciling it here prevents ``/status`` from reporting ``running: true``
+    forever and records an accurate terminal status for the crashed pass.
+
+    Returns the number of rows reconciled.  Best-effort: failures are logged,
+    not raised.
+    """
+    finished = datetime.now(timezone.utc).isoformat()
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    UPDATE mmingest_crawl_runs
+                    SET status = 'interrupted', finished_at = :finished_at
+                    WHERE status = 'running'
+                """),
+                {"finished_at": finished},
+            )
+        return result.rowcount or 0
+    except Exception:
+        logger.exception("mmingest telemetry: failed to reconcile stale running rows")
+        return 0
+
+
 async def read_status(engine: AsyncEngine) -> Optional[dict[str, Any]]:
     """Return the most recent crawl run as a dict, plus a ``running`` flag.
 
@@ -122,6 +152,11 @@ async def read_status(engine: AsyncEngine) -> Optional[dict[str, Any]]:
             "last_run": { ... row fields ... } | None,
             "running": bool,
         }
+
+    ``running`` is derived from the most recent row's status — NOT a global
+    count of unfinished rows.  A global count would stay ``true`` forever after
+    a crash orphans a ``running`` row; deriving from the latest row means a
+    later completed/interrupted pass correctly reports ``running: false``.
     """
     async with engine.connect() as conn:
         # Preflight: table may not exist during the deploy window before 021.
@@ -141,10 +176,6 @@ async def read_status(engine: AsyncEngine) -> Optional[dict[str, Any]]:
             LIMIT  1
         """))).fetchone()
 
-        running = (await conn.execute(text("""
-            SELECT COUNT(*) FROM mmingest_crawl_runs
-            WHERE status = 'running' AND finished_at IS NULL
-        """))).scalar_one()
-
     last_run = dict(row._mapping) if row is not None else None
-    return {"last_run": last_run, "running": bool(running)}
+    running = last_run is not None and last_run["status"] == "running" and last_run["finished_at"] is None
+    return {"last_run": last_run, "running": running}

--- a/api/services/mmingest/run_status.py
+++ b/api/services/mmingest/run_status.py
@@ -1,0 +1,150 @@
+"""Persistence helpers for mmingest crawl-run telemetry.
+
+One row per delta-walk pass is written to ``mmingest_crawl_runs`` (migration
+021).  The scheduler records a ``running`` row when a pass starts and updates it
+to a terminal status when the pass finishes — so ``GET /api/mmingest/status``
+can report the last run's outcome and counts.
+
+Design notes
+------------
+  * These helpers own the telemetry table so the indexer's ``run_once()`` stays
+    free of telemetry concerns (and its tests don't need the new table).
+  * ``record_run_start`` / ``record_run_finish`` are best-effort: telemetry must
+    never crash a crawl.  Callers may wrap them, but the functions themselves
+    only touch a single small table and re-raise nothing the caller can't see.
+  * ``read_status`` preflights ``sqlite_master`` so it returns ``None`` rather
+    than raising during the deploy window before migration 021 applies.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+if TYPE_CHECKING:
+    from api.services.mmingest.indexer import IndexerRun
+
+logger = logging.getLogger(__name__)
+
+
+async def record_run_start(engine: AsyncEngine) -> Optional[int]:
+    """Insert a ``running`` row and return its id (or None on failure).
+
+    Failure to record telemetry is logged but never propagated — a crawl must
+    not die because its bookkeeping table is missing or locked.
+    """
+    started = datetime.now(timezone.utc).isoformat()
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    INSERT INTO mmingest_crawl_runs (started_at, status)
+                    VALUES (:started_at, 'running')
+                """),
+                {"started_at": started},
+            )
+            # SQLite: lastrowid is populated on the CursorResult.
+            run_id = result.lastrowid
+        return int(run_id) if run_id is not None else None
+    except Exception:
+        logger.exception("mmingest telemetry: failed to record run start")
+        return None
+
+
+async def record_run_finish(
+    engine: AsyncEngine,
+    run_id: Optional[int],
+    *,
+    status: str,
+    run: Optional["IndexerRun"] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Update a run row to a terminal ``status`` with counts from ``run``.
+
+    No-op when ``run_id`` is None (start was never recorded).  Best-effort:
+    telemetry failures are logged, never raised.
+
+    Args:
+        run_id:  id returned by record_run_start (None disables the update).
+        status:  'completed' | 'suppressed' | 'failed'.
+        run:     IndexerRun summary; its counts are persisted when present.
+        error:   Error string for failed/suppressed runs.
+    """
+    if run_id is None:
+        return
+
+    finished = datetime.now(timezone.utc).isoformat()
+    params: dict[str, Any] = {
+        "id": run_id,
+        "finished_at": finished,
+        "status": status,
+        "files_seen": run.files_seen if run else None,
+        "files_new": run.files_new if run else None,
+        "sidecars_fetched": run.sidecars_fetched if run else None,
+        "sidecars_persisted": run.sidecars_persisted if run else None,
+        "fts_parity_delta": run.fts_parity_delta if run else None,
+        "elapsed_seconds": run.elapsed_seconds if run else None,
+        "error": error,
+    }
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("""
+                    UPDATE mmingest_crawl_runs SET
+                        finished_at        = :finished_at,
+                        status             = :status,
+                        files_seen         = :files_seen,
+                        files_new          = :files_new,
+                        sidecars_fetched   = :sidecars_fetched,
+                        sidecars_persisted = :sidecars_persisted,
+                        fts_parity_delta   = :fts_parity_delta,
+                        elapsed_seconds    = :elapsed_seconds,
+                        error              = :error
+                    WHERE id = :id
+                """),
+                params,
+            )
+    except Exception:
+        logger.exception("mmingest telemetry: failed to record run finish for run_id=%s", run_id)
+
+
+async def read_status(engine: AsyncEngine) -> Optional[dict[str, Any]]:
+    """Return the most recent crawl run as a dict, plus a ``running`` flag.
+
+    Returns None if the telemetry table does not yet exist (pre-migration 021)
+    or no run has been recorded.  The shape is:
+
+        {
+            "last_run": { ... row fields ... } | None,
+            "running": bool,
+        }
+    """
+    async with engine.connect() as conn:
+        # Preflight: table may not exist during the deploy window before 021.
+        exists = await conn.execute(text("""
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type = 'table' AND name = 'mmingest_crawl_runs'
+        """))
+        if exists.scalar_one() < 1:
+            return None
+
+        row = (await conn.execute(text("""
+            SELECT id, started_at, finished_at, status,
+                   files_seen, files_new, sidecars_fetched, sidecars_persisted,
+                   fts_parity_delta, elapsed_seconds, error
+            FROM   mmingest_crawl_runs
+            ORDER  BY id DESC
+            LIMIT  1
+        """))).fetchone()
+
+        running = (await conn.execute(text("""
+            SELECT COUNT(*) FROM mmingest_crawl_runs
+            WHERE status = 'running' AND finished_at IS NULL
+        """))).scalar_one()
+
+    last_run = dict(row._mapping) if row is not None else None
+    return {"last_run": last_run, "running": bool(running)}

--- a/api/services/mmingest/scheduler.py
+++ b/api/services/mmingest/scheduler.py
@@ -64,7 +64,11 @@ async def run_delta_walk() -> None:
     # branches.  Import lazily to avoid circular imports at module load time.
     import api.services.database as _db_module
     from api.services.mmingest.indexer import MmingestIndexer
-    from api.services.mmingest.run_status import record_run_finish, record_run_start
+    from api.services.mmingest.run_status import (
+        reconcile_running_as_interrupted,
+        record_run_finish,
+        record_run_start,
+    )
 
     # _engine is the module-level singleton created by init_db(); if the
     # scheduler fires before init_db() completes, the engine will be None
@@ -73,6 +77,13 @@ async def run_delta_walk() -> None:
     if engine is None:
         logger.error("mmingest indexer: DB engine not initialised (init_db() not yet called). Skipping this run.")
         return
+
+    # Reconcile any orphaned 'running' rows from a process that died mid-walk
+    # (e.g. a deploy restart).  Safe here: this job is single-instance and only
+    # one container runs, so a lingering 'running' row is always stale.
+    reconciled = await reconcile_running_as_interrupted(engine)
+    if reconciled:
+        logger.warning("mmingest telemetry: marked %d orphaned 'running' run(s) as interrupted", reconciled)
 
     # Record a 'running' telemetry row so /api/mmingest/status can report an
     # in-flight (or stalled) pass even before it completes.

--- a/api/services/mmingest/scheduler.py
+++ b/api/services/mmingest/scheduler.py
@@ -60,21 +60,25 @@ async def run_delta_walk() -> None:
     """
     logger.info("mmingest delta walk + index starting")
 
+    # Resolve the engine before the try so we can record telemetry in all
+    # branches.  Import lazily to avoid circular imports at module load time.
+    import api.services.database as _db_module
+    from api.services.mmingest.indexer import MmingestIndexer
+    from api.services.mmingest.run_status import record_run_finish, record_run_start
+
+    # _engine is the module-level singleton created by init_db(); if the
+    # scheduler fires before init_db() completes, the engine will be None
+    # and we log an error rather than crashing.
+    engine = _db_module._engine
+    if engine is None:
+        logger.error("mmingest indexer: DB engine not initialised (init_db() not yet called). Skipping this run.")
+        return
+
+    # Record a 'running' telemetry row so /api/mmingest/status can report an
+    # in-flight (or stalled) pass even before it completes.
+    run_id = await record_run_start(engine)
+
     try:
-        # Import lazily to avoid circular imports at module load time.
-        # _engine is the module-level singleton created by init_db(); if the
-        # scheduler fires before init_db() completes, the engine will be None
-        # and we log an error rather than crashing.
-        import api.services.database as _db_module
-        from api.services.mmingest.indexer import MmingestIndexer
-
-        engine = _db_module._engine
-        if engine is None:
-            logger.error(
-                "mmingest indexer: DB engine not initialised (init_db() not yet called). " "Skipping this run."
-            )
-            return
-
         indexer = MmingestIndexer(
             engine=engine,
             base_url="https://mmingest.pbswi.wisc.edu/",
@@ -85,6 +89,7 @@ async def run_delta_walk() -> None:
 
         run = await indexer.run_once()
 
+        await record_run_finish(engine, run_id, status="completed", run=run)
         logger.info(
             "mmingest delta walk complete: files_seen=%d files_new=%d "
             "sidecars_fetched=%d sidecars_persisted=%d fts_delta=%s elapsed=%.1fs",
@@ -98,8 +103,12 @@ async def run_delta_walk() -> None:
 
     except RuntimeError as exc:
         # Pause-window suppression is a normal operational event, not a failure.
+        await record_run_finish(engine, run_id, status="suppressed", error=str(exc))
         logger.info("mmingest delta walk suppressed: %s", exc)
-    except Exception:
+    except Exception as exc:
+        # Record the failure so it surfaces via /api/mmingest/status, then
+        # re-log with traceback.  A silently-empty index must never look healthy.
+        await record_run_finish(engine, run_id, status="failed", error=repr(exc))
         logger.exception("mmingest delta walk failed")
 
 

--- a/tests/api/test_mmingest_status.py
+++ b/tests/api/test_mmingest_status.py
@@ -1,0 +1,134 @@
+"""Tests for GET /api/mmingest/status (crawler health endpoint).
+
+Verifies the endpoint reports live index counts and the last crawl run, and
+that it returns 200 with zeroed/null fields on a freshly-migrated (empty) DB
+rather than 500ing.  Uses the same TestClient-over-migrated-SQLite harness as
+test_mmingest_router.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    fd, db_path = tempfile.mkstemp(suffix="_mmingest_status_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine, db_path
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+def _make_client(db_path: str) -> TestClient:
+    os.environ["DATABASE_PATH"] = db_path
+
+    import api.routers.mmingest
+
+    importlib.reload(api.routers.mmingest)
+
+    import api.main
+
+    importlib.reload(api.main)
+
+    return TestClient(api.main.app, raise_server_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_status_empty_db_returns_200_with_zeros(migrated_engine):
+    """A migrated-but-empty DB returns 200, null last_run, zeroed counts."""
+    engine, db_path = migrated_engine
+    client = _make_client(db_path)
+
+    resp = client.get("/api/mmingest/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["last_run"] is None
+    assert body["running"] is False
+    assert body["counts"] == {"files": 0, "current_files": 0, "sidecars": 0}
+
+
+@pytest.mark.asyncio
+async def test_status_reports_counts_and_last_run(migrated_engine):
+    """With data + a recorded run, /status reports both."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        # Two files, one superseded.
+        await conn.execute(text("""
+            INSERT INTO mmingest_files (remote_url, filename, file_type, media_id, prefix, first_seen_at, superseded_by)
+            VALUES ('u1', '6POL0101.mp4', 'mp4', '6POL0101', '6POL', '2026-03-19T10:00:00', NULL)
+        """))
+        await conn.execute(text("""
+            INSERT INTO mmingest_files (remote_url, filename, file_type, media_id, prefix, first_seen_at, superseded_by)
+            VALUES ('u2', '6POL0101_old.mp4', 'mp4', '6POL0101', '6POL', '2026-03-19T10:00:00', 1)
+        """))
+        await conn.execute(text("""
+            INSERT INTO mmingest_sidecars (file_id, kind, body_text)
+            VALUES (1, 'srt', 'hello world')
+        """))
+        await conn.execute(text("""
+            INSERT INTO mmingest_crawl_runs
+                (started_at, finished_at, status, files_seen, files_new, sidecars_persisted, fts_parity_delta, elapsed_seconds)
+            VALUES ('2026-06-29T17:00:00', '2026-06-29T17:01:00', 'completed', 2, 2, 1, 0, 42.0)
+        """))
+
+    client = _make_client(db_path)
+    resp = client.get("/api/mmingest/status")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["counts"] == {"files": 2, "current_files": 1, "sidecars": 1}
+    assert body["running"] is False
+    assert body["last_run"]["status"] == "completed"
+    assert body["last_run"]["files_seen"] == 2
+    assert body["last_run"]["sidecars_persisted"] == 1
+    assert body["last_run"]["fts_parity_delta"] == 0
+
+
+@pytest.mark.asyncio
+async def test_status_running_flag_for_in_flight_pass(migrated_engine):
+    """A 'running' row with NULL finished_at sets running=true."""
+    engine, db_path = migrated_engine
+
+    async with engine.begin() as conn:
+        await conn.execute(text("""
+            INSERT INTO mmingest_crawl_runs (started_at, status)
+            VALUES ('2026-06-29T17:00:00', 'running')
+        """))
+
+    client = _make_client(db_path)
+    resp = client.get("/api/mmingest/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["running"] is True
+    assert body["last_run"]["status"] == "running"
+    assert body["last_run"]["finished_at"] is None

--- a/tests/integration/test_mmingest_incremental.py
+++ b/tests/integration/test_mmingest_incremental.py
@@ -1,0 +1,195 @@
+"""Integration tests for incremental (per-directory) persistence + telemetry.
+
+These cover the fix for the empty-index-on-prod bug (2026-06-29): the indexer
+now persists each directory's work items as the crawler discovers them, so an
+interrupted walk still populates the DB.  Telemetry (mmingest_crawl_runs) is
+exercised via the run_status helpers.
+
+The shared migrated_engine fixture mirrors tests/integration/test_mmingest_index.py.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from api.services.mmingest.crawler import FileWorkItem
+from api.services.mmingest.indexer import MmingestIndexer
+from api.services.mmingest.run_status import read_status, record_run_finish, record_run_start
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    """Stand up a fresh DB via `alembic upgrade head`, return an async engine."""
+    fd, db_path = tempfile.mkstemp(suffix="_incremental_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+def _file(url: str, filename: str, media_id: str, *, file_type: str = "mp4") -> FileWorkItem:
+    return FileWorkItem(
+        url=url,
+        directory_path="/IWP/",
+        filename=filename,
+        media_id=media_id,
+        prefix="6POL",
+        prefix_category="non-broadcast",
+        show_name="Inside Wisconsin Politics",
+        season=1,
+        episode=1,
+        hd=None,
+        revision_date=None,
+        variant_tag=None,
+        unknown_tag=None,
+        file_type=file_type,
+        remote_modified_at=None,
+        file_size_bytes=1000,
+        change_triple=(None, None, 1000),
+        lane="primary",
+    )
+
+
+async def _count_files(engine) -> int:
+    async with engine.connect() as conn:
+        return (await conn.execute(text("SELECT COUNT(*) FROM mmingest_files"))).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Incremental persistence: interrupted walk still leaves earlier dirs in the DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_walk_persists_completed_directories(migrated_engine):
+    """If the walk streams one directory then crashes, that directory persists.
+
+    A crawler double invokes on_directory for the first directory's items, then
+    raises (simulating a container restart / network death mid-walk).  run_once
+    propagates the error, but the streamed rows must already be committed.
+    """
+    dir1 = [
+        _file("https://mmingest.pbswi.wisc.edu/IWP/6POL0101.mp4", "6POL0101.mp4", "6POL0101"),
+        _file("https://mmingest.pbswi.wisc.edu/IWP/6POL0102.mp4", "6POL0102.mp4", "6POL0102"),
+    ]
+
+    async def fake_delta_walk(*, directories, known, on_directory):  # noqa: ARG001
+        # Stream the first directory's items (these should persist) ...
+        await on_directory(dir1)
+        # ... then die before the walk completes.
+        raise RuntimeError("simulated mid-walk crash")
+
+    mock_crawler = AsyncMock()
+    mock_crawler.delta_walk = AsyncMock(side_effect=fake_delta_walk)
+
+    with patch("api.services.mmingest.indexer.MmingestCrawler", return_value=mock_crawler):
+        indexer = MmingestIndexer(engine=migrated_engine)
+        with pytest.raises(RuntimeError, match="simulated mid-walk crash"):
+            await indexer.run_once()
+
+    # The two streamed rows survived the crash — this is the whole point of the fix.
+    assert await _count_files(migrated_engine) == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_batches_are_not_double_counted(migrated_engine):
+    """Items streamed via on_directory are not re-persisted by the final sweep.
+
+    The crawler streams two directories, then returns the full flat list (as the
+    real crawler does).  run_once's residual sweep must skip already-persisted
+    URLs, so sidecar/file counts reflect each item exactly once.
+    """
+    dir1 = [_file("https://mmingest.pbswi.wisc.edu/A/6POL0101.mp4", "6POL0101.mp4", "6POL0101")]
+    dir2 = [_file("https://mmingest.pbswi.wisc.edu/B/6POL0202.mp4", "6POL0202.mp4", "6POL0202")]
+
+    async def fake_delta_walk(*, directories, known, on_directory):  # noqa: ARG001
+        await on_directory(dir1)
+        await on_directory(dir2)
+        return dir1 + dir2  # full list returned, exactly like the real crawler
+
+    mock_crawler = AsyncMock()
+    mock_crawler.delta_walk = AsyncMock(side_effect=fake_delta_walk)
+
+    with patch("api.services.mmingest.indexer.MmingestCrawler", return_value=mock_crawler):
+        indexer = MmingestIndexer(engine=migrated_engine)
+        run = await indexer.run_once()
+
+    assert run.files_seen == 2
+    assert await _count_files(migrated_engine) == 2  # not 4 — no double persistence
+
+
+# ---------------------------------------------------------------------------
+# Telemetry: run_status roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_run_start_and_finish_roundtrip(migrated_engine):
+    """record_run_start writes a 'running' row; record_run_finish completes it."""
+    run_id = await record_run_start(migrated_engine)
+    assert run_id is not None
+
+    status = await read_status(migrated_engine)
+    assert status is not None
+    assert status["running"] is True
+    assert status["last_run"]["status"] == "running"
+    assert status["last_run"]["finished_at"] is None
+
+    # Build a minimal IndexerRun-like object for counts.
+    class _Run:
+        files_seen = 7
+        files_new = 7
+        sidecars_fetched = 3
+        sidecars_persisted = 3
+        fts_parity_delta = 0
+        elapsed_seconds = 12.5
+
+    await record_run_finish(migrated_engine, run_id, status="completed", run=_Run())
+
+    status2 = await read_status(migrated_engine)
+    assert status2["running"] is False
+    lr = status2["last_run"]
+    assert lr["status"] == "completed"
+    assert lr["files_seen"] == 7
+    assert lr["sidecars_persisted"] == 3
+    assert lr["fts_parity_delta"] == 0
+    assert lr["finished_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_record_run_finish_failed_captures_error(migrated_engine):
+    """A failed run records status='failed' and the error string."""
+    run_id = await record_run_start(migrated_engine)
+    await record_run_finish(migrated_engine, run_id, status="failed", error="boom: connection reset")
+
+    status = await read_status(migrated_engine)
+    assert status["running"] is False
+    assert status["last_run"]["status"] == "failed"
+    assert "boom" in status["last_run"]["error"]

--- a/tests/integration/test_mmingest_incremental.py
+++ b/tests/integration/test_mmingest_incremental.py
@@ -23,7 +23,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from api.services.mmingest.crawler import FileWorkItem
 from api.services.mmingest.indexer import MmingestIndexer
-from api.services.mmingest.run_status import read_status, record_run_finish, record_run_start
+from api.services.mmingest.run_status import (
+    read_status,
+    reconcile_running_as_interrupted,
+    record_run_finish,
+    record_run_start,
+)
 
 
 @pytest_asyncio.fixture
@@ -193,3 +198,41 @@ async def test_record_run_finish_failed_captures_error(migrated_engine):
     assert status["running"] is False
     assert status["last_run"]["status"] == "failed"
     assert "boom" in status["last_run"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_running_flag_not_stuck_after_orphaned_run(migrated_engine):
+    """An orphaned 'running' row must not pin running=true after a later run.
+
+    Regression for the crash-leaves-running-forever bug: a process that dies
+    mid-walk leaves a 'running' row.  A subsequent completed run must report
+    running=false because the flag is derived from the latest row, not a global
+    count of unfinished rows.
+    """
+    # Orphan: a 'running' row that never finished (dead process).
+    await record_run_start(migrated_engine)
+
+    # A later pass starts and completes normally.
+    run_id2 = await record_run_start(migrated_engine)
+    await record_run_finish(migrated_engine, run_id2, status="completed")
+
+    status = await read_status(migrated_engine)
+    assert status["running"] is False, "running flag stuck true despite latest run completing"
+    assert status["last_run"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_marks_orphaned_running_as_interrupted(migrated_engine):
+    """reconcile_running_as_interrupted flips lingering 'running' rows."""
+    await record_run_start(migrated_engine)  # orphan
+
+    reconciled = await reconcile_running_as_interrupted(migrated_engine)
+    assert reconciled == 1
+
+    status = await read_status(migrated_engine)
+    assert status["running"] is False
+    assert status["last_run"]["status"] == "interrupted"
+    assert status["last_run"]["finished_at"] is not None
+
+    # Idempotent: a second reconcile finds nothing to do.
+    assert await reconcile_running_as_interrupted(migrated_engine) == 0

--- a/tests/services/mmingest/test_scheduler_telemetry.py
+++ b/tests/services/mmingest/test_scheduler_telemetry.py
@@ -1,0 +1,96 @@
+"""Tests that run_delta_walk records crawl-run telemetry in every branch.
+
+Locks the "no silently-empty index" guarantee: a completed pass records
+status='completed' with counts, and a failing pass records status='failed'
+with the error (and still re-logs via logger.exception).  Mirrors the migrated
+SQLite harness used elsewhere; the DB engine singleton is patched so the
+scheduler resolves a real, migrated engine.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import api.services.database as _db_module
+from api.services.mmingest.indexer import IndexerRun
+from api.services.mmingest.run_status import read_status
+
+
+@pytest_asyncio.fixture
+async def migrated_engine():
+    fd, db_path = tempfile.mkstemp(suffix="_scheduler_telemetry_test.db")
+    os.close(fd)
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    env = {**os.environ, "DATABASE_PATH": db_path}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}"
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    yield engine
+
+    await engine.dispose()
+    try:
+        os.unlink(db_path)
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_completed_run_records_telemetry(migrated_engine):
+    """A successful run_delta_walk records status='completed' with counts."""
+    from api.services.mmingest import scheduler
+
+    fake_run = IndexerRun(files_seen=5, files_new=5, sidecars_persisted=2, fts_parity_delta=0, elapsed_seconds=3.0)
+    mock_indexer = AsyncMock()
+    mock_indexer.run_once = AsyncMock(return_value=fake_run)
+
+    # run_delta_walk imports MmingestIndexer locally at call time, so patch the
+    # source module where the name is resolved.
+    with (
+        patch.object(_db_module, "_engine", migrated_engine),
+        patch("api.services.mmingest.indexer.MmingestIndexer", return_value=mock_indexer),
+    ):
+        await scheduler.run_delta_walk()
+
+    status = await read_status(migrated_engine)
+    assert status["running"] is False
+    assert status["last_run"]["status"] == "completed"
+    assert status["last_run"]["files_seen"] == 5
+    assert status["last_run"]["sidecars_persisted"] == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_run_records_failed_status(migrated_engine):
+    """A run that raises records status='failed' with the error (not silent)."""
+    from api.services.mmingest import scheduler
+
+    mock_indexer = AsyncMock()
+    mock_indexer.run_once = AsyncMock(side_effect=ValueError("crawl exploded"))
+
+    with (
+        patch.object(_db_module, "_engine", migrated_engine),
+        patch("api.services.mmingest.indexer.MmingestIndexer", return_value=mock_indexer),
+    ):
+        # run_delta_walk catches the exception (logs + records); it does not re-raise.
+        await scheduler.run_delta_walk()
+
+    status = await read_status(migrated_engine)
+    assert status["running"] is False
+    assert status["last_run"]["status"] == "failed"
+    assert "crawl exploded" in status["last_run"]["error"]


### PR DESCRIPTION
## Why

The prod mmingest index on `cardigan.riechers.co` was **empty despite a healthy read API** (all `/api/mmingest/*` read endpoints 200 with zero rows). Live diagnosis on `cardigan01` (2026-06-29):

- **Not a stale image / broken auto-deploy** — api+worker images were 4h old, `cardigan-update.timer` healthy, the post-#215 scheduler demonstrably running.
- **Not egress / pause-window / parse failure** — httpx logs show `GET mmingest.pbswi.wisc.edu/ → 200`; listings are tiny (root 9KB).
- **Actual failure:** the hourly delta-walk **never completes a single pass** — ~3 HTTP requests in 3.5h with multi-hour idle gaps *while the event loop stayed alive* (it served a WebSocket mid-gap). Because the indexer only persisted **after** the full walk returned (commit-at-end), zero rows were ever written; and deploy-driven container restarts discarded each in-progress walk before it could commit.

The exact reason the crawl coroutine stalls between requests is not yet pinned from logs — the per-directory progress logging + `/status` telemetry added here are the instrument to capture it on the next instrumented run.

## What

Robust regardless of the precise stall cause:

**Incremental persistence (the durable fix)**
- Crawler streams each directory's work items via a new `on_directory` callback as it walks.
- Indexer persists per-directory (`_persist_batch`, serialised with a lock, idempotent via existing `INSERT OR IGNORE/REPLACE`). An interrupted pass now leaves the directories it reached in the DB.
- `run_once` keeps a final residual sweep, so the non-streaming path (all existing mocked-`delta_walk` tests) is unchanged.

**Observability**
- Migration `021` adds `mmingest_crawl_runs` (one row/pass: start/finish, status, `IndexerRun` counts, error).
- Scheduler records start/finish and records `failed` on exception (still re-logs via `logger.exception`) — a stalled/failed crawl can no longer hide behind an empty index.
- `GET /api/mmingest/status` reports last run + live row counts; always 200 (zeros/null pre-migration) so monitors can poll through deploys.
- Per-directory `INFO` progress logging in the crawler exposes the stall live in `docker logs`.

## Tests

New: incremental partial-walk persistence + no-double-count, `run_status` roundtrip, scheduler telemetry (completed/failed), `/status` endpoint (empty DB / populated / running flag). Full suite green locally (**843 passed, 5 xfailed**); `black` + `ruff` clean.

## Deploy note

Additive migration (new table) — safe. **Redeploy is a separate, explicitly-approved step.** After deploy, poll `GET /api/mmingest/status` and watch the per-directory crawl logs to pin the stall, then tune rate/concurrency/scope in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)