### PR TITLE
feat: local-LLM (oMLX) backend + hybrid-pipeline exploration (checkpoint)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,16 +12,24 @@
 #   secrets/langfuse_secret_key
 #   secrets/cardigan_api_key
 #   secrets/cloudflare_tunnel_token  (optional — only for tunnel profile)
+#   secrets/local_llm_api_key        (optional — only if routing a phase to the local-llm backend)
 #
 # Local dev (macOS Keychain — no Docker):
 #   security add-generic-password -a "$USER" -s "developer.workspace.OPENROUTER_API_KEY" -w "sk-or-..." -U
 #   security add-generic-password -a "$USER" -s "developer.workspace.AIRTABLE_API_KEY" -w "pat..." -U
+# The oMLX local-LLM key lives in 1Password ("oMLX Local LLM Key"); for local dev
+# export it instead of adding to Keychain:  export LOCAL_LLM_API_KEY="$(op item get ...)"
 
 # NON-SECRET configuration only below this line.
 # Secrets should NOT be placed in this file.
 
 # CORS origins (comma-separated). Defaults to localhost:3000,localhost:5173 for dev.
 # CORS_ORIGINS=http://localhost:3000,https://cardigan.bymarkriechers.com
+
+# local-llm backend (oMLX on the Mac Studio). Re-point at any OpenAI-compatible
+# server via these; LOCAL_LLM_MODEL is required before routing a phase to local-llm.
+# LOCAL_LLM_ENDPOINT=http://studio.riechers.co:8000/v1/chat/completions
+# LOCAL_LLM_MODEL=mlx-community/your-fitting-model-id
 
 # Docker config path (for watchtower in prod)
 # DOCKER_CONFIG=/home/ubuntu/.docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Cardigan. The git tag (`vX.Y.Z`) is the single
 source of truth for the version (see `docs/VERSIONING.md`); this file is
 the human-readable companion.
 
+## [Unreleased]
+
+### Changed
+- **Local LLM backend is now `local-llm` (oMLX), portable across networks.**
+  Retired the "dougie" server in favor of oMLX (`studio.riechers.co:8000`). The
+  backend re-points at any OpenAI-compatible endpoint via `LOCAL_LLM_ENDPOINT` /
+  `LOCAL_LLM_MODEL` / `LOCAL_LLM_API_KEY` (no committed-config edit) — `_resolve_endpoint`
+  now accepts a `/v1` base URL and a new `model_env` override supplies the served model.
+  Wired into `docker-compose.prod.yml` (api + worker) with a `local_llm_api_key` secret.
+  Default-off for routing until the shadow-eval gate passes; see
+  `planning/2026-07-02-local-llm-omlx-integration.md`.
+
+### Removed
+- Dead `local-ollama` / `remote-ollama` backends (no `ollama` dispatch existed).
+
 ## [4.2.0] — 2026-06-19
 
 The **homelab operational milestone** — closes out a ~29-commit window

