### PR TITLE
feat: local-model endpoints — Settings UI + assignment write-side (step 4)

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -204,6 +204,14 @@ async def update_phase_models(update: PhaseModelsUpdate):
     config = _load_config()
     valid_phases = {"analyst", "formatter", "seo", "validator", "timestamp", "copy_editor", "chat"}
     models_data = await get_available_models()
+    # Without a roster we can neither validate the model id nor look up its serving
+    # backend, so routing the (backend, model) pair below would silently leave
+    # phase_backends stale — an inconsistent config. Fail loudly instead.
+    if not models_data:
+        raise HTTPException(
+            status_code=503,
+            detail="Model roster is unavailable right now; cannot assign models safely. Try again after it refreshes.",
+        )
     available_model_ids = {m["id"] for m in models_data}
 
     for phase, model_id in update.phase_models.items():

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -127,14 +127,18 @@ async def update_phase_backends(update: PhaseBackendsUpdate):
 
 
 class AvailableModel(BaseModel):
-    """A model available for phase assignment."""
+    """A model available for phase assignment (cloud via OpenRouter or a locally
+    discovered model)."""
 
-    id: str = Field(..., description="OpenRouter model ID (e.g., 'anthropic/claude-sonnet-4-5-20250514')")
+    id: str = Field(..., description="Model ID (e.g. 'anthropic/claude-sonnet-4.6' or 'Qwen2.5-7B-Instruct-4bit')")
     name: str = Field(..., description="Human-readable model name")
-    provider: str = Field(..., description="Model provider (e.g., 'Anthropic', 'Google')")
-    tier: int = Field(..., ge=0, le=2, description="Cost tier (0=economy, 1=standard, 2=premium)")
+    provider: str = Field(..., description="Serving provider (e.g. 'Anthropic', 'Google', 'oMLX')")
+    tier: Optional[int] = Field(None, ge=0, le=2, description="Cost tier (0=economy..2=premium); null for local models")
     pricing_input: Optional[float] = Field(None, description="Cost per 1M input tokens (USD)")
     pricing_output: Optional[float] = Field(None, description="Cost per 1M output tokens (USD)")
+    backend: Optional[str] = Field(None, description="Config backend key that serves this model (local models)")
+    host: Optional[str] = Field(None, description="Host of the serving endpoint (local models), for grouping")
+    context_len: Optional[int] = Field(None, description="Max context length if the server advertises it")
 
 
 class PhaseModelsResponse(BaseModel):
@@ -214,6 +218,27 @@ async def update_phase_models(update: PhaseModelsUpdate):
     phase_models = config.get("phase_models", DEFAULT_PHASE_MODELS)
     phase_models.update(update.phase_models)
     config["phase_models"] = phase_models
+
+    # Route on the (backend, model) pair: keep phase_backends consistent with the
+    # assigned model so the model actually reaches the right server. A local model
+    # carries its serving backend in the roster; assigning it points the phase at
+    # that backend. A cloud model has no roster backend, so only reset the phase
+    # *off* a local backend (back to the primary cloud backend) — an existing cloud
+    # tier (e.g. openrouter-cheapskate) is left untouched.
+    roster_by_id = {m["id"]: m for m in models_data}
+    phase_backends = config.get("phase_backends", {})
+    backends = config.get("backends", {})
+    primary = config.get("primary_backend", "openrouter")
+    for phase, model_id in update.phase_models.items():
+        model_backend = roster_by_id.get(model_id, {}).get("backend")
+        if model_backend:
+            phase_backends[phase] = model_backend
+        else:
+            current = phase_backends.get(phase)
+            if current and backends.get(current, {}).get("type") == "openai":
+                phase_backends[phase] = primary
+    config["phase_backends"] = phase_backends
+
     _save_config(config)
 
     # Reload the live LLM client so changes take effect immediately

