### PR TITLE
fix(mmingest): fix TokenBucket livelock that stalled the crawl (root cause)

### DIFF
--- a/api/services/mmingest/crawler.py
+++ b/api/services/mmingest/crawler.py
@@ -130,10 +130,21 @@ class TokenBucket:
     async def acquire(self) -> None:
         """Wait until a token is available, then consume it.
 
-        Uses a re-acquire loop to avoid over-issue during the sleep period:
-        after sleeping, we re-enter the lock and re-check — another coroutine
-        may have consumed the token that was refilled during our sleep, so we
-        loop until we can actually decrement.
+        Refills lazily from elapsed wall-clock on each lock entry and consumes a
+        whole token only once one has accumulated.  The ``_lock`` serialises the
+        decrement, so two waiters can never consume the same token — no
+        speculative reservation is needed.
+
+        IMPORTANT: do NOT zero ``self._tokens`` for non-acquiring waiters.  An
+        earlier version reset ``self._tokens = 0.0`` while computing the sleep,
+        which — combined with advancing ``_last_refill`` on every entry —
+        discarded the fractional tokens accrued so far.  With many concurrent
+        waiters re-entering the lock faster than the refill period, the accrued
+        fraction was perpetually thrown away, tokens almost never reached 1.0,
+        and callers starved indefinitely (a livelock that left the mmingest
+        crawl stuck after its first request).  Preserving ``_tokens`` across
+        entries lets the fraction accumulate to a whole token at the configured
+        rate regardless of contention.
         """
         while True:
             async with self._lock:
@@ -146,10 +157,9 @@ class TokenBucket:
                     self._tokens -= 1.0
                     return
 
-                # Compute sleep and reserve the token speculatively
-                # (set tokens to 0 so concurrent acquires see an empty bucket)
+                # Not enough yet — sleep for the remaining deficit, leaving the
+                # accrued fraction in place so it keeps accumulating.
                 wait_time = (1.0 - self._tokens) / self._rate
-                self._tokens = 0.0
 
             # Sleep outside the lock so other coroutines can run
             await asyncio.sleep(wait_time)

--- a/tests/services/mmingest/test_crawler.py
+++ b/tests/services/mmingest/test_crawler.py
@@ -74,6 +74,38 @@ class TestTokenBucket:
         # Allow generous tolerance for CI environments
         assert elapsed >= 0.05, f"Should have waited but only took {elapsed:.3f}s"
 
+    @pytest.mark.asyncio
+    async def test_concurrent_staggered_acquire_does_not_livelock(self):
+        """Many staggered concurrent waiters must all drain at ~rate (regression).
+
+        Reproduces the livelock that left the prod mmingest index empty: acquire()
+        discarded accumulated tokens (``self._tokens = 0.0``) on every
+        non-acquiring waiter while also advancing ``_last_refill`` on every lock
+        entry.  With N waiters re-entering the lock faster than the refill period,
+        the accumulated fraction was perpetually reset, tokens almost never
+        reached 1.0, and nearly all callers starved indefinitely.
+
+        The staggered start is essential: synchronized waiters happen to wake in a
+        tight batch and mask the bug, but real callers desynchronise (the root
+        request's network I/O offsets each child).  Under the bug this test hangs
+        and times out; with the fix all 30 drain in ~1.5s.
+        """
+        bucket = TokenBucket(rate=20.0, burst=1)  # 1 token / 50ms
+        await bucket.acquire()  # consume the initial token (mimics the root request)
+
+        done = 0
+        N = 30
+
+        async def waiter(i: int) -> None:
+            nonlocal done
+            await asyncio.sleep(i * 0.003)  # desynchronise the waiters
+            await bucket.acquire()
+            done += 1
+
+        # At 20/s, 30 acquisitions take ~1.5s; the livelock would blow past 8s.
+        await asyncio.wait_for(asyncio.gather(*(waiter(i) for i in range(N))), timeout=8.0)
+        assert done == N, f"only {done}/{N} acquired — rate limiter starved waiters"
+
 
 # ---------------------------------------------------------------------------
 # MmingestCrawler — concurrency cap


### PR DESCRIPTION
## The actual root cause of the empty prod index

#282 made the empty mmingest index **durable + observable** (incremental persistence + `/api/mmingest/status` + per-directory logging). That instrumentation handed us the real cause, and this PR fixes it.

### Diagnosis (reproduced locally against the real mmingest server)
After the root request, the crawl issued **~1 HTTP request every 1–2 hours** and otherwise sat idle (prod: root at 22:30, `/AANM/` at 23:57, then nothing for 18h). Steps to ground truth:
1. Live `asyncio` task dump → **41 subdir coroutines parked in `TokenBucket.acquire()`**.
2. Counter instrumentation → `rate.acquire 42→1` (42 started, 1 returned); semaphore and `client.get` never reached.
3. Acquire-loop instrumentation → every iteration saw `elapsed≈0`, `tokens≈0` — a **livelock**.

### Cause
`acquire()` advanced `_last_refill = now` on **every** lock entry *and* set `self._tokens = 0.0` speculatively for non-acquiring waiters. With N waiters re-entering the lock faster than the 1/sec refill (a lock entry every ~24ms with 41 waiters), the fractional tokens accrued between entries were perpetually discarded — tokens almost never reached 1.0, so callers starved. The rare success was a lucky >1s gap.

A synchronized-waiter unit test masked this; **real callers desynchronise** because the root request's network I/O staggers each child — which is why it only surfaced under the live crawler, not in isolation.

### Fix
Remove the `self._tokens = 0.0` reset (one line). The `_lock` already serialises the decrement, so preserving the accrued fraction across entries **cannot** over-issue and lets tokens accumulate to a whole token at the configured rate regardless of contention.

Verified against the real server: **drains at a steady 1/sec (20 requests in 20s)** vs 1-in-20s before.

### Test
`test_concurrent_staggered_acquire_does_not_livelock` reproduces the starvation with staggered waiters — **times out on the old code, passes with the fix**. Full suite green (846 passed); black + ruff clean.

### Deploy note
Once merged + deployed, the next delta-walk (fires ~1h after container start) should crawl the full tree at ~1 req/sec and populate the index. `/api/mmingest/status` (#282) will show `counts.files` climbing and the run reaching `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)