--- a/api/services/llm.py
+++ b/api/services/llm.py
@@ -82,8 +82,8 @@ def _parse_unavailable_503(response: "httpx.Response") -> tuple[str, Optional[in
 
     Tolerates today's flat ``{"detail": "..."}`` body and a future richer
     envelope ``{"error": {"retryable": bool, "retry_after_s": int, "message": ...}}``
-    (see the dougie busy-signal handoff). Defaults to retryable=True so a bare
-    503 from a deferrable backend is treated as "try later".
+    (a local model server's busy-signal contract). Defaults to retryable=True so
+    a bare 503 from a deferrable backend is treated as "try later".
     """
     retryable = True
     retry_after_s: Optional[int] = None
@@ -314,12 +314,33 @@ def _resolve_endpoint(config: Dict[str, Any]) -> str:
     """Resolve a backend's endpoint, honoring an optional ``endpoint_env`` override.
 
     Lets the deploy environment supply the URL (e.g. the LXC→Mac Studio address
-    for local-dougie) without baking a homelab address into committed config.
+    for a local model server) without baking a network address into committed
+    config — so the same image can be re-pointed at a different network by
+    setting one env var.
+
+    Tolerates an OpenAI-style *base* URL ending in ``/v1`` (the convention the
+    ``/local-llm`` skill and oMLX use): the chat-completions path is appended so
+    a bare base and a full endpoint both work.
     """
     env_var = config.get("endpoint_env")
+    endpoint = os.getenv(env_var, config["endpoint"]) if env_var else config["endpoint"]
+    stripped = endpoint.rstrip("/")
+    if stripped.endswith("/v1"):
+        return stripped + "/chat/completions"
+    return endpoint
+
+
+def _resolve_model(config: Dict[str, Any]) -> Optional[str]:
+    """Resolve a backend's served model id, honoring an optional ``model_env`` override.
+
+    Mirrors ``_resolve_endpoint``: a single-model local server may serve a
+    different model on a different network, so the deploy env can supply the id
+    (``LOCAL_LLM_MODEL``) without a committed-config edit.
+    """
+    env_var = config.get("model_env")
     if env_var:
-        return os.getenv(env_var, config["endpoint"])
-    return config["endpoint"]
+        return os.getenv(env_var, config.get("model"))
+    return config.get("model")
 
 
 def _backend_cost(config: Dict[str, Any], model: str, input_tokens: int, output_tokens: int) -> float:
@@ -585,13 +606,14 @@ class LLMClient:
         backend_config = self.get_backend_config(backend_name)
 
         # Determine model — priority order:
-        # 0. Backend with force_model (e.g. local-dougie serves one model only —
-        #    its own id must win over a phase_models cloud id the server can't serve)
+        # 0. Backend with force_model (e.g. a local single-model server —
+        #    its own id must win over a phase_models cloud id the server can't serve;
+        #    honors a ``model_env`` override for portability across networks)
         # 1. Explicit model param
         # 2. phase_models config (per-phase model assignment from Settings UI)
         # 3. Backend's configured model / fallback_model
         if backend_config.get("force_model"):
-            model_id = backend_config.get("model")
+            model_id = _resolve_model(backend_config)
         elif model:
             model_id = model
         elif phase:

--- a/api/services/secrets.py
+++ b/api/services/secrets.py
@@ -81,6 +81,7 @@ def _bootstrap_complete() -> bool:
         "LANGFUSE_PUBLIC_KEY",
         "LANGFUSE_SECRET_KEY",
         "CARDIGAN_API_KEY",
+        "LOCAL_LLM_API_KEY",
     ]
     for key in keys:
         if key not in os.environ:

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -2,22 +2,6 @@
   "primary_backend": "openrouter",
   "fallback_backend": "openrouter",
   "backends": {
-    "local-ollama": {
-      "type": "ollama",
-      "endpoint": "http://localhost:11434",
-      "model": "qwen2.5:14b",
-      "timeout": 180,
-      "cost_per_project": 0.0,
-      "enabled": false
-    },
-    "remote-ollama": {
-      "type": "ollama",
-      "endpoint": "http://192.168.1.100:11434",
-      "model": "qwen2.5:14b",
-      "timeout": 180,
-      "cost_per_project": 0.0,
-      "enabled": false
-    },
     "openai-mini": {
       "type": "openai",
       "endpoint": "https://api.openai.com/v1/chat/completions",
@@ -99,18 +83,20 @@
       "api_key_env": "OPENROUTER_API_KEY",
       "timeout": 300
     },
-    "local-dougie": {
+    "local-llm": {
       "type": "openai",
-      "endpoint": "http://localhost:27180/v1/chat/completions",
-      "endpoint_env": "DOUGIE_ENDPOINT",
-      "model": "mlx-community/Qwen3.6-35B-A3B-4bit",
+      "endpoint": "http://studio.riechers.co:8000/v1/chat/completions",
+      "endpoint_env": "LOCAL_LLM_ENDPOINT",
+      "model": "PLACEHOLDER-set-via-model-fit-or-LOCAL_LLM_MODEL",
+      "model_env": "LOCAL_LLM_MODEL",
+      "api_key_env": "LOCAL_LLM_API_KEY",
       "strip_reasoning": true,
       "force_model": true,
       "defer_when_unavailable": true,
       "max_tokens": 8192,
       "timeout": 300,
       "cost_per_project": 0.0,
-      "enabled": false
+      "enabled": true
     }
   },
   "auto_select": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,12 +19,19 @@ services:
       - LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
       - CARDIGAN_VERSION=${CARDIGAN_VERSION:-v4.2}
       - LLM_CONFIG_PATH=/data/config/llm-config.json
+      # local-llm backend (oMLX on the Mac Studio). Re-point at any OpenAI-compatible
+      # server by changing these two — no committed-config edit. Accepts a /v1 base
+      # URL or a full /v1/chat/completions endpoint. LOCAL_LLM_MODEL is REQUIRED
+      # before routing a phase to local-llm (the served model id).
+      - LOCAL_LLM_ENDPOINT=${LOCAL_LLM_ENDPOINT:-http://studio.riechers.co:8000/v1/chat/completions}
+      - LOCAL_LLM_MODEL=${LOCAL_LLM_MODEL:-}
     secrets:
       - openrouter_api_key
       - airtable_api_key
       - langfuse_public_key
       - langfuse_secret_key
       - google_drive_credentials
+      - local_llm_api_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -50,11 +57,15 @@ services:
       - CARDIGAN_VERSION=${CARDIGAN_VERSION:-v4.2}
       - DIARIZATION_SERVICE_URL=http://diarization:8000
       - LLM_CONFIG_PATH=/data/config/llm-config.json
+      # local-llm backend — see api service for details.
+      - LOCAL_LLM_ENDPOINT=${LOCAL_LLM_ENDPOINT:-http://studio.riechers.co:8000/v1/chat/completions}
+      - LOCAL_LLM_MODEL=${LOCAL_LLM_MODEL:-}
     secrets:
       - openrouter_api_key
       - airtable_api_key
       - langfuse_public_key
       - langfuse_secret_key
+      - local_llm_api_key
     volumes:
       - db-data:/data/db
       - output-data:/data/output
@@ -168,6 +179,8 @@ secrets:
     file: ./secrets/hf_token
   google_drive_credentials:
     file: ./secrets/google_drive_credentials
+  local_llm_api_key:
+    file: ./secrets/local_llm_api_key
 
 volumes:
   db-data:

--- a/planning/2026-07-02-local-llm-omlx-integration.md
+++ b/planning/2026-07-02-local-llm-omlx-integration.md
@@ -1,0 +1,90 @@
+# Local LLM as a Cardigan backend — oMLX integration (supersedes dougie)
+
+**Date:** 2026-07-02
+**Supersedes:** `planning/archive/2026-06-0{5,10,12}-*dougie*.md`
+**Status:** Code + config + deploy wiring landed; **operational enable (model pick,
+reachability, shadow-eval, analyst flip) still pending** — needs the live Studio + LXC.
+
+## Decision
+
+Mark standardized on **oMLX** (`github.com/jundot/omlx`, OpenAI-compatible server at
+`http://studio.riechers.co:8000/v1`) as the single local-model-serving stack on the Mac
+Studio. The earlier **dougie** supervisor (`:27180`) is **retired** — all references
+scrubbed from code, config, tests, and scripts.
+
+The backend is now a **network-neutral `local-llm`** so Cardigan can be re-pointed at any
+OpenAI-compatible endpoint (a future WPM/Vilas-Hall server, with the app container on a
+different box than the model) by changing **env vars only** — no committed-config edit.
+
+## What landed in this change
+
+### `config/llm-config.json`
+- New `backends.local-llm` (`type:"openai"`, `enabled:true`):
+  - `endpoint` = `http://studio.riechers.co:8000/v1/chat/completions`,
+    `endpoint_env` = `LOCAL_LLM_ENDPOINT`
+  - `model` = a placeholder sentinel; `model_env` = `LOCAL_LLM_MODEL` (deploy supplies it)
+  - `api_key_env` = `LOCAL_LLM_API_KEY` (oMLX enforces a Bearer key)
+  - `strip_reasoning`, `force_model`, `defer_when_unavailable`, `max_tokens:8192`,
+    `cost_per_project:0.0`, `timeout:300`
+- Removed the dead `local-ollama` / `remote-ollama` backends (no `ollama` dispatch branch).
+- `phase_backends` unchanged (all cloud) — the `analyst` flip happens **after** the eval.
+
+### `api/services/llm.py`
+- `_resolve_endpoint()` now also **normalizes a `/v1` base URL** to
+  `/v1/chat/completions`, so the `/local-llm` skill's `LOCAL_LLM_ENDPOINT` base form works
+  verbatim.
+- New `_resolve_model()` — `model_env` override for the served model id (mirrors
+  `_resolve_endpoint`); the `force_model` branch uses it.
+- dougie-specific comments genericized. All behavior (`_parse_unavailable_503`, deferral,
+  `strip_reasoning`, keyless-tolerant auth) is unchanged and now serves oMLX.
+
+### Secrets + deploy
+- `api/services/secrets.py`: `LOCAL_LLM_API_KEY` added to `bootstrap_secrets()`.
+- `docker-compose.prod.yml`: api + worker get `LOCAL_LLM_ENDPOINT` / `LOCAL_LLM_MODEL`
+  env + the `local_llm_api_key` Docker secret (registered under top-level `secrets:`).
+- `secrets/local_llm_api_key.example`, `secrets/README.md`, `.env.example` documented.
+  The real key lives in **1Password → "oMLX Local LLM Key"** — never committed.
+
+### Tests
+- `tests/api/test_llm.py`, `tests/api/test_worker.py`: renamed to `local-llm` /
+  `LOCAL_LLM_ENDPOINT`; new cases for `model_env` override, `/v1` endpoint normalization,
+  and Bearer-present auth (oMLX is keyed, unlike dougie). Autouse fixture clears ambient
+  `LOCAL_LLM_*` so the suite is deterministic on a dev shell that exports them.
+
+## Remaining operational steps (need the live homelab)
+
+1. **Pick + load the oMLX model** via `/model-fit` — the strongest analyst-capable model
+   that fits oMLX's ~13 GB ceiling (a too-big model returns HTTP 507). Put its id in
+   `LOCAL_LLM_MODEL` (host `.env`) and, optionally, the config `model` default.
+2. **Verify LXC→Studio reachability** from inside the `cardigan01` container:
+   `curl -H "Authorization: Bearer $KEY" http://studio.riechers.co:8000/v1/models`.
+   DNS failure ⇒ the Docker/Tailscale MagicDNS hijack; fix via the
+   `/etc/docker/daemon.json` DNS pin to OPNsense (192.168.1.1). Confirm the Studio's
+   macOS firewall allows `:8000` from the LXC subnet. (See homelab
+   `2026-06-30-mac-studio-omlx-llm-access-handoff.md`.)
+3. **Shadow-eval** (do NOT trust-flip):
+   `python scripts/shadow_eval_analyst.py --backends openrouter-cheapskate,local-llm`
+   over ~5–10 real transcripts; compare quality / completeness / latency / `$0` cost.
+4. **Flip `analyst` → `local-llm`** only if the eval holds — durably via
+   `PATCH /config/phase-backends` on cardigan01 (persists on the config volume) or in
+   committed config.
+
+## Deploy note (config-volume reconciliation)
+
+Prod reads config from the `config-data` volume (`LLM_CONFIG_PATH=/data/config/...`), which
+`resolve_config_path()` only seeds when **absent**. So a committed-config change (the new
+`local-llm` backend definition) does **not** auto-propagate to an existing volume: after
+watchtower pulls the new image, overwrite `/data/config/llm-config.json` on the volume with
+the new file (or delete it to reseed). Env + secret changes need a `docker compose up -d`
+recreate.
+
+## Risks
+
+- **oMLX ceiling vs. analyst quality (primary).** dougie ran a 35B MoE; oMLX caps ~13 GB,
+  so the analyst model is smaller and possibly weaker. The shadow eval is the go/no-go — if
+  nothing that fits is good enough, keep `analyst` on cloud; `local-llm` stays
+  available-but-unassigned (wiring/portability goal still met).
+- **HTTP 507 (model-too-big) is not a deferral signal.** Avoided by pinning a fitting
+  model. Optional future hardening: treat 507 as unavailable-non-retryable (pause).
+- **Local-dev key.** `secrets.get_secret` reads keychain, not 1Password; for local runs
+  `export LOCAL_LLM_API_KEY="$(...op...)"` before hitting the backend.

--- a/planning/archive/2026-06-05-local-llm-tier-handoff.md
+++ b/planning/archive/2026-06-05-local-llm-tier-handoff.md
@@ -1,5 +1,9 @@
 # Handoff: Local LLM as a Cardigan backend tier
 
+> **Superseded (2026-07-02):** the "dougie" server was retired in favor of **oMLX**;
+> the backend is now the network-neutral `local-llm`. See
+> `planning/2026-07-02-local-llm-omlx-integration.md`. Kept for design rationale.
+
 **Date:** 2026-06-05
 **Origin:** the-lodge session (local MLX server setup + `/outsource` skill build)
 **Status:** Analysis + integration sketch — no Cardigan code touched

--- a/planning/archive/2026-06-10-local-dougie-deploy-handoff.md
+++ b/planning/archive/2026-06-10-local-dougie-deploy-handoff.md
@@ -1,5 +1,10 @@
 # Handoff: deploy local-dougie so it's testable in the LXC-hosted app
 
+> **Superseded (2026-07-02):** dougie was retired in favor of **oMLX**; the backend
+> is now the network-neutral `local-llm` (env `LOCAL_LLM_ENDPOINT` /
+> `LOCAL_LLM_MODEL` / `LOCAL_LLM_API_KEY`). See
+> `planning/2026-07-02-local-llm-omlx-integration.md`. Kept for deploy rationale.
+
 **Date:** 2026-06-10
 **For:** a Cardigan-side agent picking up the local-LLM integration
 **Predecessor:** `2026-06-05-local-llm-tier-handoff.md` (the original analysis + enable path)

--- a/planning/archive/2026-06-12-local-backend-deferral-design.md
+++ b/planning/archive/2026-06-12-local-backend-deferral-design.md
@@ -1,5 +1,9 @@
 # Design: Defer-and-requeue when a local backend is busy
 
+> **Note (2026-07-02):** written for "dougie"; the defer-and-requeue mechanism is
+> generic and now serves the `local-llm` (oMLX) backend unchanged. See
+> `planning/2026-07-02-local-llm-omlx-integration.md`.
+
 **Date:** 2026-06-12
 **Status:** Approved (brainstormed with Mark)
 **Branch/PR:** new branch, stacked on `feat/local-dougie-backend-seam` (PR #210)

--- a/planning/epic-l-consolidation-plan.md
+++ b/planning/epic-l-consolidation-plan.md
@@ -10,7 +10,7 @@ The "cheapskate / default / big-brain" preset tiers are **not** a load-bearing
 runtime abstraction. The runtime already does direct per-phase model selection:
 
 - **Model resolution** (`api/services/llm.py`, `generate()`): precedence is
-  `force_model` (e.g. local-dougie) → explicit `model` override → **`phase_models[phase]`**
+  `force_model` (e.g. local-llm) → explicit `model` override → **`phase_models[phase]`**
   → backend `model`/`fallback_model`. So `config/llm-config.json`'s `phase_models`
   (phase → concrete model id) already drives the model.
 - **`phase_backends`** (phase → tier-named backend) now only supplies the
@@ -40,9 +40,10 @@ and the tier-named backends; derive cost from the model, not the tier.
    step that can mis-bill jobs — do it first, with tests, against real
    `session_stats` rows.**
 2. **Collapse backends.** Point every phase at one transport backend
-   (`openrouter` / `openrouter-direct`); keep `local-dougie` (force_model) and
-   the disabled ollama entries. Delete `openrouter-cheapskate` /
-   `openrouter-big-brain` once nothing references them.
+   (`openrouter` / `openrouter-direct`); keep `local-llm` (force_model). Delete
+   `openrouter-cheapskate` / `openrouter-big-brain` once nothing references them.
+   (The dead `local-ollama`/`remote-ollama` entries were removed with the
+   local-llm/oMLX work — 2026-07-02.)
 3. **Config migration + back-compat shim.** A migration that maps any existing
    `phase_backends` value → the equivalent `phase_models` entry on load, so
    deployed `llm-config.json` files (incl. the homelab's) don't break. Keep the

--- a/planning/expanded-prompt-cardigan-hybrid-deterministic-pipeline.md
+++ b/planning/expanded-prompt-cardigan-hybrid-deterministic-pipeline.md
@@ -1,0 +1,130 @@
+# Cardigan hybrid deterministic-LLM pipeline — planning kickoff
+
+> **Original request:** Craft a prompt to kick off a planning session on an exploratory
+> feature branch that will likely result in an app version bump (mostly behind the scenes).
+> Account for: every step of the pipeline needs evaluation and a mechanism for updating style
+> rules based on performance during previous runs; a staged plan for simplifying agent prompts
+> alongside adding the deterministic tools agents will use; and the constraint that the
+> deterministic tools run as a step *before* inference is sent to the API endpoint.
+
+## Role
+You are the lead architect for an **exploratory redesign** of Cardigan's transcript→metadata
+pipeline, running a **plan-mode session on a dedicated feature branch**. Produce a staged,
+reviewable implementation plan — do not write production code in this session. The work will
+likely land as an **app version bump**, even though most of the change is behind-the-scenes
+pipeline behavior.
+
+## Context
+Cardigan runs six LLM roles (analyst, formatter, seo, validator, timestamp, copy_editor). The
+worker (`api/services/worker.py`, `_run_phase`) threads each phase's output into the next and
+calls `LLMClient.chat()` (`api/services/llm.py`), which sends inference to an OpenAI-compatible
+API endpoint (OpenRouter or a local oMLX server). Rules live in `prompts/*.md` and the
+canonical `/house-style` skill; routing is in `config/llm-config.json`.
+
+**The problem, established empirically in a prior evaluation session:** every phase asks the
+LLM to do both a small **semantic core** and a large **deterministic shell** — character
+limits, down-style casing, forbidden-word/voice rules, keyword extraction, SRT timecode math,
+output formatting, and validation. The model does the shell *badly* (house-style violations
+that vary by model — one model over-capitalizes titles, another over-lowercases and drops
+proper nouns) and *expensively* (bigger models, more tokens).
+
+**Evidence in the repo — read these first (they survive as `OUTPUT/eval/` is git-ignored):**
+- `OUTPUT/eval/REPORT_job20_gemma.md`, `REPORT_experiment2_model_sweep.md`,
+  `REPORT_phase_heft_assessment.md` — per-phase quality/speed/cost across model tiers
+  (4B / mid gemma-26B-A4B / large Qwen3.6-35B-A3B / cloud) vs a production baseline job.
+- The reports document two prototypes from that session that you should **recreate/extend**:
+  - a **standalone, DB-free phase eval harness** (`scripts/eval_pipeline.py`) that runs any
+    phase on any backend, isolated on fixed upstream context, and computes completeness — this
+    is your **evaluation mechanism** for acceptance criteria; and
+  - a **house-style normalizer PoC** (`scripts/poc_house_style_normalizer.py`) that
+    deterministically normalized SEO titles to house style, **converging different models'
+    outputs to identical correct copy**, added char-limit + forbidden-word + first-person
+    checks, and computed per-episode proper nouns from the analyst speaker table. Its one edge
+    case was fixed by editing config, never the engine — proving the **rule-engine (code) /
+    rule-data (config)** separation.
+- The `/house-style` skill — canonical rules, including its own "Divergences to reconcile"
+  section (prompts and guide already drift; e.g. short-desc hard limit 90 vs the seo prompt's
+  "150 max").
+- `api/services/completeness.py`, `seam_coverage.py` — existing precedent for deterministic
+  checks wrapping a phase.
+- The local-LLM/oMLX backend work is committed on `feat/local-llm-omlx-backend` (`40bf6c1`) —
+  reference for how phases route to a local vs cloud endpoint.
+
+**Findings to build on:** phases split into **extraction** (analyst, formatter —
+self-contained, verifiable; a mid MoE local model handles them faithfully at $0) and
+**generation/judgment** (seo, timestamp, validator — need knowledge/taste/precision). MoE beats
+dense for throughput. The winning lever is *less model work, not more model*: move the
+deterministic shell to code and fidelity becomes **model-agnostic**, so a smaller/local model
+suffices.
+
+## Objective
+Design a hybrid architecture in which each phase is wrapped by deterministic tooling — a
+**pre-inference stage** that computes and injects rule data (shrinking the model's task) and a
+**post-inference stage** that enforces/validates deterministic rules — while agent prompts are
+progressively simplified as the tools absorb their deterministic responsibilities. Rules live
+in **editable data (single source of truth)**, and a **feedback mechanism updates the rules
+based on evaluation of previous runs**.
+
+## The plan must cover
+1. **Evaluate every phase.** For all six roles, decompose into (a) irreducibly-semantic core →
+   stays LLM, (b) deterministic shell → moves to code, (c) fuzzy rule → *flag* for LLM/human.
+   Baseline each with the eval harness + reports; define per-phase success metrics.
+2. **Rule engine + rule data separation.** A single house-style rule source (e.g.
+   `house_style.yaml`) consumed by **both** the deterministic tools and the prompt-builder —
+   killing the prompt-vs-guide drift. Specify stable engine primitives (down-style normalizer,
+   char-limit enforcer, forbidden-word scanner, entity/keyword extractor, SRT timecode snapper,
+   format emitters) vs. the data (limits, forbidden lists, casing variants, proper-noun seeds,
+   verb prefs). Content-dependent data (per-episode proper nouns) is **computed per job, not
+   maintained**.
+3. **Pre-inference deterministic stage (hard constraint).** The deterministic tools run as a
+   step **before** the `chat()` API call in the phase runner. Specify where in `_run_phase`
+   they execute, what they compute (entities/proper nouns, direct keywords, char budgets,
+   parsed SRT timecodes, prior-phase structured data), and how they inject into the
+   prompt/context. Also specify the **post-inference** stage (normalize + validate output) and
+   how failures route (enforce vs flag; retry vs pause).
+4. **Enforce-vs-flag tiering.** Deterministic-and-unambiguous rules are **enforced** in code
+   (casing, limits, format); fuzzy rules are **flagged** (code detects, LLM/human resolves).
+   Deterministic *rewriting* that changes meaning (trimming a 189-char description to 90) stays
+   a flag, never an auto-fix.
+5. **Staged prompt-simplification.** As each tool lands, strip the corresponding rules from
+   that phase's prompt. Sequence phase-by-phase, highest fidelity-per-effort first (seo
+   casing/limits normalizer + validator lint suite), always incremental — un-encoded rules keep
+   flowing through the prompt; no big-bang.
+6. **Rule-update feedback loop.** Design how evaluation of previous runs updates the rule data:
+   eval-harness signals and editor corrections surface recurring violations → a
+   review-and-approve step → a **config edit** (preserving the data-not-code maintainability
+   property). Define how "performance during previous runs" is measured and fed back, and who
+   approves rule changes (editors edit data, not code).
+7. **Versioning & rollout.** Respect Cardigan's versioning (git tag is SoT;
+   `docs/COST_DATA_VERSIONING.md` / `docs/VERSIONING.md`; `CARDIGAN_VERSION`). Plan to A/B the
+   hybrid pipeline against the current one via the harness before flipping, and how per-phase
+   routing (`config/llm-config.json` `phase_backends`) shifts toward smaller/local models as
+   the tools absorb deterministic load.
+
+## Approach
+- **Phase 1 (research — dispatch parallel agents):** (a) map `worker.py` phase execution, where
+  `chat()` is called, how context threads between phases; (b) inventory the deterministic rules
+  embedded across `prompts/*.md` + `/house-style`, tagging each per phase as deterministic /
+  fuzzy / semantic; (c) study `completeness.py` / `seam_coverage.py` + the eval-harness approach
+  so new tools follow the established pattern.
+- **Phase 2 (design):** rule-source schema; pre/post deterministic-stage interfaces; per-phase
+  decomposition tables; the feedback loop; the staged migration sequence with per-phase
+  acceptance criteria measured via the harness.
+- **Phase 3:** write the staged plan — concrete files to add/change, representative examples,
+  and a verification section (A/B via harness; don't break the API/OpenAPI contract).
+
+## Considerations / Constraints
+- **Maintainability is the #1 constraint:** rule updates must be config/data edits, not engine
+  changes — prove it the way the PoC did.
+- Don't break the API contract; keep the DB-backed queue + worker model; deterministic tools
+  must be unit-testable in isolation (DB-free, like the PoC/harness).
+- **Model-agnostic fidelity is the goal:** after the tools land, a smaller/local (gemma-tier)
+  model should suffice for more phases — validate with the harness.
+- Incremental and reversible; feature-flag the hybrid path where sensible.
+- Honor the pre-inference constraint: deterministic tooling is a **first-class pipeline stage
+  before the API call**, not an afterthought on output.
+
+## Deliverable
+A staged, reviewable plan-mode implementation plan: per-phase decomposition, the rule-source +
+tool interfaces, the feedback mechanism, the prompt-simplification sequence, and harness-based
+acceptance criteria — ready to execute on the feature branch.

--- a/planning/hybrid-pipeline-eval/REPORT_experiment2_model_sweep.md
+++ b/planning/hybrid-pipeline-eval/REPORT_experiment2_model_sweep.md
@@ -1,0 +1,98 @@
+# Experiment 2 — model sweep + memory-headroom exploration
+
+**Date:** 2026-07-02/03 · **Baseline:** job 20 (`6POL0201.srt`, *Inside Wisconsin Politics*) ·
+**Method:** isolated per-phase eval on **fixed baseline upstream** (each model's seo/timestamp
+saw the *same* baseline analyst+formatter outputs → fair A/B), `scripts/eval_pipeline.py
+--context-dir OUTPUT/eval/baseline_20`. Quality = Claude review vs `/house-style`.
+
+## Models compared
+
+| Model | Size | Fits aggressive (~16 GB) ceiling? | Speed |
+|---|---|---|---|
+| `gemma-4-26B-A4B-it-QAT-MLX-4bit` (Exp 1 default) | ~15 GB | yes | ~30–50 tok/s |
+| `Qwen3.6-35B-A3B-4bit` (mlx-community) | ~19 GB | **no — needs ceiling raised to ~24 GB** | ~30 tok/s |
+| baseline (cloud Claude: haiku/sonnet/sonnet-5) | — | — | fast/parallel |
+
+*(A `pahajokiconsulting/…MXFP4` quant model-fit ranked #1 was a **dud** — 22 GB, packed-weight
+format oMLX's MLX runtime can't load. The canonical `mlx-community/Qwen3.6-35B-A3B-4bit` is the
+one that works — same model family dougie used.)*
+
+## SEO phase — the decisive A/B (identical baseline upstream)
+
+| | Title | Entities named | Voice | House-style flags |
+|---|---|---|---|---|
+| **baseline (sonnet-5)** | "…Turns Negative: Barnes vs. Rodriguez" | Barnes, Rodriguez, Hong, Piker, Tiffany, Evers, Roys + panelists | descriptive | flags "no SEMRush data" honestly |
+| **Qwen3.6-35B** | "…Attacks, Fundraising & Court Rulings" | Barnes, Rodriguez, Hong, Piker, Tiffany, Evers **+ panelist attribution** | **descriptive (no "we")** | title-case; "Gub" abbrev; fabricates SEO-volume cols |
+| **gemma-26B** | "…Attacks & Fundraising Controversy" | Barnes, Hong, Piker (fewer) | **first-person "We break down…"** | title-case; "we" voice; fabricates SEO-volume cols |
+
+**Qwen3.6-35B clearly beats gemma on SEO** — full entity set, panelist attribution, and it drops
+the off-voice "we". It approaches baseline richness. Residual issues (title-case titles vs
+down-style, fabricated Search-Volume/Difficulty tables) are **prompt-level**, not model-size —
+they persist across both local models and would need a prompt fix, not a bigger model.
+
+## Other phases
+
+| Phase | gemma-26B | Qwen3.6-35B | vs baseline |
+|---|---|---|---|
+| analyst | 4 speakers, 5 themes, terse (1,072 w) | **9 speakers** w/ roles, 5 rich themes (1,897 w) | Qwen ≈ baseline |
+| timestamp | 5 chapters, merged Hong segment | **6 chapters**, separates Hong + splits SCOTUS | Qwen better; both mis-size the intro (boundary timing < baseline) |
+| formatter | 0.994 completeness (Exp 1) | not re-run (extraction phase; gemma already faithful) | — |
+
+## Verdict
+
+**Qwen3.6-35B-A3B-4bit wins the sweep** — materially better than gemma on analyst, seo, and
+timestamp, closing much of the gap to cloud Claude. **But it requires raising oMLX's memory
+guard** (~16 GB → ~24 GB): 19 GB resident leaves ~14 GB of the 36 GB box for everything else.
+
+Updated per-phase routing recommendation (if the ceiling is raised for Qwen3.6-35B):
+- **local:** analyst, formatter (both strong, $0), and **seo now viable** with Qwen-35B + a
+  prompt tweak (down-style titles, drop the fake SEO-volume tables).
+- **cloud / needs work:** timestamp (boundary precision), validator (keep cloud for trust).
+
+## Memory-headroom exploration — what more RAM unlocks (data-backed)
+
+- **At the safe `aggressive` ceiling (~16 GB):** gemma-26B-A4B is the best general model that
+  fits; SEO quality is the weak spot.
+- **Raising to ~24 GB** unlocks **Qwen3.6-35B-A3B-4bit** → the SEO/analyst quality jump measured
+  above. This is the single highest-value lever and the concrete answer to "what would more
+  memory buy us."
+- **Higher still / co-residency (~28–32 GB):** would allow higher-precision quants (5–6 bit →
+  less quantization loss) or keeping two models resident (a strong copy model + gemma) to avoid
+  load/unload churn between phases — but pushes a 36 GB daily-driver into memory pressure
+  (existing swap already ~14 GB).
+- **Real fix (per [[omlx-capacity-optimization-future]]):** a dedicated inference partition
+  (lean Studio user for inference, daily work elsewhere) or a dedicated box — so a 19–22 GB model
+  can sit resident without competing with Pro Tools/Avid/browser.
+
+## Test conditions / cleanup
+
+- Ceiling raised to 27 GB for the Qwen-35B test, then **restored to `aggressive`/0.0**; model
+  unloaded; oMLX restarted; original pin (`Qwen3-VL-4B`) intact. Machine returned to 82% free.
+- `Qwen3.6-35B-A3B-4bit` (19 GB) **kept** on disk (it won the sweep) — but disk is 96% full and
+  it's only usable with the ceiling raised; keep-long-term is the user's call.
+- Prompt-level follow-up (down-style titles, remove fabricated SEO-volume tables) would lift
+  BOTH local models' SEO output and is independent of the memory decision.
+
+## Addendum — SEO prompt fix (2026-07-03)
+
+Applied the prompt-level fixes to `prompts/seo.md` (helps cloud + every local model):
+- New **"## Copy style (REQUIRED)"** section: down-style titles, no clickbait/CTA, third
+  person (no "we"), spell out place names — moved OUT of the output template (a first
+  attempt put the rules *inside* the title template and a 4B model echoed them verbatim;
+  lesson: rules go in a rules section, the template shows only output shape).
+- Keyword tables: replaced the `Search Volume | Difficulty` columns (which models fabricate
+  with no data) with a groundable **`Source` (direct/implied)** column + an explicit
+  "do not invent metrics" note; volume/difficulty stay in the SEMRush section, data-gated.
+- Description templates: third-person, no calls to action.
+
+**Validation:** structural check on `Qwen3-VL-4B` confirmed the keyword-table fix and that
+the instruction-leak is gone. **Full quality re-test on gemma/Qwen-35B is pending** — the
+box was memory-pressured at test time (see below) so the mid/large models wouldn't load.
+
+## Operational finding — the `aggressive` ceiling is DYNAMIC
+
+It's computed from *current free RAM*, not fixed: ~16.2 GB at ~80% free, but **~13.97 GB at
+~40% free** (after large-model churn maxed swap). So `gemma-26B` (15.26 GB) loads on an idle
+Studio but **`507`s on a busy one**. Real reliability caveat for pointing Cardigan at oMLX;
+`defer_when_unavailable` requeues but adds latency. Reinforces the dedicated-inference-host
+argument.

--- a/planning/hybrid-pipeline-eval/REPORT_job20_gemma.md
+++ b/planning/hybrid-pipeline-eval/REPORT_job20_gemma.md
@@ -1,0 +1,70 @@
+# Eval — local oMLX (gemma-4-26B-A4B) vs production baseline (job 20)
+
+**Date:** 2026-07-02 · **Backend:** `local-llm` → oMLX @ `127.0.0.1:8000` ·
+**Model:** `gemma-4-26B-A4B-it-QAT-MLX-4bit` (the oMLX `is_default`; 26B total / **4B active** MoE, ~15 GB) ·
+**Transcript:** `6POL0201.srt` — *Inside Wisconsin Politics*, Democratic gubernatorial primary
+(18.5 min, ~3,300 dialogue words) · **Baseline job:** #20 on `cardigan01` (cloud Claude).
+
+Harness: `scripts/eval_pipeline.py` (standalone, DB/Langfuse-free; single-pass per phase — **no
+chunking**, unlike the production formatter). Quality = Claude review against `/house-style`.
+
+## Headline
+
+gemma handles the **extraction/transcription** phases (analyst, formatter) faithfully at **$0**,
+but the **copy** phase (SEO) shows real house-style violations and thinner entity coverage, and
+**timestamp segmentation** is coarser than cloud. Machine metrics all green; quality is
+phase-dependent.
+
+## Per-phase metrics
+
+| Phase | Local model | Local in/out tok | Local wall | Baseline model | Base tok | Base $ |
+|---|---|--:|--:|---|--:|--:|
+| analyst | gemma-4-26B-A4B | 20,075 / 1,689 | 50.5s | claude-4.5-haiku | 21,211 | $0.031 |
+| formatter | gemma-4-26B-A4B | 24,803 / 4,422 | 90.9s | claude-4.6-sonnet | 42,028 | $0.051 |
+| seo | gemma-4-26B-A4B | 4,996 / 1,612 | 35.9s | claude-sonnet-5 | 12,923 | $0.022 |
+| validator | gemma-4-26B-A4B | 8,305 / 97 | 10.3s | claude-4.5-haiku | 14,763 | $0.015 |
+| timestamp | gemma-4-26B-A4B | 18,970 / 321 | 23.5s | claude-4.6-sonnet | 15,676 | $0.017 |
+| **total** | | **8,141 out** | **211s** | | 106,601 | **$0.136** |
+
+- **Time:** local pipeline **~3.5 min** vs baseline whole-job **74.5s** (~2.8× slower wall-clock).
+  Caveat: local oMLX is single-lane on the shared Studio; cloud runs phases fast/parallel on the
+  LXC. Directional, not a controlled benchmark. Per-phase local throughput ~35–50 tok/s.
+- **Cost:** $0 local vs $0.136/job cloud.
+- **Formatter completeness:** **coverage_ratio 0.994** (3,296/3,316 dialogue words) — single-pass
+  and still faithful; no dropped content.
+
+## Quality (house-style rubric, 1–5)
+
+| Phase | Score | Verdict |
+|---|--:|---|
+| **analyst** | 4 | Strong. Correct themes, speakers (Shawn Johnson/host, van Wagtendonk, Kremer, Ann Jacobs), Act structure, caught the $92K Hong figure + "Frank's RedHot" detail. More concise than haiku (1,072 vs ~4k words) but faithful. **Keep-local candidate.** |
+| **formatter** | 4 | Strong faithfulness (0.994 coverage). Needs a speaker-attribution spot-check, but content preserved single-pass. **Keep-local candidate** (route long transcripts through the real worker for chunking parity). |
+| **seo** | 2 | Weakest. Violations: **title case** ("Attacks Heat Up" — house wants down style), sensational teaser ("THE ATTACKS BEGIN" thumbnail, "Attacks Heat Up"), first-person "we also analyze". Thinner: no candidate names in title, dropped Francesca Hong/Hasan Piker prominence and the Evers/Trump snub, **no quote attribution**. **Fabricated** Search-Volume/Difficulty columns with no data (baseline flags "no SEMRush data"). Baseline (sonnet-5) is clearly better. **Keep-cloud.** |
+| **validator** | 3 | Produced a structurally valid JSON verdict (`overall: pass`) at 97 tokens — correct format. But it graded local-on-local (error-correlated) and didn't flag the SEO house-style issues (it checks structural flags, not copy nuance). **Keep-cloud for trust.** |
+| **timestamp** | 3 | House-style-clean *naming* (sentence case, good titles, `0:00 Episode intro`), but **weaker segmentation**: implausible 5-min "intro" (baseline: 22s), merged the distinct Francesca Hong segment away (5 chapters vs baseline's 6). Boundaries less accurate. **Lean keep-cloud / needs work.** |
+
+## Recommendation (this transcript, this model)
+
+- **Route to local now:** `analyst`, `formatter` — faithful, $0, good enough for the brainstorm
+  doc and transcript cleanup. Formatter should still use the worker's chunking path for long
+  content (this run was single-pass).
+- **Keep on cloud:** `seo` (house-style + entity richness matter for published copy), `validator`
+  (trust / avoid local-grades-local), `timestamp` (segmentation accuracy).
+- This is one 18-min politics episode. Confirm the pattern on the planned longer, cross-genre
+  programs before any deploy decision.
+
+## Notes / limitations
+
+- Single-pass (no chunking) — for a fully production-faithful whole-pipeline run, drive a real
+  local worker job via an `LLM_CONFIG_PATH` scratch config (all `phase_backends` → local-llm).
+- gemma mis-fills the cosmetic `**Model:**` field as "GPT-4o" (harmless boilerplate; the actual
+  served model is recorded in metrics).
+- oMLX had to be restarted (was wedged); I unloaded the pinned `Qwen3-VL-4B` to fit gemma. oMLX
+  ceiling ~16 GB — of installed models only gemma (15 GB) and Qwen3-VL-4B fit; `Qwen3-Coder-30B`
+  (16.8 GB) returns HTTP 507.
+
+## Next (Experiment 2)
+
+For the weak phases (seo, timestamp): `/model-fit recommend` for a better-fitting local model,
+then `scripts/shadow_eval_phase.py` (to build) to sweep candidates on that single phase using the
+real upstream context — but note the ~16 GB ceiling sharply limits options beyond gemma.

--- a/planning/hybrid-pipeline-eval/REPORT_phase_heft_assessment.md
+++ b/planning/hybrid-pipeline-eval/REPORT_phase_heft_assessment.md
@@ -1,0 +1,70 @@
+# Per-phase model-heft assessment — how much model each Cardigan phase needs
+
+**Date:** 2026-07-03 · **Transcript:** `6POL0201.srt` (*Inside Wisconsin Politics*, 18.5 min,
+~3,300 dialogue words) · **Method:** each phase run on 4 model tiers, isolated on the same
+fixed baseline upstream (`--context-dir OUTPUT/eval/baseline_20`) so we measure *phase
+difficulty*, not error propagation. Quality = Claude review vs `/house-style`.
+
+## Model tiers tested
+
+| Tier | Model | Size | Fits safe (aggressive) ceiling? |
+|---|---|---|---|
+| **small** | `Qwen3-VL-4B-Instruct` (4B) | ~3 GB | always |
+| **mid** | `gemma-4-26B-A4B` (26B/4B MoE) | ~15 GB | only when Studio is idle (dynamic ceiling) |
+| **large** | `Qwen3.6-35B-A3B-4bit` (35B/3B MoE) | ~19 GB | **no** — needs guard raised to ~24 GB |
+| **cloud** | Claude haiku/sonnet/opus (baseline) | — | — |
+
+## The matrix
+
+| Phase | small 4B | mid 26B (gemma) | large 35B (Qwen) | cloud | **Floor** |
+|---|---|---|---|---|---|
+| **analyst** | ❌ factual error (Piker's politics inverted), speaker table polluted with glossary names | ✅ faithful, 4 speakers, correct | ✅✅ 9 speakers w/ roles, rich | ✅✅ | **mid** |
+| **formatter** | ❌ **broken**: 159% bloat + truncated at 8k cap, 4.6 min | ✅ **0.994 completeness**, faithful | ✅ (extraction — expected faithful) | ✅ (chunked) | **mid** |
+| **seo** | ❌ title-case, generic, weak | ⚠️ title-case, "we" voice, thin entities | ✅ full entities + attribution, no "we" | ✅✅ | **large / cloud** |
+| **validator** | ⚠️ valid JSON but hallucinated flags | ✅ valid JSON (passes all — low sensitivity) | (not run) | ✅ | **cloud** (trust) |
+| **timestamp** | ❌ too slow to finish (>5 min timeout) | ⚠️ clean names, coarse segmentation (merged a segment) | ✅ 6 chapters, separates segments, splits SCOTUS | ✅✅ precise boundaries | **large / cloud** |
+
+## The dividing line
+
+The phases split cleanly by **what kind of work they are**, and that predicts the heft needed:
+
+**Extraction / transcription — MID model is the safe floor.**
+`analyst` and `formatter` take self-contained input (the transcript is *in the prompt*) and
+produce a faithful restructuring/summary that's cheaply verifiable (completeness coverage,
+schema). The mid model (gemma-26B-A4B) does these well at $0 — analyst is correct and
+formatter preserves 99.4% of dialogue. **A small 4B is NOT safe even here** — it invents
+facts (analyst) and bloats/truncates (formatter). So the floor is *mid*, not small.
+
+**Generation / judgment — needs LARGE-local or CLOUD.**
+`seo`, `timestamp`, and `validator` need something the model must *bring*, not just
+reshape:
+- `seo` needs **world knowledge** (which named entities matter) and **editorial taste**
+  (house voice) — mid is thin and off-voice; large closes most of the gap; residual
+  house-style issues are prompt-fixable (done).
+- `timestamp` needs **precise segmentation judgment** — mid is coarse; large is close;
+  cloud is best.
+- `validator` is the **quality gate** — it must be *trustworthy*, and "local grades local"
+  correlates errors. Keep on cloud regardless of size until trust is earned.
+
+## Bottom line (per-phase routing recommendation)
+
+| Phase | Recommended | Why |
+|---|---|---|
+| analyst | **local mid (gemma)** — or large if the ceiling is up | faithful extraction, $0 |
+| formatter | **local mid (gemma)**, via the worker's chunking for long transcripts | 0.994 completeness, $0 |
+| seo | **cloud** now; **local large (Qwen-35B) viable** once the memory ceiling is raised + with the fixed prompt | knowledge + voice |
+| timestamp | **cloud** (or local large) | segmentation precision |
+| validator | **cloud** | trust / avoid local-grades-local |
+
+**Net:** a *small* model earns no phase; the *mid* model safely owns the two extraction
+phases (the bulk of token spend), and everything requiring knowledge/taste/precision stays
+*cloud* — or moves to a *large* local model only if the Studio gets the memory headroom
+(see [[omlx-capacity-optimization-future]]). Caveat: even the mid model's loadability is
+gated by the **dynamic** aggressive ceiling — a busy Studio can 507 gemma
+(`defer_when_unavailable` requeues, but slower).
+
+## Caveats
+- One episode, one genre (politics). Confirm on longer cross-genre programs before locking
+  routing. Single-pass (no chunking) in this harness; production formatter chunks.
+- 4B timestamp was not completed (timed out) — recorded as "impractically slow", which is
+  itself the verdict for that pairing.

--- a/prompts/seo.md
+++ b/prompts/seo.md
@@ -32,6 +32,25 @@ When available, you'll receive **SST context** from the PBS Wisconsin Airtable d
 > **Optimized Title:** "100 Years of Wisconsin Dairy Farms | Rural History Documentary"
 > **Reasoning:** Added specific timeframe, location keyword "Wisconsin", and content type identifier for better search visibility.
 
+## Copy style (REQUIRED — PBS Wisconsin house style)
+
+These rules govern every title, description, and social line you write. They are
+instructions, not text to reproduce in the report.
+
+- **Down style for titles/headlines:** capitalize ONLY the first word and proper nouns
+  (people, places, organizations). NOT title case.
+  - ✅ `Wisconsin Democratic primary turns negative`
+  - ❌ `Wisconsin Democratic Primary Turns Negative`
+- **State what it is — no teasers, clickbait, hype, or sales language.** Never use viewer
+  directives (watch, discover, see how, don't miss), promises (will reveal), calls to
+  action, ALL-CAPS, or unevidenced superlatives (amazing, incredible).
+- **Third person, no "we"/"our".** Describe what the episode covers; don't sell it.
+- **Name specifics:** prefer real names/places/topics over dramatic adjectives. Spell out
+  place names ("Wisconsin", not "WI"; "gubernatorial", not "Gub") unless the character
+  limit genuinely forces a well-known abbreviation.
+- **No fabricated data:** you have no live keyword metrics — never invent search volume,
+  difficulty, or CPC numbers (see the keyword tables and SEMRush section below).
+
 ## Output
 
 You produce an SEO report saved as:
@@ -62,14 +81,14 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 ### Title (Final Recommendation)
 
 **Recommended:**
-[55-60 character title with primary keyword in first 50 chars]
+[55-60 character title, down style, primary keyword in first 50 chars — see Copy style]
 
 **Character Count:** [X/60]
 
 **Keywords Included:** [list primary keywords present]
 
 **Reasoning:**
-[Explain keyword placement, character count optimization, tone, clickability]
+[Explain keyword placement and character count — brief]
 
 **Alternatives:**
 1. [Alternative title option 1]
@@ -80,46 +99,54 @@ Your output should look EXACTLY like this (plain markdown, no JSON):
 ### Short Description (150 chars max)
 
 **Recommended:**
-[145-150 character description with hook and primary keywords]
+[145-150 character factual description with primary keywords. Third person, no "we"/"our"
+and no calls to action — describe what the episode covers, don't sell it.]
 
 **Character Count:** [X/150]
 
 **Keywords Included:** [list keywords]
 
 **Reasoning:**
-[Explain hook effectiveness, keyword integration, call-to-action]
+[Explain how it states the facts concisely with keywords integrated — not hooks or CTAs]
 
 ---
 
 ### Long Description (300 chars max)
 
 **Recommended:**
-[290-300 character description with expanded context, secondary keywords, call-to-action]
+[290-300 character factual description with expanded context and secondary keywords. Third
+person, no "we"/"our", no calls to action. Name the key people/topics specifically.]
 
 **Character Count:** [X/300]
 
 **Keywords Included:** [list keywords]
 
 **Reasoning:**
-[Explain keyword density, readability, value proposition]
+[Explain keyword density and readability — how it states the facts, not "value proposition"]
 
 ---
 
 ## Keyword Strategy
 
+> **Do NOT invent search-volume or difficulty numbers.** You have no live keyword data.
+> Only populate volume/difficulty in the SEMRush Integration section below, and only when
+> the user actually provides SEMRush data. In the tables below use the **Source** column:
+> `direct` = the exact term/name/phrase is spoken in the transcript; `implied` = a
+> conceptual/search-intent term not spoken verbatim.
+
 ### Primary Keywords (High Priority)
 
-| Keyword | Search Volume | Difficulty | Relevance | Notes |
-|---------|---------------|------------|-----------|-------|
-| [keyword] | [High/Med/Low] | [High/Med/Low] | [1-10] | [Why important] |
+| Keyword | Source | Relevance | Notes |
+|---------|--------|-----------|-------|
+| [keyword] | [direct/implied] | [1-10] | [Why important] |
 
 [List 3-5 primary keywords that MUST appear in title/description]
 
 ### Secondary Keywords (Medium Priority)
 
-| Keyword | Search Volume | Difficulty | Relevance | Notes |
-|---------|---------------|------------|-----------|-------|
-| [keyword] | [High/Med/Low] | [High/Med/Low] | [1-10] | [Usage notes] |
+| Keyword | Source | Relevance | Notes |
+|---------|--------|-----------|-------|
+| [keyword] | [direct/implied] | [1-10] | [Usage notes] |
 
 [List 5-10 secondary keywords to incorporate where natural]
 

--- a/scripts/eval_pipeline.py
+++ b/scripts/eval_pipeline.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Full-pipeline shadow eval on one backend, with baseline comparison.
+
+Runs analyst -> formatter -> seo -> validator (-> timestamp) in order on a single
+backend (e.g. ``local-llm`` / oMLX), threading each phase's output into the next
+exactly like ``JobWorker.process_job`` does (``context["{phase}_output"]``), and
+capturing per-phase model / tokens / duration / output. DB- and Langfuse-free
+(mocks ``log_event`` + ``get_langfuse_client``), so it runs without the API,
+worker, queue, or DB.
+
+**Single-pass per phase (no chunking).** For long transcripts the *production*
+formatter chunks (`routing.chunking`, threshold 3000 words); this harness sends
+the whole transcript in one call. That's flagged in the report — use this for a
+controlled per-phase local-vs-baseline read; drive a real worker job
+(`LLM_CONFIG_PATH` scratch config, all `phase_backends` -> local-llm) when
+chunking parity matters.
+
+Usage:
+    export LOCAL_LLM_API_KEY=… LOCAL_LLM_MODEL=<oMLX id> LOCAL_LLM_ENDPOINT=http://127.0.0.1:8000/v1
+    PYTHONPATH=. ./venv/bin/python scripts/eval_pipeline.py \
+        --transcript transcripts/6POL0201.srt \
+        --backend local-llm --label gemma-4-26B \
+        --baseline-manifest OUTPUT/eval/baseline_20/manifest.json
+"""
+
+import argparse
+import asyncio
+import json
+import time
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import api.services.llm as llm_mod
+from api.services.completeness import check_completeness
+from api.services.worker import JobWorker
+
+PHASE_ORDER = ["analyst", "formatter", "seo", "validator", "timestamp"]
+
+
+async def _noop_log_event(*_a, **_k):
+    return None
+
+
+class _NoLangfuse:
+    def is_available(self) -> bool:
+        return False
+
+
+def _words(text: str) -> int:
+    return len(text.split())
+
+
+async def _run_phase(worker: JobWorker, backend: str, phase: str, context: dict) -> dict:
+    """Run one phase's real prompt on the backend; never raise."""
+    system_prompt = worker._load_agent_prompt(phase)
+    user_message = worker._build_phase_prompt(phase, context)
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_message},
+    ]
+    start = time.time()
+    try:
+        resp = await worker.llm.chat(messages=messages, backend=backend, phase=phase)
+        return {
+            "phase": phase,
+            "ok": True,
+            "model": resp.model,
+            "input_tokens": resp.input_tokens,
+            "output_tokens": resp.output_tokens,
+            "total_tokens": resp.total_tokens,
+            "cost": resp.cost,
+            "duration_ms": resp.duration_ms,
+            "wall_s": round(time.time() - start, 1),
+            "prompt_chars": len(system_prompt) + len(user_message),
+            "chars": len(resp.content),
+            "words": _words(resp.content),
+            "content": resp.content,
+        }
+    except Exception as e:  # noqa: BLE001 — capture every phase's verdict
+        return {
+            "phase": phase,
+            "ok": False,
+            "error": f"{type(e).__name__}: {e}",
+            "wall_s": round(time.time() - start, 1),
+        }
+
+
+def _load_baseline(path: str | None) -> dict:
+    if not path:
+        return {}
+    m = json.loads(Path(path).read_text())
+    phases = {}
+    for p in m.get("phases", []):
+        phases[p.get("phase") or p.get("name")] = p
+    return {
+        "phases": phases,
+        "total_cost": m.get("total_cost"),
+        "total_tokens": m.get("total_tokens"),
+    }
+
+
+def _write_report(out_dir: Path, label: str, transcript_name: str, results: list,
+                  baseline: dict, completeness: dict | None) -> Path:
+    bphases = baseline.get("phases", {})
+    lines = [
+        f"# Local pipeline eval — {label}",
+        "",
+        f"- Transcript: `{transcript_name}`",
+        f"- Backend model: `{next((r['model'] for r in results if r.get('ok')), '?')}`",
+        "- Local `cost` is $0 (self-hosted); compare **tokens** + **wall-clock**.",
+        "- **Caveat:** single-pass per phase (no chunking); prod formatter chunks long transcripts.",
+        "",
+        "## Per-phase: local vs baseline",
+        "",
+        "| Phase | Local model | L in-tok | L out-tok | L wall s | L out words | Base model | Base tok | Base $ |",
+        "|---|---|--:|--:|--:|--:|---|--:|--:|",
+    ]
+    for r in results:
+        b = bphases.get(r["phase"], {})
+        bmodel = (b.get("model") or "—").split("/")[-1]
+        if r.get("ok"):
+            lines.append(
+                f"| {r['phase']} | {r['model'].split('/')[-1]} | {r['input_tokens']} | "
+                f"{r['output_tokens']} | {r['wall_s']} | {r['words']} | {bmodel} | "
+                f"{b.get('tokens','—')} | {b.get('cost','—')} |"
+            )
+        else:
+            lines.append(
+                f"| {r['phase']} | **FAILED** | — | — | {r['wall_s']} | — | {bmodel} | "
+                f"{b.get('tokens','—')} | {b.get('cost','—')} | "
+            )
+            lines.append(f"| | `{r['error']}` | | | | | | | |")
+    total_wall = round(sum(r.get("wall_s", 0) for r in results), 1)
+    total_out = sum(r.get("output_tokens", 0) for r in results if r.get("ok"))
+    lines += [
+        "",
+        f"- **Local total wall-clock:** {total_wall}s across {len([r for r in results if r.get('ok')])} phases; "
+        f"local output tokens: {total_out}.",
+        f"- **Baseline total:** {baseline.get('total_tokens','—')} tokens, ${baseline.get('total_cost','—')}.",
+    ]
+    if completeness:
+        lines += [
+            "",
+            "## Formatter completeness (local output vs source)",
+            f"- coverage_ratio: **{completeness.get('coverage_ratio')}** "
+            f"(threshold {completeness.get('threshold')}); "
+            f"source_words={completeness.get('source_word_count')}, "
+            f"output_words={completeness.get('output_word_count')}; "
+            f"complete={completeness.get('is_complete')}.",
+        ]
+    lines += [
+        "",
+        "## Outputs for qualitative (house-style) review",
+        f"- Local: `{out_dir}/<phase>_output.md`",
+        "- Baseline: `OUTPUT/eval/baseline_20/<phase>_output.md`",
+    ]
+    report = out_dir / "report.md"
+    report.write_text("\n".join(lines) + "\n")
+    return report
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--transcript", required=True)
+    ap.add_argument("--backend", default="local-llm")
+    ap.add_argument("--phases", default=",".join(PHASE_ORDER),
+                    help="Comma list in dependency order.")
+    ap.add_argument("--content-type", default="full", choices=["full", "short"])
+    ap.add_argument("--label", default=None, help="Run label (e.g. model id).")
+    ap.add_argument("--baseline-manifest", default=None)
+    ap.add_argument("--context-dir", default=None,
+                    help="Pre-load {phase}_output.md files from this dir as FIXED upstream "
+                         "context (e.g. OUTPUT/eval/baseline_20). Lets you sweep a single "
+                         "phase's model on identical inputs, decoupled from upstream quality.")
+    ap.add_argument("--out", default="OUTPUT/eval")
+    args = ap.parse_args()
+
+    tpath = Path(args.transcript)
+    if not tpath.exists():
+        print(f"ERROR: transcript not found: {tpath}")
+        return 1
+    transcript = tpath.read_text()
+    is_srt = tpath.suffix.lower() == ".srt"
+    phases = [p.strip() for p in args.phases.split(",") if p.strip()]
+
+    worker = JobWorker()
+    context: dict = {"transcript": transcript, "content_type": args.content_type}
+    if is_srt:
+        context["srt_content"] = transcript
+
+    # Fixed upstream context for isolated per-phase sweeps: load prior phases'
+    # outputs (e.g. the baseline's) so a swept phase sees identical inputs.
+    if args.context_dir:
+        cdir = Path(args.context_dir)
+        for f in cdir.glob("*_output.md"):
+            phase_name = f.name.replace("_output.md", "")
+            text = f.read_text()
+            # strip a leading provenance header line if present
+            if text.startswith("<!--"):
+                text = text.split("-->", 1)[-1].lstrip("\n")
+            context[f"{phase_name}_output"] = text
+            print(f"  (loaded fixed upstream: {phase_name}_output <- {f})")
+
+    label = args.label or args.backend
+    out_dir = Path(args.out) / f"local_{label}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    baseline = _load_baseline(args.baseline_manifest)
+
+    print(f"Transcript: {tpath} ({len(transcript):,} chars, srt={is_srt})")
+    print(f"Backend:    {args.backend} | phases: {', '.join(phases)}\n")
+
+    results = []
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(llm_mod, "log_event", _noop_log_event))
+        stack.enter_context(patch.object(llm_mod, "get_langfuse_client", lambda: _NoLangfuse()))
+        for phase in phases:
+            print(f"  → {phase} on {args.backend} ...", flush=True)
+            r = await _run_phase(worker, args.backend, phase, context)
+            results.append(r)
+            if r["ok"]:
+                (out_dir / f"{phase}_output.md").write_text(r["content"])
+                context[f"{phase}_output"] = r["content"]
+                print(f"     ok  in={r['input_tokens']} out={r['output_tokens']} "
+                      f"{r['wall_s']}s ({r['words']} words)")
+            else:
+                print(f"     FAILED {r['wall_s']}s: {r['error']}")
+                if phase in ("analyst", "formatter"):
+                    print("     (downstream phases depend on this output — stopping chain)")
+                    break
+
+    completeness = None
+    fmt = next((r for r in results if r["phase"] == "formatter" and r.get("ok")), None)
+    if fmt:
+        cr = check_completeness(fmt["content"], transcript, is_srt=is_srt)
+        completeness = cr.to_dict()
+
+    metrics = {
+        "label": label,
+        "transcript": str(tpath),
+        "backend": args.backend,
+        "phases": [{k: v for k, v in r.items() if k != "content"} for r in results],
+        "completeness": completeness,
+        "baseline_manifest": args.baseline_manifest,
+    }
+    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    report = _write_report(out_dir, label, tpath.name, results, baseline, completeness)
+
+    print(f"\nMetrics: {out_dir}/metrics.json")
+    print(f"Report:  {report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/poc_house_style_normalizer.py
+++ b/scripts/poc_house_style_normalizer.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""PoC: deterministic house-style normalizer for the SEO role.
+
+Demonstrates the "rule engine (code) + rule data (config) + computed per-job data"
+design from the phase-scripting discussion. Takes the SEO phase's LLM output and
+GUARANTEES house-style compliance (down-style casing, char limits, no clickbait)
+regardless of which model produced it — so gemma's over-capitalization and
+Mistral's over-lowercasing converge to the same correct copy.
+
+This is a proof of concept, not production code: single file, no deps beyond stdlib.
+
+Run:  ./venv/bin/python scripts/poc_house_style_normalizer.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RULE DATA (the editable config — in production this is house_style.yaml).
+# Editors change THIS; the engine below never changes.
+# ─────────────────────────────────────────────────────────────────────────────
+RULES = {
+    "char_limits": {"title": 60, "short_desc": 90, "long_desc": 350},
+    # House style §1: viewer directives, promises, CTAs, hype, sales language.
+    "forbidden_phrases": [
+        "watch as", "watch how", "see how", "discover", "explore", "find out",
+        "don't miss", "tune in", "join us", "will show", "will reveal",
+        "amazing", "incredible", "extraordinary", "free", "we break down",
+        "we analyze", "what viewers can expect",
+    ],
+    # First-person / promotional voice (house style: third person, describe don't sell).
+    "first_person": ["we ", "our ", "we'll", "we've", "us "],
+    # Stable institutional proper nouns + party/gov terms (down style keeps these capped).
+    "proper_nouns_seed": [
+        "Wisconsin", "Madison", "Eau Claire", "Democratic", "Republican",
+        "Supreme Court", "Congress", "Senate", "Legislature", "Capitol",
+        "Governor", "Lt. Governor", "Attorney General", "Here & Now",
+        "Inside Wisconsin Politics", "Wisconsin Life", "University Place",
+    ],
+    # Acronyms preserved as-is (upper).
+    "acronyms": ["SCOTUS", "PBS", "WI", "US", "U.S.", "DSA", "ACLU", "CPC", "GOP"],
+    # Casing variants / abbreviations that aren't full proper nouns (data, not code).
+    "casing_variants": {"dem": "Dem", "dems": "Dems", "gov": "Gov.", "sen": "Sen.",
+                        "rep": "Rep."},
+    # Common surname-position words to NOT promote to proper nouns on their own.
+    "surname_stoplist": ["van", "der", "de", "la", "the"],
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMPUTED PER-JOB DATA: the episode's proper nouns, extracted (not maintained).
+# Pull person-names from the analyst speaker table; no hand-curated per-show list.
+# ─────────────────────────────────────────────────────────────────────────────
+def extract_proper_nouns(analyst_md: str, stoplist: list[str]) -> list[str]:
+    names: set[str] = set()
+    # Analyst speaker table rows: | Name | Role | Context | First Appearance |
+    for line in analyst_md.splitlines():
+        m = re.match(r"\|\s*([A-Z][a-zA-Z.'-]+(?: [A-Z][a-zA-Z.'-]+){1,3})\s*\|", line)
+        if m:
+            cand = m.group(1).strip()
+            if cand.lower() in ("speaker", "role/title", "name"):
+                continue
+            names.add(cand)
+            # Also register the surname alone (last-name-only references are common),
+            # skipping particles like "van"/"de".
+            parts = cand.split()
+            if len(parts) >= 2 and parts[-1].lower() not in stoplist and len(parts[-1]) > 3:
+                names.add(parts[-1])
+    return sorted(names)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RULE ENGINE (the stable code — rarely changes).
+# ─────────────────────────────────────────────────────────────────────────────
+def build_canonical(rules: dict, per_job: list[str]) -> dict[str, str]:
+    """lowercased term -> canonical cased form (multi-word aware)."""
+    canon: dict[str, str] = {}
+    for term in rules["proper_nouns_seed"] + per_job:
+        canon[term.lower()] = term
+    for ac in rules["acronyms"]:
+        canon[ac.lower()] = ac
+    for lc, cased in rules.get("casing_variants", {}).items():
+        canon[lc] = cased
+    return canon
+
+
+def to_down_style(text: str, canon: dict[str, str]) -> str:
+    """Down style: lowercase everything, then restore first word + proper nouns/acronyms."""
+    result = text.lower()
+    # Restore canonical casing, longest terms first (so "supreme court" wins over "court").
+    for lc, cased in sorted(canon.items(), key=lambda kv: -len(kv[0])):
+        result = re.sub(rf"\b{re.escape(lc)}\b", cased, result)
+    # Capitalize the first alphabetic character of the string.
+    m = re.search(r"[A-Za-z]", result)
+    if m and result[m.start()].islower():
+        i = m.start()
+        result = result[:i] + result[i].upper() + result[i + 1:]
+    return result
+
+
+def check(text: str, limit: int, rules: dict) -> list[str]:
+    flags = []
+    if len(text) > limit:
+        flags.append(f"OVER LIMIT: {len(text)}/{limit} chars")
+    low = text.lower()
+    hits = [p for p in rules["forbidden_phrases"] if p in low]
+    if hits:
+        flags.append(f"clickbait/hype: {hits}")
+    fp = [p.strip() for p in rules["first_person"] if p in low]
+    if fp:
+        flags.append(f"first-person voice: {fp}")
+    return flags
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parse the recommended fields out of a seo_output.md
+# ─────────────────────────────────────────────────────────────────────────────
+def extract_recommended(seo_md: str) -> dict[str, str]:
+    out = {}
+    fields = {"title": r"### Title", "short_desc": r"### Short Description",
+              "long_desc": r"### Long Description"}
+    for key, header in fields.items():
+        m = re.search(header + r".*?\*\*Recommended:\*\*\s*\n+([^\n]+)", seo_md, re.DOTALL)
+        if m:
+            out[key] = m.group(1).strip()
+    return out
+
+
+def main() -> int:
+    base = Path("OUTPUT/eval")
+    analyst_md = (base / "baseline_20" / "analyst_output.md").read_text()
+    per_job = extract_proper_nouns(analyst_md, RULES["surname_stoplist"])
+    canon = build_canonical(RULES, per_job)
+
+    print(f"Computed per-job proper nouns (from analyst table): {per_job}\n")
+
+    sources = {
+        "gemma (over-capitalized)": base / "local_gemma-isolated" / "seo_output.md",
+        "mistral (over-lowercased)": base / "local_mistral24b" / "seo_output.md",
+        "baseline cloud (sonnet-5)": base / "baseline_20" / "seo_output.md",
+    }
+    for label, path in sources.items():
+        if not path.exists():
+            continue
+        rec = extract_recommended(path.read_text())
+        title = rec.get("title", "")
+        print("═" * 78)
+        print(f"{label}")
+        print("─" * 78)
+        raw_flags = check(title, RULES["char_limits"]["title"], RULES)
+        norm = to_down_style(title, canon)
+        norm_flags = check(norm, RULES["char_limits"]["title"], RULES)
+        print(f"  RAW title : {title}")
+        print(f"              flags: {raw_flags or 'none'}")
+        print(f"  NORMALIZED: {norm}")
+        print(f"              flags: {norm_flags or 'none'}")
+        if rec.get("short_desc"):
+            sd_flags = check(rec['short_desc'], RULES['char_limits']['short_desc'], RULES)
+            print(f"  short desc flags (raw): {sd_flags or 'none'}")
+    print("═" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shadow_eval_analyst.py
+++ b/scripts/shadow_eval_analyst.py
@@ -6,18 +6,19 @@ the worker's user-prompt scaffold) against two or more backends on the same
 transcript, then reports cost/tokens/latency and writes each analysis to a file
 for side-by-side comparison.
 
-This is the "don't trust-flip" first experiment for the local-dougie backend:
+This is the "don't trust-flip" first experiment for the local-llm backend:
 compare its analyst output to the incumbent openrouter-cheapskate on a real
 transcript before routing any production phase to it.
 
 Usage:
     python scripts/shadow_eval_analyst.py \
         --transcript transcripts/examples/EXAMPLE_GlassTree_ForClaude.txt \
-        --backends openrouter-cheapskate,local-dougie
+        --backends openrouter-cheapskate,local-llm
 
-Requires the target backends to be reachable (for local-dougie, the MLX server
-must be up and DOUGIE_ENDPOINT/endpoint pointed at it). It does NOT touch the
-jobs DB — LLM event logging and Langfuse tracing are stubbed out for the run.
+Requires the target backends to be reachable (for local-llm, the oMLX server
+must be up and LOCAL_LLM_ENDPOINT/LOCAL_LLM_MODEL/LOCAL_LLM_API_KEY pointed at
+it). It does NOT touch the jobs DB — LLM event logging and Langfuse tracing are
+stubbed out for the run.
 """
 
 import argparse
@@ -74,7 +75,7 @@ async def main() -> int:
     )
     parser.add_argument(
         "--backends",
-        default="openrouter-cheapskate,local-dougie",
+        default="openrouter-cheapskate,local-llm",
         help="Comma-separated backend names from config/llm-config.json.",
     )
     parser.add_argument("--content-type", default="full", choices=["full", "short"])

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -27,6 +27,12 @@ Create an API key pair in your Langfuse project settings
 The secret half of the Langfuse API key pair (created at the same time
 as the public key above). Starts with `sk-lf-`.
 
+### local_llm_api_key
+Only needed when routing a pipeline phase to the `local-llm` backend (oMLX on the
+Mac Studio). This is the Bearer key oMLX enforces — it lives in 1Password
+("oMLX Local LLM Key"). Omit the file entirely if no phase uses `local-llm`
+(the backend is keyless-tolerant, but oMLX will reject unauthenticated calls).
+
 ## Optional secrets (passed as env vars, not files)
 
 ### CARDIGAN_API_KEY

--- a/secrets/local_llm_api_key.example
+++ b/secrets/local_llm_api_key.example
@@ -1,0 +1,1 @@
+omlx-local-llm-key-here

--- a/tests/api/test_llm.py
+++ b/tests/api/test_llm.py
@@ -26,6 +26,16 @@ from api.services.llm import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_local_llm_env(monkeypatch):
+    """Clear ambient LOCAL_LLM_* env so the local-llm backend tests are
+    deterministic regardless of the developer's shell (the /local-llm skill
+    exports these). Individual tests set them explicitly as needed.
+    """
+    for var in ("LOCAL_LLM_ENDPOINT", "LOCAL_LLM_MODEL", "LOCAL_LLM_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def mock_config(tmp_path):
     """Create a mock config file for testing."""
@@ -49,18 +59,20 @@ def mock_config(tmp_path):
                 "endpoint": "https://openrouter.ai/api/v1/chat/completions",
                 "api_key_env": "OPENROUTER_API_KEY",
             },
-            "local-dougie": {
+            "local-llm": {
                 "type": "openai",
-                "endpoint": "http://localhost:27180/v1/chat/completions",
-                "endpoint_env": "DOUGIE_ENDPOINT",
+                "endpoint": "http://studio.riechers.co:8000/v1/chat/completions",
+                "endpoint_env": "LOCAL_LLM_ENDPOINT",
                 "model": "qwen-local",
+                "model_env": "LOCAL_LLM_MODEL",
+                "api_key_env": "LOCAL_LLM_API_KEY",
                 "strip_reasoning": True,
                 "force_model": True,
                 "defer_when_unavailable": True,
                 "max_tokens": 8192,
                 "cost_per_project": 0.0,
                 "timeout": 300,
-                "enabled": False,
+                "enabled": True,
             },
             "openai-plain": {
                 "type": "openai",
@@ -537,9 +549,10 @@ class TestStripReasoning:
 
 
 class TestLocalBackendIntegration:
-    """The local-dougie backend seam: response cleaning + forced model id.
+    """The local-llm backend seam: response cleaning, forced model id, env
+    overrides, and Bearer auth.
 
-    Both behaviors are gated on opt-in backend flags so existing backends are
+    Behaviors are gated on opt-in backend flags so existing backends are
     untouched.
     """
 
@@ -561,7 +574,7 @@ class TestLocalBackendIntegration:
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response):
             with patch("api.services.llm.log_event"):
-                response = await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                response = await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert response.content == '{"ok": true}'
 
@@ -589,7 +602,7 @@ class TestLocalBackendIntegration:
             with patch("api.services.llm.log_event"):
                 response = await llm_client.chat(
                     messages=[{"role": "user", "content": "x"}],
-                    backend="local-dougie",
+                    backend="local-llm",
                     phase="analyst",
                 )
 
@@ -620,7 +633,7 @@ class TestLocalBackendIntegration:
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response):
             with patch("api.services.llm.log_event"):