--- a/tests/api/test_config_backends.py
+++ b/tests/api/test_config_backends.py
@@ -4,6 +4,7 @@ Step 3 of the self-updating local-model backends design: a user adds a local
 OpenAI-compatible endpoint and it becomes a discoverable, routable backend —
 keyed by host so it self-identifies, with no code or config-file hand-edit.
 """
+
 import json
 
 import pytest
@@ -97,15 +98,56 @@ def test_delete_referenced_backend_conflicts(api_client, cfg_path):
     assert api_client.delete("/api/config/backends/openrouter").status_code == 409
 
 
+def test_delete_backend_referenced_only_by_fallback_conflicts(api_client, monkeypatch, tmp_path):
+    """A backend used *solely* as fallback_backend (not primary, not in any phase)
+    must still refuse deletion, so the fallback chain can't be orphaned."""
+    cfg = {
+        "primary_backend": "openrouter",
+        "fallback_backend": "studio.riechers.co:8000",
+        "backends": {
+            "openrouter": {"type": "openrouter", "endpoint": "https://openrouter.ai/api/v1/chat/completions"},
+            "studio.riechers.co:8000": {
+                "type": "openai",
+                "endpoint": "http://studio.riechers.co:8000/v1",
+                "enabled": True,
+                "discover": True,
+            },
+        },
+        "phase_backends": {"analyst": "openrouter"},
+        "phase_models": {},
+    }
+    p = tmp_path / "fallback.json"
+    p.write_text(json.dumps(cfg))
+    monkeypatch.setattr("api.routers.config.CONFIG_PATH", p)
+
+    resp = api_client.delete("/api/config/backends/studio.riechers.co:8000")
+    assert resp.status_code == 409, resp.text
+    assert "fallback_backend" in resp.json()["detail"]
+
+
 def test_get_models_includes_local_models_with_host_and_backend(api_client, cfg_path, monkeypatch):
     """GET /config/models must not choke on a local model (tier=None) and must
     pass through host/backend so the dropdown can group by server."""
     roster = [
-        {"id": "anthropic/claude-haiku-4.5", "name": "Claude Haiku 4.5",
-         "provider": "Anthropic", "tier": 0, "pricing_input": 0.8, "pricing_output": 4.0},
-        {"id": "Qwen2.5-7B-Instruct-4bit", "name": "Qwen2.5-7B-Instruct-4bit",
-         "provider": "oMLX", "backend": "studio.riechers.co:8000", "host": "studio.riechers.co:8000",
-         "tier": None, "pricing_input": 0, "pricing_output": 0, "context_len": 32768},
+        {
+            "id": "anthropic/claude-haiku-4.5",
+            "name": "Claude Haiku 4.5",
+            "provider": "Anthropic",
+            "tier": 0,
+            "pricing_input": 0.8,
+            "pricing_output": 4.0,
+        },
+        {
+            "id": "Qwen2.5-7B-Instruct-4bit",
+            "name": "Qwen2.5-7B-Instruct-4bit",
+            "provider": "oMLX",
+            "backend": "studio.riechers.co:8000",
+            "host": "studio.riechers.co:8000",
+            "tier": None,
+            "pricing_input": 0,
+            "pricing_output": 0,
+            "context_len": 32768,
+        },
     ]
 
     async def _roster():