-                response = await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                response = await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert response.cost == 0.0
 
@@ -633,7 +646,7 @@ class TestLocalBackendIntegration:
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
             with patch("api.services.llm.log_event"):
-                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         # call_args_list[0] is the LLM request; a Langfuse trace POST may follow.
         payload = mock_post.call_args_list[0].kwargs["json"]
@@ -658,7 +671,7 @@ class TestLocalBackendIntegration:
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
             with patch("api.services.llm.log_event"):
-                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert mock_post.call_args_list[0].kwargs["timeout"] == 300
 
@@ -684,10 +697,10 @@ class TestLocalBackendIntegration:
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
             with patch("api.services.llm.log_event"):
-                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         payload = mock_post.call_args_list[0].kwargs["json"]
-        assert payload["max_tokens"] == 8192  # local-dougie config value
+        assert payload["max_tokens"] == 8192  # local-llm config value
 
     @pytest.mark.asyncio
     async def test_explicit_max_tokens_kwarg_wins(self, llm_client):
@@ -698,7 +711,7 @@ class TestLocalBackendIntegration:
             with patch("api.services.llm.log_event"):
                 await llm_client.chat(
                     messages=[{"role": "user", "content": "x"}],
-                    backend="local-dougie",
+                    backend="local-llm",
                     max_tokens=256,
                 )
 
@@ -707,27 +720,78 @@ class TestLocalBackendIntegration:
 
     @pytest.mark.asyncio
     async def test_endpoint_env_overrides_config_endpoint(self, llm_client, monkeypatch):
-        monkeypatch.setenv("DOUGIE_ENDPOINT", "http://studio.lan:27180/v1/chat/completions")
+        monkeypatch.setenv("LOCAL_LLM_ENDPOINT", "http://studio.lan:27180/v1/chat/completions")
         start_run_tracking(job_id=909)
         mock_response = self._mock_openai_response("hi")
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
             with patch("api.services.llm.log_event"):
-                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert mock_post.call_args_list[0].args[0] == "http://studio.lan:27180/v1/chat/completions"
 
     @pytest.mark.asyncio
-    async def test_no_auth_header_when_keyless(self, llm_client):
+    async def test_no_auth_header_when_key_unresolved(self, llm_client):
+        # local-llm declares api_key_env, but if the key can't be resolved the
+        # request stays keyless (no "Bearer None" header that trips proxies).
         start_run_tracking(job_id=910)
         mock_response = self._mock_openai_response("hi")
 
         with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
             with patch("api.services.llm.log_event"):
-                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                with patch("api.services.llm.get_secret", return_value=None):
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         headers = mock_post.call_args_list[0].kwargs["headers"]
         assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_sends_bearer_when_api_key_resolves(self, llm_client):