@@ -130,9 +172,16 @@ def _setup_pair(monkeypatch, tmp_path, seo_backend):
         "primary_backend": "openrouter",
         "backends": {
             "openrouter": {"type": "openrouter", "endpoint": "https://openrouter.ai/api/v1/chat/completions"},
-            "openrouter-cheapskate": {"type": "openrouter", "endpoint": "https://openrouter.ai/api/v1/chat/completions"},
-            "studio.riechers.co:8000": {"type": "openai", "endpoint": "http://studio.riechers.co:8000/v1",
-                                        "enabled": True, "discover": True},
+            "openrouter-cheapskate": {
+                "type": "openrouter",
+                "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+            },
+            "studio.riechers.co:8000": {
+                "type": "openai",
+                "endpoint": "http://studio.riechers.co:8000/v1",
+                "enabled": True,
+                "discover": True,
+            },
         },
         "phase_backends": {"seo": seo_backend},
         "phase_models": {},
@@ -142,8 +191,14 @@ def _setup_pair(monkeypatch, tmp_path, seo_backend):
     monkeypatch.setattr("api.routers.config.CONFIG_PATH", p)
 
     roster = [
-        {"id": "Qwen2.5-7B-Instruct-4bit", "name": "Qwen2.5-7B-Instruct-4bit", "provider": "oMLX",
-         "backend": "studio.riechers.co:8000", "host": "studio.riechers.co:8000", "tier": None},
+        {
+            "id": "Qwen2.5-7B-Instruct-4bit",
+            "name": "Qwen2.5-7B-Instruct-4bit",
+            "provider": "oMLX",
+            "backend": "studio.riechers.co:8000",
+            "host": "studio.riechers.co:8000",
+            "tier": None,
+        },
         {"id": "anthropic/claude-haiku-4.5", "name": "Claude Haiku 4.5", "provider": "Anthropic", "tier": 0},
     ]
 
@@ -177,3 +232,22 @@ def test_assigning_cloud_model_keeps_existing_cloud_backend(api_client, monkeypa
     assert resp.status_code == 200, resp.text
     saved = json.loads(p.read_text())
     assert saved["phase_backends"]["seo"] == "openrouter-cheapskate"  # unchanged
+
+
+def test_assigning_model_with_empty_roster_is_rejected(api_client, monkeypatch, tmp_path):
+    """If the roster is unavailable (e.g. OpenRouter unreachable, cold cache), the
+    (backend, model) pair can't be resolved — assignment must 503 rather than
+    silently save a model_id with a stale phase_backends entry."""
+    p = _setup_pair(monkeypatch, tmp_path, "openrouter")
+
+    async def _empty_roster():
+        return []
+
+    monkeypatch.setattr("api.routers.config.get_available_models", _empty_roster)
+
+    resp = api_client.patch("/api/config/models", json={"phase_models": {"seo": "Qwen2.5-7B-Instruct-4bit"}})
+    assert resp.status_code == 503, resp.text
+    # config must be untouched — no half-written pairing
+    saved = json.loads(p.read_text())
+    assert saved["phase_models"] == {}
+    assert saved["phase_backends"]["seo"] == "openrouter"

--- a/tests/api/test_config_backends.py
+++ b/tests/api/test_config_backends.py
@@ -95,3 +95,85 @@ def test_delete_backend(api_client, cfg_path):
 def test_delete_referenced_backend_conflicts(api_client, cfg_path):
     # openrouter is primary_backend AND used by phase_backends -> must not orphan routing
     assert api_client.delete("/api/config/backends/openrouter").status_code == 409
+
+
+def test_get_models_includes_local_models_with_host_and_backend(api_client, cfg_path, monkeypatch):
+    """GET /config/models must not choke on a local model (tier=None) and must
+    pass through host/backend so the dropdown can group by server."""
+    roster = [
+        {"id": "anthropic/claude-haiku-4.5", "name": "Claude Haiku 4.5",
+         "provider": "Anthropic", "tier": 0, "pricing_input": 0.8, "pricing_output": 4.0},
+        {"id": "Qwen2.5-7B-Instruct-4bit", "name": "Qwen2.5-7B-Instruct-4bit",
+         "provider": "oMLX", "backend": "studio.riechers.co:8000", "host": "studio.riechers.co:8000",
+         "tier": None, "pricing_input": 0, "pricing_output": 0, "context_len": 32768},
+    ]
+
+    async def _roster():
+        return roster
+
+    monkeypatch.setattr("api.routers.config.get_available_models", _roster)
+
+    resp = api_client.get("/api/config/models")
+    assert resp.status_code == 200, resp.text
+    by_id = {m["id"]: m for m in resp.json()["available_models"]}
+    local = by_id["Qwen2.5-7B-Instruct-4bit"]
+    assert local["provider"] == "oMLX"
+    assert local["host"] == "studio.riechers.co:8000"
+    assert local["backend"] == "studio.riechers.co:8000"
+    assert local["tier"] is None
+
+
+def _setup_pair(monkeypatch, tmp_path, seo_backend):
+    """Install a config with a local backend + a patched roster, with the SEO
+    phase initially routed to `seo_backend`."""
+    cfg = {
+        "primary_backend": "openrouter",
+        "backends": {
+            "openrouter": {"type": "openrouter", "endpoint": "https://openrouter.ai/api/v1/chat/completions"},
+            "openrouter-cheapskate": {"type": "openrouter", "endpoint": "https://openrouter.ai/api/v1/chat/completions"},
+            "studio.riechers.co:8000": {"type": "openai", "endpoint": "http://studio.riechers.co:8000/v1",
+                                        "enabled": True, "discover": True},
+        },
+        "phase_backends": {"seo": seo_backend},
+        "phase_models": {},
+    }
+    p = tmp_path / "pair.json"
+    p.write_text(json.dumps(cfg))
+    monkeypatch.setattr("api.routers.config.CONFIG_PATH", p)
+
+    roster = [
+        {"id": "Qwen2.5-7B-Instruct-4bit", "name": "Qwen2.5-7B-Instruct-4bit", "provider": "oMLX",
+         "backend": "studio.riechers.co:8000", "host": "studio.riechers.co:8000", "tier": None},
+        {"id": "anthropic/claude-haiku-4.5", "name": "Claude Haiku 4.5", "provider": "Anthropic", "tier": 0},
+    ]
+
+    async def _roster():
+        return roster
+
+    monkeypatch.setattr("api.routers.config.get_available_models", _roster)
+    return p
+
+
+def test_assigning_local_model_writes_phase_backend(api_client, monkeypatch, tmp_path):
+    p = _setup_pair(monkeypatch, tmp_path, "openrouter")
+    resp = api_client.patch("/api/config/models", json={"phase_models": {"seo": "Qwen2.5-7B-Instruct-4bit"}})
+    assert resp.status_code == 200, resp.text
+    saved = json.loads(p.read_text())
+    assert saved["phase_models"]["seo"] == "Qwen2.5-7B-Instruct-4bit"
+    assert saved["phase_backends"]["seo"] == "studio.riechers.co:8000"  # pair written
+
+
+def test_assigning_cloud_model_resets_off_local_backend(api_client, monkeypatch, tmp_path):
+    p = _setup_pair(monkeypatch, tmp_path, "studio.riechers.co:8000")  # phase currently local
+    resp = api_client.patch("/api/config/models", json={"phase_models": {"seo": "anthropic/claude-haiku-4.5"}})
+    assert resp.status_code == 200, resp.text
+    saved = json.loads(p.read_text())
+    assert saved["phase_backends"]["seo"] == "openrouter"  # reset to primary cloud backend
+
+
+def test_assigning_cloud_model_keeps_existing_cloud_backend(api_client, monkeypatch, tmp_path):
+    p = _setup_pair(monkeypatch, tmp_path, "openrouter-cheapskate")  # already a cloud tier
+    resp = api_client.patch("/api/config/models", json={"phase_models": {"seo": "anthropic/claude-haiku-4.5"}})
+    assert resp.status_code == 200, resp.text
+    saved = json.loads(p.read_text())
+    assert saved["phase_backends"]["seo"] == "openrouter-cheapskate"  # unchanged

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -611,13 +611,13 @@ export default function Settings() {
               </p>
 
               <div className="space-y-3">
-                {(backends || []).filter((b) => b.type === 'openai').length === 0 && (
+                {(backends || []).filter((b) => b.type === 'openai' && b.discover).length === 0 && (
                   <p className="text-sm text-surface-500">
                     No endpoints yet. Add one below to run models on your own hardware.
                   </p>
                 )}
                 {(backends || [])
-                  .filter((b) => b.type === 'openai')
+                  .filter((b) => b.type === 'openai' && b.discover)
                   .map((b) => {
                     const count = (phaseModels?.available_models || []).filter((m) => m.backend === b.name).length
                     return (

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { usePreferences, TextSize } from '../context/PreferencesContext'
 import { AGENT_INFO } from '../constants/agents'
@@ -224,9 +224,19 @@ export default function Settings() {
   // After any endpoint change, rebuild the roster so discovered models appear,
   // then reload the endpoints list and the model picker together.
   const refreshRosterAndLists = useCallback(async () => {
-    await fetch('/api/config/models/refresh', { method: 'POST' })
+    const res = await fetch('/api/config/models/refresh', { method: 'POST' })
+    if (!res.ok) {
+      setError('Could not rebuild the model roster — the model list may be out of date.')
+    }
     await Promise.all([fetchBackends(), fetchConfig()])
   }, [fetchBackends, fetchConfig])
+
+  // The roster is identical for every agent phase, so group it once per render
+  // rather than recomputing inside the AGENT_INFO map (once per agent).
+  const modelGroups = useMemo(
+    () => groupAvailableModels(phaseModels?.available_models || []),
+    [phaseModels?.available_models],
+  )
 
   const handleAddEndpoint = async () => {
     setBackendBusy(true)
@@ -543,8 +553,6 @@ export default function Settings() {
                   const currentModel = pendingPhaseModels?.[agent.id]
                     || phaseModels?.phase_models?.[agent.id]
                     || ''
-                  const models = phaseModels?.available_models || []
-                  const modelGroups = groupAvailableModels(models)
 
                   return (
                     <div key={agent.id} className="p-4 bg-surface-900 rounded-lg space-y-2">
@@ -633,6 +641,7 @@ export default function Settings() {
                             onClick={() => handleToggleEndpoint(b.name, !b.enabled)}
                             disabled={backendBusy}
                             className="text-xs text-surface-400 hover:text-white transition-colors disabled:opacity-50"
+                            aria-label={`${b.enabled ? 'Disable' : 'Enable'} endpoint ${b.name}`}
                           >
                             {b.enabled ? 'Disable' : 'Enable'}
                           </button>
@@ -640,6 +649,7 @@ export default function Settings() {
                             onClick={() => handleDeleteEndpoint(b.name)}
                             disabled={backendBusy}
                             className="text-xs text-status-failed/80 hover:text-status-failed transition-colors disabled:opacity-50"
+                            aria-label={`Remove endpoint ${b.name}`}
                           >
                             Remove
                           </button>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -648,7 +648,7 @@ export default function Settings() {
                           <button
                             onClick={() => handleDeleteEndpoint(b.name)}
                             disabled={backendBusy}
-                            className="text-xs text-status-failed/80 hover:text-status-failed transition-colors disabled:opacity-50"
+                            className="text-xs text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
                             aria-label={`Remove endpoint ${b.name}`}
                           >
                             Remove

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -4,17 +4,30 @@ import { usePreferences, TextSize } from '../context/PreferencesContext'
 import { AGENT_INFO } from '../constants/agents'
 import ModelStatsWidget from '../components/ModelStatsWidget'
 import PhaseStatsWidget from '../components/PhaseStatsWidget'
+import { groupAvailableModels } from '../utils/modelGroups'
 
 interface AvailableModel {
   id: string
   name: string
   provider: string
+  host?: string | null
+  backend?: string | null
+  tier?: number | null
+  context_len?: number | null
 }
 
 interface PhaseModelsConfig {
   phase_models: Record<string, string>
   available_models: AvailableModel[]
   available_phases: string[]
+}
+
+interface BackendInfo {
+  name: string
+  type: string
+  endpoint?: string | null
+  enabled: boolean
+  discover: boolean
 }
 
 interface WorkerConfig {
@@ -41,10 +54,11 @@ interface IngestConfigUpdate {
   scan_time?: string  // "HH:MM" format
 }
 
-type TabId = 'agents' | 'worker' | 'ingest' | 'system' | 'export' | 'accessibility'
+type TabId = 'agents' | 'models' | 'worker' | 'ingest' | 'system' | 'export' | 'accessibility'
 
 const TABS: { id: TabId; label: string; icon: string }[] = [
   { id: 'agents', label: 'Agents', icon: '🤖' },
+  { id: 'models', label: 'Models', icon: '🧠' },
   { id: 'worker', label: 'Worker', icon: '⚙️' },
   { id: 'ingest', label: 'Ingest', icon: '📥' },
   { id: 'system', label: 'System', icon: '🖥️' },
@@ -83,6 +97,12 @@ export default function Settings() {
   const [pendingWorker, setPendingWorker] = useState<Partial<WorkerConfig> | null>(null)
   const [pendingIngest, setPendingIngest] = useState<Partial<IngestConfigUpdate> | null>(null)
   const [refreshingModels, setRefreshingModels] = useState(false)
+
+  // Local-endpoint management (Models tab)
+  const [backends, setBackends] = useState<BackendInfo[] | null>(null)
+  const [newEndpoint, setNewEndpoint] = useState('')
+  const [newApiKeyEnv, setNewApiKeyEnv] = useState('')
+  const [backendBusy, setBackendBusy] = useState(false)
 
   const fetchConfig = useCallback(async () => {
     try {
@@ -135,11 +155,24 @@ export default function Settings() {
   }, [])
 
 
+  const fetchBackends = useCallback(async () => {
+    try {
+      const res = await fetch('/api/config/backends')
+      if (res.ok) {
+        const data = await res.json()
+        setBackends(data.backends)
+      }
+    } catch {
+      // Non-critical — the Models tab shows an empty list if this fails.
+    }
+  }, [])
+
   useEffect(() => {
     fetchConfig()
     fetchIngestConfig()
     fetchSystemStatus()
-  }, [fetchConfig, fetchIngestConfig, fetchSystemStatus])
+    fetchBackends()
+  }, [fetchConfig, fetchIngestConfig, fetchSystemStatus, fetchBackends])
 
   // Poll system status when on System tab
   useEffect(() => {
@@ -186,6 +219,86 @@ export default function Settings() {
   const handlePhaseModelChange = (phase: string, modelId: string) => {
     const current = pendingPhaseModels || phaseModels?.phase_models || {}
     setPendingPhaseModels({ ...current, [phase]: modelId })
+  }
+
+  // After any endpoint change, rebuild the roster so discovered models appear,
+  // then reload the endpoints list and the model picker together.
+  const refreshRosterAndLists = useCallback(async () => {
+    await fetch('/api/config/models/refresh', { method: 'POST' })
+    await Promise.all([fetchBackends(), fetchConfig()])
+  }, [fetchBackends, fetchConfig])
+
+  const handleAddEndpoint = async () => {
+    setBackendBusy(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const res = await fetch('/api/config/backends', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: newEndpoint.trim(),
+          api_key_env: newApiKeyEnv.trim() || undefined,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || 'Could not add endpoint')
+      }
+      const created = await res.json()
+      setNewEndpoint('')
+      setNewApiKeyEnv('')
+      await refreshRosterAndLists()
+      setSuccess(`Added ${created.name}`)
+      setTimeout(() => setSuccess(null), 3000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not add endpoint')
+      setTimeout(() => setError(null), 5000)
+    } finally {
+      setBackendBusy(false)
+    }
+  }
+
+  const handleToggleEndpoint = async (name: string, enabled: boolean) => {
+    setBackendBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/config/backends/${encodeURIComponent(name)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || 'Could not update endpoint')
+      }
+      await refreshRosterAndLists()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not update endpoint')
+      setTimeout(() => setError(null), 5000)
+    } finally {
+      setBackendBusy(false)
+    }
+  }
+
+  const handleDeleteEndpoint = async (name: string) => {
+    setBackendBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/config/backends/${encodeURIComponent(name)}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.detail || 'Could not remove endpoint')
+      }
+      await refreshRosterAndLists()
+      setSuccess(`Removed ${name}`)
+      setTimeout(() => setSuccess(null), 3000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not remove endpoint')
+      setTimeout(() => setError(null), 5000)
+    } finally {
+      setBackendBusy(false)
+    }
   }
 
   const handleWorkerChange = (key: keyof WorkerConfig, value: number) => {
@@ -431,10 +544,7 @@ export default function Settings() {
                     || phaseModels?.phase_models?.[agent.id]
                     || ''
                   const models = phaseModels?.available_models || []
-                  // Sort by provider then name
-                  const sortedModels = [...models].sort((a, b) =>
-                    a.provider.localeCompare(b.provider) || a.name.localeCompare(b.name)
-                  )
+                  const modelGroups = groupAvailableModels(models)
 
                   return (
                     <div key={agent.id} className="p-4 bg-surface-900 rounded-lg space-y-2">
@@ -454,10 +564,14 @@ export default function Settings() {
                           className="pl-3 pr-8 py-2 rounded-md border text-sm font-medium bg-surface-800 border-surface-600 text-surface-200"
                           aria-label={`Select model for ${agent.name} agent`}
                         >
-                          {sortedModels.map(m => (
-                            <option key={m.id} value={m.id} className="bg-surface-800 text-white">
-                              {m.name}
-                            </option>
+                          {modelGroups.map((group) => (
+                            <optgroup key={group.label} label={group.label}>
+                              {group.models.map((m) => (
+                                <option key={m.id} value={m.id} className="bg-surface-800 text-white">
+                                  {m.name}
+                                </option>
+                              ))}
+                            </optgroup>
                           ))}
                         </select>
                       </div>
@@ -472,6 +586,98 @@ export default function Settings() {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <ModelStatsWidget />
               <PhaseStatsWidget />
+            </div>
+          </div>
+        )}
+
+        {/* MODELS TAB */}
+        {activeTab === 'models' && (
+          <div className="space-y-6">
+            <div className="bg-surface-800 rounded-lg border border-surface-700 p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-lg font-semibold text-white">Local model endpoints</h2>
+                <button
+                  onClick={refreshRosterAndLists}
+                  disabled={backendBusy}
+                  className="text-xs text-surface-400 hover:text-white transition-colors disabled:opacity-50"
+                  aria-label="Re-check endpoints for available models"
+                >
+                  ↻ Rediscover
+                </button>
+              </div>
+              <p className="text-sm text-surface-400 mb-6">
+                Connect an OpenAI-compatible server (oMLX, vLLM, LM Studio). Its models join
+                the cloud ones in the Agents tab, free to run.
+              </p>
+
+              <div className="space-y-3">
+                {(backends || []).filter((b) => b.type === 'openai').length === 0 && (
+                  <p className="text-sm text-surface-500">
+                    No endpoints yet. Add one below to run models on your own hardware.
+                  </p>
+                )}
+                {(backends || [])
+                  .filter((b) => b.type === 'openai')
+                  .map((b) => {
+                    const count = (phaseModels?.available_models || []).filter((m) => m.backend === b.name).length
+                    return (
+                      <div key={b.name} className="flex items-center justify-between p-4 bg-surface-900 rounded-lg">
+                        <div className="min-w-0">
+                          <div className="font-medium text-white truncate">{b.name}</div>
+                          <div className="text-xs text-surface-400">
+                            {b.enabled ? `${count} model${count === 1 ? '' : 's'} available` : 'disabled'}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-4 shrink-0">
+                          <button
+                            onClick={() => handleToggleEndpoint(b.name, !b.enabled)}
+                            disabled={backendBusy}
+                            className="text-xs text-surface-400 hover:text-white transition-colors disabled:opacity-50"
+                          >
+                            {b.enabled ? 'Disable' : 'Enable'}
+                          </button>
+                          <button
+                            onClick={() => handleDeleteEndpoint(b.name)}
+                            disabled={backendBusy}
+                            className="text-xs text-status-failed/80 hover:text-status-failed transition-colors disabled:opacity-50"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
+              </div>
+
+              <div className="mt-6 pt-6 border-t border-surface-700 space-y-3">
+                <h3 className="text-sm font-semibold text-white">Add an endpoint</h3>
+                <div className="flex flex-col sm:flex-row gap-3">
+                  <input
+                    value={newEndpoint}
+                    onChange={(e) => setNewEndpoint(e.target.value)}
+                    placeholder="http://host:8000/v1"
+                    aria-label="Endpoint base URL"
+                    className="flex-1 px-3 py-2 rounded-md bg-surface-900 border border-surface-600 text-surface-200 text-sm placeholder:text-surface-500"
+                  />
+                  <input
+                    value={newApiKeyEnv}
+                    onChange={(e) => setNewApiKeyEnv(e.target.value)}
+                    placeholder="API key env var (optional)"
+                    aria-label="API key environment variable name (optional)"
+                    className="flex-1 px-3 py-2 rounded-md bg-surface-900 border border-surface-600 text-surface-200 text-sm placeholder:text-surface-500"
+                  />
+                  <button
+                    onClick={handleAddEndpoint}
+                    disabled={backendBusy || !newEndpoint.trim()}
+                    className="px-4 py-2 bg-pbs-500 hover:bg-pbs-400 disabled:opacity-50 text-white rounded-md text-sm transition-colors whitespace-nowrap"
+                  >
+                    {backendBusy ? 'Working…' : 'Add & discover'}
+                  </button>
+                </div>
+                <p className="text-xs text-surface-500">
+                  The key is read from that named environment variable on the server — it isn't stored here.
+                </p>
+              </div>
             </div>
           </div>
         )}

--- a/web/src/utils/__tests__/modelGroups.test.ts
+++ b/web/src/utils/__tests__/modelGroups.test.ts
@@ -19,11 +19,13 @@ describe('groupAvailableModels', () => {
     expect(groups.map((g) => g.label)).toEqual(['oMLX · h:1'])
   })
 
-  it('separates two local servers into their own groups', () => {
+  it('separates two local servers into their own groups, ordered alphabetically by label', () => {
     const groups = groupAvailableModels([
-      { id: 'a', name: 'A', provider: 'oMLX', host: 'studio:8000' },
       { id: 'b', name: 'B', provider: 'vLLM', host: 'gpu-box:8000' },
+      { id: 'a', name: 'A', provider: 'oMLX', host: 'studio:8000' },
     ])
-    expect(groups.map((g) => g.label).sort()).toEqual(['oMLX · studio:8000', 'vLLM · gpu-box:8000'])
+    // Assert the emitted order directly (no .sort()) so the alphabetical-by-label
+    // contract is what's under test — inputs are deliberately reversed.
+    expect(groups.map((g) => g.label)).toEqual(['oMLX · studio:8000', 'vLLM · gpu-box:8000'])
   })
 })

--- a/web/src/utils/__tests__/modelGroups.test.ts
+++ b/web/src/utils/__tests__/modelGroups.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { groupAvailableModels } from '../modelGroups'
+
+describe('groupAvailableModels', () => {
+  it('groups cloud models under "Cloud" and locals under "provider · host"', () => {
+    const groups = groupAvailableModels([
+      { id: 'anthropic/claude-haiku-4.5', name: 'Claude Haiku 4.5', provider: 'Anthropic' },
+      { id: 'zeta', name: 'Zeta', provider: 'oMLX', host: 'studio.riechers.co:8000', backend: 'studio.riechers.co:8000' },
+      { id: 'alpha', name: 'Alpha', provider: 'oMLX', host: 'studio.riechers.co:8000', backend: 'studio.riechers.co:8000' },
+    ])
+    expect(groups.map((g) => g.label)).toEqual(['Cloud', 'oMLX · studio.riechers.co:8000'])
+    expect(groups[0].models.map((m) => m.id)).toEqual(['anthropic/claude-haiku-4.5'])
+    // sorted by name within a group
+    expect(groups[1].models.map((m) => m.id)).toEqual(['alpha', 'zeta'])
+  })
+
+  it('omits the Cloud group when there are no cloud models', () => {
+    const groups = groupAvailableModels([{ id: 'x', name: 'X', provider: 'oMLX', host: 'h:1' }])
+    expect(groups.map((g) => g.label)).toEqual(['oMLX · h:1'])
+  })
+
+  it('separates two local servers into their own groups', () => {
+    const groups = groupAvailableModels([
+      { id: 'a', name: 'A', provider: 'oMLX', host: 'studio:8000' },
+      { id: 'b', name: 'B', provider: 'vLLM', host: 'gpu-box:8000' },
+    ])
+    expect(groups.map((g) => g.label).sort()).toEqual(['oMLX · studio:8000', 'vLLM · gpu-box:8000'])
+  })
+})

--- a/web/src/utils/modelGroups.ts
+++ b/web/src/utils/modelGroups.ts
@@ -35,7 +35,7 @@ export function groupAvailableModels(models: RosterModel[]): ModelGroup[] {
   const groups: ModelGroup[] = []
   if (cloud.length) groups.push({ label: 'Cloud', models: [...cloud].sort(byName) })
   for (const label of [...localByHost.keys()].sort()) {
-    groups.push({ label, models: localByHost.get(label)!.sort(byName) })
+    groups.push({ label, models: [...localByHost.get(label)!].sort(byName) })
   }
   return groups
 }

--- a/web/src/utils/modelGroups.ts
+++ b/web/src/utils/modelGroups.ts
@@ -1,0 +1,41 @@
+/**
+ * Groups the flat model roster into optgroup-ready sections for the per-phase
+ * model picker: cloud models under "Cloud", and each local server under
+ * "provider · host" (e.g. "oMLX · studio.riechers.co:8000").
+ *
+ * A model is "local" when it carries a `host` (set by the backend roster for
+ * discovered endpoints); cloud models have none.
+ */
+export interface RosterModel {
+  id: string
+  name: string
+  provider: string
+  host?: string | null
+  backend?: string | null
+}
+
+export interface ModelGroup {
+  label: string
+  models: RosterModel[]
+}
+
+export function groupAvailableModels(models: RosterModel[]): ModelGroup[] {
+  const byName = (a: RosterModel, b: RosterModel) => a.name.localeCompare(b.name)
+
+  const cloud = models.filter((m) => !m.host)
+  const localByHost = new Map<string, RosterModel[]>()
+  for (const m of models) {
+    if (!m.host) continue
+    const label = `${m.provider} · ${m.host}`
+    const arr = localByHost.get(label) ?? []
+    arr.push(m)
+    localByHost.set(label, arr)
+  }
+
+  const groups: ModelGroup[] = []
+  if (cloud.length) groups.push({ label: 'Cloud', models: [...cloud].sort(byName) })
+  for (const label of [...localByHost.keys()].sort()) {
+    groups.push({ label, models: localByHost.get(label)!.sort(byName) })
+  }
+  return groups
+}


### PR DESCRIPTION
## Local-model endpoints: Settings UI + assignment write-side (step 4)

Completes the self-updating local-model backends feature — the user-facing half. **Stacked on #293** (the backend); review/merge #293 first, then this. Base is set to `feat/local-model-discovery` so the diff shows only step-4 changes.

Full design: `planning/2026-07-10-self-updating-local-model-backends.md` (in #293).

### What's here

- **New "Models" Settings tab** — lists discover-flagged local endpoints (`GET /config/backends`) with an add-endpoint form (base URL + optional API-key env var), enable/disable, remove, rediscover, and a per-endpoint model count. Adding an endpoint creates it, refreshes the roster, and its models appear. The key is never stored client-side — it resolves from the named env var on the server.
- **Grouped Agents dropdown** — the per-phase model picker groups options `<optgroup>` by source: `Cloud` (OpenRouter) vs `provider · host` (e.g. `oMLX · studio.riechers.co:8000`). Selecting a local model writes the `(backend, model)` pair server-side so it routes.
- **Backend write-side** (`71c1f69`): `PATCH /config/models` sets `phase_backends` to match the assigned model (local → its backend; cloud → resets off a local backend). Also fixes a **latent 500** — `AvailableModel` required `tier:int` but local models carry `tier:null`, so `/config/models` would have errored on any discovered local model — and passes `host`/`backend`/`context_len` through for grouping.
- Grouping logic extracted to a pure, tested util; `d8aeecc` fixes the endpoint-list filter (exclude non-`discover` openai presets like `openai`/`openai-mini`).

### Verification

- `tsc --noEmit` clean · vite production build clean · Python suite **865 passed** · vitest grouping tests (3).
- **Live-verified on a local instance** (this branch's code, throwaway config — never the container): `/config/models` returns **200 not 500** (4c fix holds live) with 30 cloud + 0 local on a locked key; host-keyed `POST /config/backends` works; the Models tab renders native to the app (screenshot). Real oMLX-model *population* wasn't shown — 1Password was locked on the dev box — but the endpoint response, tagging, and grouping are covered by unit + integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSw8KPi4k2MKgZ1AKjb5jR