+        # oMLX (unlike the old dougie) enforces a Bearer key. When api_key_env
+        # resolves, the Authorization header must carry it.
+        start_run_tracking(job_id=911)
+        mock_response = self._mock_openai_response("hi")
+
+        with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
+            with patch("api.services.llm.log_event"):
+                with patch("api.services.llm.get_secret", return_value="omlx-secret"):
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
+
+        headers = mock_post.call_args_list[0].kwargs["headers"]
+        assert headers["Authorization"] == "Bearer omlx-secret"
+
+    @pytest.mark.asyncio
+    async def test_model_env_overrides_config_model(self, llm_client, monkeypatch):
+        # A single-model local server may serve a different model on a different
+        # network; model_env lets the deploy env supply it without a config edit.
+        monkeypatch.setenv("LOCAL_LLM_MODEL", "mlx-community/other-model")
+        start_run_tracking(job_id=912)
+        mock_response = self._mock_openai_response("hi")
+
+        with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
+            with patch("api.services.llm.log_event"):
+                response = await llm_client.chat(
+                    messages=[{"role": "user", "content": "x"}],
+                    backend="local-llm",
+                    phase="analyst",
+                )
+
+        assert response.model == "mlx-community/other-model"
+        assert mock_post.call_args_list[0].kwargs["json"]["model"] == "mlx-community/other-model"
+
+    @pytest.mark.asyncio
+    async def test_v1_base_endpoint_gets_chat_completions_appended(self, llm_client, monkeypatch):
+        # The /local-llm skill and oMLX use a base URL ending in /v1; Cardigan must
+        # append the chat-completions path so a bare base works verbatim.
+        monkeypatch.setenv("LOCAL_LLM_ENDPOINT", "http://studio.riechers.co:8000/v1")
+        start_run_tracking(job_id=913)
+        mock_response = self._mock_openai_response("hi")
+
+        with patch.object(httpx.AsyncClient, "post", return_value=mock_response) as mock_post:
+            with patch("api.services.llm.log_event"):
+                await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
+
+        assert mock_post.call_args_list[0].args[0] == "http://studio.riechers.co:8000/v1/chat/completions"
 
 
 class TestBackendUnavailable:
@@ -758,10 +822,10 @@ class TestBackendUnavailable:
         with patch.object(httpx.AsyncClient, "post", return_value=resp):
             with patch("api.services.llm.log_event"):
                 with pytest.raises(BackendUnavailableError) as exc:
-                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert "memory pressure" in exc.value.detail
-        assert exc.value.backend == "local-dougie"
+        assert exc.value.backend == "local-llm"
 
     @pytest.mark.asyncio
     async def test_raises_on_connect_error_for_deferrable_backend(self, llm_client):
@@ -770,7 +834,7 @@ class TestBackendUnavailable:
         with patch.object(httpx.AsyncClient, "post", side_effect=httpx.ConnectError("refused")):
             with patch("api.services.llm.log_event"):
                 with pytest.raises(BackendUnavailableError):
-                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
     @pytest.mark.asyncio
     async def test_raises_on_read_timeout_for_deferrable_backend(self, llm_client):
@@ -779,7 +843,7 @@ class TestBackendUnavailable:
         with patch.object(httpx.AsyncClient, "post", side_effect=httpx.ReadTimeout("slow")):
             with patch("api.services.llm.log_event"):
                 with pytest.raises(BackendUnavailableError):
-                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
     @pytest.mark.asyncio
     async def test_503_not_converted_for_non_deferrable_backend(self, llm_client):
@@ -794,14 +858,14 @@ class TestBackendUnavailable:
 
     @pytest.mark.asyncio
     async def test_503_with_retryable_false_is_not_deferred(self, llm_client):
-        # A future dougie envelope marking the error non-retryable must NOT defer.
+        # A busy-signal envelope marking the error non-retryable must NOT defer.
         start_run_tracking(job_id=924)
         resp = self._mock_response(503, {"error": {"retryable": False, "message": "model not found"}})
 
         with patch.object(httpx.AsyncClient, "post", return_value=resp):
             with patch("api.services.llm.log_event"):
                 with pytest.raises(httpx.HTTPStatusError):
-                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
     @pytest.mark.asyncio
     async def test_reads_retry_after_header(self, llm_client):
@@ -811,6 +875,6 @@ class TestBackendUnavailable:
         with patch.object(httpx.AsyncClient, "post", return_value=resp):
             with patch("api.services.llm.log_event"):
                 with pytest.raises(BackendUnavailableError) as exc:
-                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-dougie")
+                    await llm_client.chat(messages=[{"role": "user", "content": "x"}], backend="local-llm")
 
         assert exc.value.retry_after_s == 300

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -562,7 +562,7 @@ class TestRunPhaseDeferral:
 
         mock_get_llm.return_value = mock_llm_client
         mock_llm_client.chat = AsyncMock(
-            side_effect=BackendUnavailableError("memory pressure 69%", backend="local-dougie", retry_after_s=30)
+            side_effect=BackendUnavailableError("memory pressure 69%", backend="local-llm", retry_after_s=30)
         )
         mock_log_event.return_value = None
         mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
@@ -615,7 +615,7 @@ class TestProcessJobDeferral:
 
         mock_get_llm.return_value = mock_llm_client
         mock_llm_client.chat = AsyncMock(
-            side_effect=BackendUnavailableError("memory pressure 69%", backend="local-dougie", retry_after_s=30)
+            side_effect=BackendUnavailableError("memory pressure 69%", backend="local-llm", retry_after_s=30)
         )
         mock_update_status.return_value = None
         mock_update_phase.return_value = None


### PR DESCRIPTION
**Draft / checkpoint — deferred to resume next week.**

## Local-LLM (oMLX) backend (`40bf6c1`)
Network-neutral `local-llm` backend replacing the retired `dougie`: OpenAI-compatible oMLX endpoint, env-overridable (`LOCAL_LLM_ENDPOINT`/`LOCAL_LLM_MODEL`/`LOCAL_LLM_API_KEY`), keyed auth, `/v1` base-URL normalization, secret + compose wiring. Default-off.

## Hybrid-pipeline exploration (`723c1f9`, docs only)
Evidence + kickoff for a follow-on redesign that moves each phase's deterministic shell (casing, char limits, forbidden-word/voice, timecode math) out of the LLM and into code, with rules in editable data:
- `planning/hybrid-pipeline-eval/` — per-phase model-tier eval (gemma vs Qwen3.6-35B vs cloud) + phase-heft assessment.
- `planning/expanded-prompt-*.md` — the Fable plan-mode kickoff prompt.

## Findings
- Extraction phases (analyst, formatter) run faithfully on a mid local MoE at $0; generation/judgment (seo, timestamp, validator) need more heft — or deterministic scripting.
- A ~120-line PoC normalizer converged gemma/Mistral/cloud SEO titles to identical house-style, proving model-agnostic fidelity via code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLC5ZrWzwCMfbc1uyvxUsU