### PR TITLE
feat(pipeline): deterministic seam robustness + SEO length enforcement + prevention

### DIFF
--- a/api/services/chunking.py
+++ b/api/services/chunking.py
@@ -474,28 +474,33 @@ def _dedup_seam_turns(prev_body: str, next_body: str) -> str:
 
     Replaces the previous fuzzy word-window trim (which flattened structure and
     could over-trim real dialogue). It works on whole speaker turns, so it never
-    flattens, never trims mid-label, and never deletes a partial line. A leading
-    turn is dropped only when its dialogue is an exact (whitespace-normalized)
-    duplicate of one of the last few turns of the previous chunk — i.e. the
-    model echoed the input overlap despite being told not to. Because
-    ``_split_srt`` partitions the source captions with no content overlap, such
-    a leading duplicate can only be an echo; genuine new content is never an
-    exact duplicate of the immediately-preceding turn, so real dialogue is never
-    dropped.
+    flattens, never trims mid-label, and never deletes a partial line.
+
+    An echo is modelled precisely: the model re-emitting the input overlap means
+    ``next_body`` OPENS with a contiguous run of turns identical (whitespace-
+    normalized) to the turns that CLOSE ``prev_body`` — a suffix of prev
+    appearing as a prefix of next. Only that seam-adjacent contiguous run is
+    dropped (the largest match, up to ``_MAX_SEAM_ECHO_TURNS``). Anchoring on the
+    exact seam — rather than matching a leading turn against *any* recent turn —
+    avoids misclassifying a short turn that merely repeats one said a few turns
+    earlier (e.g. a "Right." backchannel) as an echo. Because ``_split_srt``
+    partitions the source captions with no content overlap, a seam-adjacent
+    contiguous duplicate is an echo, not new dialogue.
     """
     prev_turns = _split_into_turns(prev_body)
     next_turns = _split_into_turns(next_body)
     if not prev_turns or not next_turns:
         return next_body
 
-    recent_keys = {_turn_dialogue_key(t) for t in prev_turns[-_MAX_SEAM_ECHO_TURNS:]}
-    recent_keys.discard("")
+    prev_keys = [_turn_dialogue_key(t) for t in prev_turns]
+    next_keys = [_turn_dialogue_key(t) for t in next_turns]
+    max_k = min(len(prev_turns), len(next_turns), _MAX_SEAM_ECHO_TURNS)
 
     drop = 0
-    for turn in next_turns[:_MAX_SEAM_ECHO_TURNS]:
-        if _turn_dialogue_key(turn) in recent_keys:
-            drop += 1
-        else:
+    for k in range(max_k, 0, -1):
+        prev_tail = prev_keys[-k:]
+        if all(prev_tail) and prev_tail == next_keys[:k]:  # non-empty contiguous match
+            drop = k
             break
 
     if not drop:

--- a/api/services/chunking.py
+++ b/api/services/chunking.py
@@ -42,16 +42,58 @@ def _count_dialogue_words_srt(captions: List[SRTCaption]) -> int:
     return sum(len(c.text.split()) for c in captions)
 
 
+# How far past the word target to scan for a natural chunk boundary.
+_TURN_LOOKAHEAD = 25  # captions — prefer ending right before a new speaker turn
+_SENTENCE_LOOKAHEAD = 10  # captions — fallback: sentence-ending punctuation
+
+
+def _starts_new_turn(caption: SRTCaption) -> bool:
+    """True if this caption begins a new speaker turn.
+
+    ``split_interior_speaker_changes`` runs before chunking on SRT input, so
+    every ``>>`` marker is guaranteed caption-leading by the time we split —
+    a leading ``>>`` reliably marks a new turn. Scripted transcripts with no
+    ``>>`` never match; the caller then falls back to sentence boundaries.
+    """
+    return caption.text.lstrip().startswith(">>")
+
+
+def _choose_break_idx(captions: List[SRTCaption], i: int) -> int:
+    """Pick the caption index to end the current chunk on, at/after ``i``.
+
+    Preference order, so a chunk seam never lands mid-speaker-turn (which is
+    what forces the next chunk to re-guess who is speaking and drives the
+    speaker-label breakdown at seams):
+
+    1. End at ``j`` where the *next* caption opens a new speaker turn (``>>``),
+       so the following chunk starts cleanly on a fresh turn.
+    2. Else the first sentence-ending caption (``.?!``) within a shorter window.
+    3. Else a hard break at ``i``.
+    """
+    n = len(captions)
+    turn_hi = min(i + _TURN_LOOKAHEAD, n)
+    for j in range(i, turn_hi):
+        if j + 1 < n and _starts_new_turn(captions[j + 1]):
+            return j
+    sentence_hi = min(i + _SENTENCE_LOOKAHEAD, n)
+    for j in range(i, sentence_hi):
+        text = captions[j].text.strip()
+        if text and text[-1] in ".?!":
+            return j
+    return i
+
+
 def _split_srt(
     content: str,
     target_chunk_words: int,
     overlap_captions: int,
 ) -> Optional[List[TranscriptChunk]]:
-    """Split SRT content into chunks at sentence boundaries.
+    """Split SRT content into chunks at speaker-turn boundaries.
 
-    Walks captions accumulating word count. At the target, looks ahead
-    up to 10 captions for sentence-ending punctuation to find a natural
-    break point.
+    Walks captions accumulating word count. Once past the target it picks a
+    break via ``_choose_break_idx`` — preferring to end just before a new
+    speaker turn (``>>``), falling back to sentence-ending punctuation — so a
+    seam never splits a single speaker's turn across two chunks.
     """
     captions = parse_srt(content)
     if not captions:
@@ -65,7 +107,6 @@ def _split_srt(
     chunks: List[TranscriptChunk] = []
     chunk_start_idx = 0
     accumulated_words = 0
-    LOOKAHEAD = 10
 
     i = 0
     while i < len(captions):
@@ -73,16 +114,8 @@ def _split_srt(
         accumulated_words += caption_words
 
         if accumulated_words >= target_chunk_words and i < len(captions) - 1:
-            # Look ahead for sentence-ending punctuation
-            break_idx = i
-            for j in range(i, min(i + LOOKAHEAD, len(captions))):
-                text = captions[j].text.strip()
-                if text and text[-1] in ".?!":
-                    break_idx = j
-                    break
-            else:
-                # No sentence boundary found in lookahead, break at current
-                break_idx = i
+            # Prefer a speaker-turn boundary; fall back to a sentence boundary.
+            break_idx = _choose_break_idx(captions, i)
 
             # Build this chunk's captions
             chunk_captions = captions[chunk_start_idx : break_idx + 1]
@@ -385,9 +418,9 @@ def merge_formatter_chunks(chunks: List[str]) -> str:
 
         bodies.append(body)
 
-    # Deduplicate overlap at seams
+    # Deduplicate any echoed overlap at seams (structural, turn-aware).
     for i in range(len(bodies) - 1):
-        bodies[i + 1] = _trim_overlap(bodies[i], bodies[i + 1])
+        bodies[i + 1] = _dedup_seam_turns(bodies[i], bodies[i + 1])
 
     # Build final document
     parts = []
@@ -411,45 +444,62 @@ def merge_formatter_chunks(chunks: List[str]) -> str:
     return "\n\n".join(parts)
 
 
-def _trim_overlap(prev_body: str, next_body: str, window: int = 100) -> str:
-    """Remove duplicate text at the seam between two chunks.
+# Max leading turns of a continuation chunk to test for echoed overlap (also the
+# window of trailing previous-chunk turns tested against).
+_MAX_SEAM_ECHO_TURNS = 6
 
-    Compares the last ~window words of prev with the first ~window
-    words of next. If >50% overlap, trims the duplicate from next.
+# A speaker turn starts at a line-leading bold label, e.g. ``**Jane Doe:**``.
+_TURN_SPLIT_RE = re.compile(r"(?m)(?=^\*\*[^*\n]+?:\*\*)")
+_TURN_LABEL_RE = re.compile(r"^\*\*[^*\n]+?:\*\*[ \t]*")
+
+
+def _split_into_turns(body: str) -> List[str]:
+    """Split a formatted transcript body into speaker-turn blocks.
+
+    A turn runs from a line-leading ``**Speaker:**`` label to the next such
+    label. Any text before the first label is kept as a leading block so
+    nothing is dropped, and whitespace inside each block is preserved verbatim.
     """
-    prev_words = prev_body.split()
-    next_words = next_body.split()
+    return [part for part in _TURN_SPLIT_RE.split(body) if part.strip()]
 
-    if len(prev_words) < 10 or len(next_words) < 10:
+
+def _turn_dialogue_key(turn: str) -> str:
+    """Whitespace/label-normalized dialogue of a turn, for echo comparison."""
+    without_label = _TURN_LABEL_RE.sub("", turn.strip(), count=1)
+    return re.sub(r"\s+", " ", without_label).strip().lower()
+
+
+def _dedup_seam_turns(prev_body: str, next_body: str) -> str:
+    """Drop leading turns of ``next_body`` that echo the tail of ``prev_body``.
+
+    Replaces the previous fuzzy word-window trim (which flattened structure and
+    could over-trim real dialogue). It works on whole speaker turns, so it never
+    flattens, never trims mid-label, and never deletes a partial line. A leading
+    turn is dropped only when its dialogue is an exact (whitespace-normalized)
+    duplicate of one of the last few turns of the previous chunk — i.e. the
+    model echoed the input overlap despite being told not to. Because
+    ``_split_srt`` partitions the source captions with no content overlap, such
+    a leading duplicate can only be an echo; genuine new content is never an
+    exact duplicate of the immediately-preceding turn, so real dialogue is never
+    dropped.
+    """
+    prev_turns = _split_into_turns(prev_body)
+    next_turns = _split_into_turns(next_body)
+    if not prev_turns or not next_turns:
         return next_body
 
-    prev_tail = prev_words[-window:]
-    next_head = next_words[:window]
+    recent_keys = {_turn_dialogue_key(t) for t in prev_turns[-_MAX_SEAM_ECHO_TURNS:]}
+    recent_keys.discard("")
 
-    # Find the longest matching suffix of prev_tail that starts next_head
-    best_match_len = 0
-    for start in range(len(prev_tail)):
-        candidate = prev_tail[start:]
-        candidate_len = len(candidate)
-        if candidate_len < 5:
+    drop = 0
+    for turn in next_turns[:_MAX_SEAM_ECHO_TURNS]:
+        if _turn_dialogue_key(turn) in recent_keys:
+            drop += 1
+        else:
             break
-        # Check if next_head starts with this candidate
-        match_len = 0
-        for k in range(min(candidate_len, len(next_head))):
-            if candidate[k].lower() == next_head[k].lower():
-                match_len += 1
-            else:
-                break
-        if match_len > best_match_len and match_len >= 5:
-            best_match_len = match_len
 
-    # If >50% of the window overlaps, trim
-    if best_match_len > 0 and best_match_len / min(window, len(next_head)) > 0.5:
-        logger.info(
-            "Trimming overlap at chunk seam",
-            extra={"overlap_words": best_match_len},
-        )
-        trimmed_words = next_words[best_match_len:]
-        return " ".join(trimmed_words)
+    if not drop:
+        return next_body
 
-    return next_body
+    logger.info("Dropped echoed turn(s) at chunk seam", extra={"turns": drop})
+    return "".join(next_turns[drop:]).lstrip("\n")

--- a/api/services/seam_coverage.py
+++ b/api/services/seam_coverage.py
@@ -16,6 +16,14 @@ Word-order trigrams are specific enough that a dropped caption scores ~0 while a
 retained-but-lightly-reflowed caption scores ~1.0 (measured on job 12: retained
 captions 1.00, dropped captions 0.00). The comparison is against a global trigram
 set, so reordering whole turns does not cause false positives.
+
+Blocking vs. detection: trigram detection cannot distinguish a genuine drop from
+a HEAVILY reconstructed caption (e.g. garbled ASR "gouess"→"guess", "yout"→"out")
+— both destroy the source word order and score ~0. So a detected gap only
+*blocks* (pauses the job) when corroborated by **net content loss**: the output
+has fewer content words than the source. A reconstruction adds content (labels,
+cleanup) so its net ratio is ≥ 1.0 → recorded but non-blocking; a real dropped
+span removes content → ratio below ``DEFAULT_BLOCKING_RATIO`` → blocking.
 """
 
 import logging
@@ -23,6 +31,7 @@ import re
 from dataclasses import dataclass, field
 from typing import List, Optional, Set, Tuple
 
+from api.services.completeness import count_content_words, count_source_words
 from api.services.utils import parse_srt
 
 logger = logging.getLogger(__name__)
@@ -35,6 +44,12 @@ DEFAULT_PER_CAPTION_FLOOR = 0.5
 # Only a contiguous run of at least this many missing captions counts as a
 # dropped section. Below this is treated as paraphrase noise, not content loss.
 DEFAULT_MIN_RUN = 4
+
+# A detected gap only *blocks* (pauses the job) when the formatter output has
+# fewer content words than the source × this ratio — corroborating that content
+# was actually lost rather than reconstructed. Reconstruction of garbled captions
+# keeps output ≥ source; a real dropped span pushes it below this.
+DEFAULT_BLOCKING_RATIO = 0.98
 
 # Trigram tokens are alphabetic runs of at least this length.
 DEFAULT_MIN_TOKEN_LEN = 3
@@ -58,10 +73,16 @@ class SeamCoverageResult:
     has_gap: bool
     dropped_spans: List[DroppedSpan] = field(default_factory=list)
     captions_checked: int = 0
+    # Output content words / source content words. < 1.0 means net content loss.
+    net_coverage_ratio: float = 1.0
+    # has_gap AND net content loss — the signal the worker pauses on.
+    blocking: bool = False
 
     def to_dict(self) -> dict:
         return {
             "has_gap": self.has_gap,
+            "blocking": self.blocking,
+            "net_coverage_ratio": round(self.net_coverage_ratio, 4),
             "captions_checked": self.captions_checked,
             "dropped_spans": [
                 {
@@ -131,6 +152,15 @@ def _caption_status(
     return coverage < floor
 
 
+def _net_coverage_ratio(source_transcript: str, formatter_output: str, is_srt: bool) -> float:
+    """Output content words / source content words (reusing the completeness
+    tokenizers so this matches the global gate's notion of 'content')."""
+    src_words = count_source_words(source_transcript, is_srt=is_srt)
+    if src_words <= 0:
+        return 1.0
+    return count_content_words(formatter_output) / src_words
+
+
 def find_dropped_spans(
     source_transcript: str,
     formatter_output: str,
@@ -138,6 +168,7 @@ def find_dropped_spans(
     min_run: int = DEFAULT_MIN_RUN,
     per_caption_floor: float = DEFAULT_PER_CAPTION_FLOOR,
     min_token_len: int = DEFAULT_MIN_TOKEN_LEN,
+    blocking_ratio: float = DEFAULT_BLOCKING_RATIO,
 ) -> SeamCoverageResult:
     """Detect contiguous source spans missing from the formatter output.
 
@@ -188,10 +219,24 @@ def find_dropped_spans(
             )
         i = j
 
+    net_ratio = _net_coverage_ratio(source_transcript, formatter_output, is_srt)
+    has_gap = bool(spans)
+    blocking = has_gap and net_ratio < blocking_ratio
+
     if spans:
         logger.warning(
             "Seam gap detected in formatter output",
-            extra={"dropped_spans": [s.start_timecode for s in spans]},
+            extra={
+                "dropped_spans": [s.start_timecode for s in spans],
+                "net_coverage_ratio": round(net_ratio, 4),
+                "blocking": blocking,
+            },
         )
 
-    return SeamCoverageResult(has_gap=bool(spans), dropped_spans=spans, captions_checked=n)
+    return SeamCoverageResult(
+        has_gap=has_gap,
+        dropped_spans=spans,
+        captions_checked=n,
+        net_coverage_ratio=net_ratio,
+        blocking=blocking,
+    )

--- a/api/services/style_engine/lint.py
+++ b/api/services/style_engine/lint.py
@@ -602,7 +602,11 @@ def _check_seam_coverage_gate(context: Mapping[str, Any], phase: str) -> list[Ru
     seam = context.get("seam_coverage")
     if not isinstance(seam, Mapping):
         return []
-    if not seam.get("has_gap", False):
+    # Only flag a gap the worker would actually act on: one corroborated by net
+    # content loss (blocking). A detected-but-non-blocking gap is the garbled-ASR
+    # reconstruction false positive (see seam_coverage.py) -- recording it as a
+    # validator flag would just resurface the noise this pipeline silences.
+    if not seam.get("blocking", False):
         return []
 
     dropped_spans = seam.get("dropped_spans")

--- a/api/services/style_engine/post_stage.py
+++ b/api/services/style_engine/post_stage.py
@@ -117,6 +117,32 @@ from api.services.utils import get_srt_duration, parse_srt
 _GUARD_MIN_RATIO = 0.995
 _GUARD_MAX_RATIO = 1.005
 
+# Trailing characters trimmed before appending the ellipsis so a truncated
+# description doesn't end on a dangling comma/dash.
+_TRUNCATE_TRIM = " ,;:—-"
+
+
+def _truncate_to_limit(value: str, max_len: int) -> str:
+    """Truncate ``value`` to at most ``max_len`` chars at a word boundary + "…".
+
+    Returns ``value`` unchanged when already within ``max_len``. Reserves one
+    char for the ellipsis and backs off to the last whitespace so a word is
+    never cut mid-token (unless the first token alone already exceeds the
+    budget, in which case it hard-cuts that token). The result is always
+    ``<= max_len`` characters.
+    """
+    if len(value) <= max_len:
+        return value
+    budget = max_len - 1  # reserve one char for the ellipsis
+    head = value[:budget]
+    trimmed = head.rstrip()
+    if " " in trimmed:
+        head = trimmed[: trimmed.rfind(" ")]
+    head = head.rstrip(_TRUNCATE_TRIM)
+    if not head:  # a single token longer than the whole budget
+        head = value[:budget].rstrip()
+    return head + "…"
+
 
 def run_post_stage(phase: str, raw_output: str, context: Mapping[str, Any], rules: StyleRules) -> PostStageResult:
     """Normalize (enforce tier) then validate (flag tier) one phase's raw LLM output.
@@ -189,32 +215,49 @@ def run_post_stage(phase: str, raw_output: str, context: Mapping[str, Any], rule
 
     analyst_output = context.get("analyst_output") or ""
     canonical = build_canonical(rules, extract_proper_nouns(analyst_output, rules.surname_stoplist()))
+    program = context.get("program")
+    content_type = context.get("content_type") or "full"
+    limits = rules.limits_for(program, content_type)
+
+    # Enforce tier: down-style the TITLE casing and truncate over-limit
+    # DESCRIPTIONS to their hard character budget. Both are spliced back by
+    # exact span in a single pass over the original document, so the
+    # Recommended value -- the only text the SST write path consumes -- is
+    # always length-compliant.
+    replacements: dict[str, str] = {}
+    fixes: list[AppliedFix] = []
 
     raw_title = fields.title.value
     normalized_title = to_down_style(raw_title, canonical)
-    changed = normalized_title != raw_title
+    if normalized_title != raw_title:
+        replacements["title"] = normalized_title
+        fixes.append(AppliedFix(rule_id="casing.down_style.title", before=raw_title, after=normalized_title))
 
-    fixes: list[AppliedFix] = []
-    if changed:
-        normalized_output = splice_seo_fields(raw_output, fields, {"title": normalized_title})
-        fixes.append(
-            AppliedFix(
-                rule_id="casing.down_style.title",
-                before=raw_title,
-                after=normalized_title,
-            )
-        )
-    else:
-        normalized_output = raw_output
+    for field_name, span in (
+        ("short_description", fields.short_description),
+        ("long_description", fields.long_description),
+    ):
+        if span is None:
+            continue
+        max_len = (limits.get(field_name) or {}).get("max")
+        if not isinstance(max_len, int):
+            continue
+        truncated = _truncate_to_limit(span.value, max_len)
+        if truncated != span.value:
+            replacements[field_name] = truncated
+            fixes.append(AppliedFix(rule_id=f"limits.{field_name}.truncated", before=span.value, after=truncated))
 
-    program = context.get("program")
-    content_type = context.get("content_type") or "full"
+    changed = bool(replacements)
+    normalized_output = splice_seo_fields(raw_output, fields, replacements) if changed else raw_output
 
-    final_values: dict[str, str] = {"title": normalized_title}
+    # Flag tier runs over the post-enforcement values (limits now satisfied for
+    # any field we truncated; a still-over field would only occur if it had no
+    # configured max).
+    final_values: dict[str, str] = {"title": replacements.get("title", raw_title)}
     if fields.short_description is not None:
-        final_values["short_description"] = fields.short_description.value
+        final_values["short_description"] = replacements.get("short_description", fields.short_description.value)
     if fields.long_description is not None:
-        final_values["long_description"] = fields.long_description.value
+        final_values["long_description"] = replacements.get("long_description", fields.long_description.value)
 
     violations = list(check_field_limits(final_values, rules, phase, program=program, content_type=content_type))
     for field_name, value in final_values.items():

--- a/api/services/style_engine/post_stage.py
+++ b/api/services/style_engine/post_stage.py
@@ -5,9 +5,10 @@ Runs after a phase's LLM call returns raw markdown. Two tiers, never
 conflated:
 
 - **Enforce tier** -- deterministic rewrites that never change meaning. For
-  ``seo`` this is limited to down-styling the TITLE field's casing (spliced
-  back into the document via its exact span). Nothing else is ever rewritten
-  here.
+  ``seo`` this is down-styling the TITLE field's casing and truncating an
+  over-limit ``short_description``/``long_description`` to its hard character
+  budget at a word boundary (both spliced back into the document via their
+  exact spans). No other field or text is rewritten here.
 - **Flag tier** -- everything else (over-limit text, forbidden phrases,
   first/second-person voice) is detection-only. Violations are surfaced as
   ``RuleViolation``s for a human or a later model-fixable pass; this module

--- a/api/services/worker.py
+++ b/api/services/worker.py
@@ -1089,7 +1089,11 @@ Extract any name or spelling corrections that should be added to the glossary. S
                 # ratio can't see (issue #269). Runs only if the completeness
                 # check above didn't already pause the job.
                 if phase_name == "formatter" and not truncation_paused:
-                    from api.services.seam_coverage import find_dropped_spans, format_gap_message
+                    from api.services.seam_coverage import (
+                        DEFAULT_BLOCKING_RATIO,
+                        find_dropped_spans,
+                        format_gap_message,
+                    )
 
                     seam_config = self.llm.config.get("routing", {}).get("seam_coverage", {})
                     if seam_config.get("enabled", True):
@@ -1103,37 +1107,44 @@ Extract any name or spelling corrections that should be added to the glossary. S
                             is_srt=is_srt,
                             min_run=seam_config.get("min_run", 4),
                             per_caption_floor=seam_config.get("per_caption_floor", 0.5),
+                            blocking_ratio=seam_config.get("blocking_ratio", DEFAULT_BLOCKING_RATIO),
                         )
 
                         context["seam_coverage"] = seam.to_dict()
 
                         if seam.has_gap:
-                            gap_msg = format_gap_message(seam)
                             logger.warning(
                                 "Seam gap detected in formatter output",
                                 extra={
                                     "job_id": job_id,
+                                    "blocking": seam.blocking,
+                                    "net_coverage_ratio": seam.net_coverage_ratio,
                                     "dropped_spans": seam.to_dict()["dropped_spans"],
                                 },
                             )
-                            await log_event(
-                                EventCreate(
-                                    job_id=job_id,
-                                    event_type=EventType.phase_failed,
-                                    data=EventData(
-                                        phase="seam_coverage",
-                                        extra=seam.to_dict(),
-                                    ),
+                            # Only pause on a gap corroborated by net content loss
+                            # (blocking). A gap with no net loss is the formatter
+                            # reconstructing garbled captions, not real content loss
+                            # — record it (context["seam_coverage"]) but proceed.
+                            if seam.blocking:
+                                await log_event(
+                                    EventCreate(
+                                        job_id=job_id,
+                                        event_type=EventType.phase_failed,
+                                        data=EventData(
+                                            phase="seam_coverage",
+                                            extra=seam.to_dict(),
+                                        ),
+                                    )
                                 )
-                            )
-                            if seam_config.get("pause_on_gap", True):
-                                await update_job_status(
-                                    job_id,
-                                    JobStatus.paused,
-                                    error_message=gap_msg,
-                                )
-                                truncation_paused = True
-                                break  # Exit phase loop cleanly (no exception)
+                                if seam_config.get("pause_on_gap", True):
+                                    await update_job_status(
+                                        job_id,
+                                        JobStatus.paused,
+                                        error_message=format_gap_message(seam),
+                                    )
+                                    truncation_paused = True
+                                    break  # Exit phase loop cleanly (no exception)
 
             # Handle truncation pause — exit before optional phases
             if truncation_paused:

--- a/config/llm-config.json
+++ b/config/llm-config.json
@@ -156,7 +156,8 @@
       "enabled": true,
       "min_run": 4,
       "per_caption_floor": 0.5,
-      "pause_on_gap": true
+      "pause_on_gap": true,
+      "blocking_ratio": 0.98
     },
     "speaker_segmentation": {
       "enabled": true
@@ -174,15 +175,15 @@
       "ceiling_hours": 6
     },
     "style_engine": {
-      "enabled": false,
+      "enabled": true,
       "rules_file": "config/house_style.yaml",
       "keep_raw_on_fix": true,
       "phases": {
-        "analyst":   {"pre": false, "post": "off"},
-        "formatter": {"pre": false, "post": "off"},
-        "seo":       {"pre": false, "post": "off"},
-        "validator": {"pre": false, "lint": "off"},
-        "timestamp": {"pre": false, "post": "off"}
+        "analyst":   {"pre": true, "post": "off"},
+        "formatter": {"pre": true, "post": "off"},
+        "seo":       {"pre": true, "post": "off"},
+        "validator": {"pre": true, "lint": "off"},
+        "timestamp": {"pre": true, "post": "off"}
       },
       "qa_gate": {"merge_flags": true, "fail_on_error": true}
     }

--- a/tests/api/test_chunking.py
+++ b/tests/api/test_chunking.py
@@ -447,3 +447,25 @@ class TestDedupSeamTurns:
         prev = "**Alice:**  \nOne.\n\n**Bob:**  \nTwo."
         nxt = "**Carol:**  \nThree.\n\n**Dave:**  \nFour."
         assert _dedup_seam_turns(prev, nxt) == nxt
+
+    def test_drops_multi_turn_contiguous_echo(self):
+        """A 2+ turn contiguous echo (prev's tail re-emitted as next's head) is
+        fully dropped, leaving only the genuinely new content."""
+        prev = "**Alice:**  \nFirst point here.\n\n**Bob:**  \nSecond point here."
+        nxt = "**Alice:**  \nFirst point here.\n\n**Bob:**  \nSecond point here.\n\n" "**Carol:**  \nBrand new content."
+        out = _dedup_seam_turns(prev, nxt)
+        assert out.count("First point here") == 0
+        assert out.count("Second point here") == 0
+        assert "Brand new content" in out
+        assert out.strip().startswith("**Carol:**")
+
+    def test_backchannel_matching_non_seam_turn_is_kept(self):
+        """A leading turn that matches a prev turn NOT at the seam (a "Right."
+        backchannel said a few turns earlier) is kept — the match must anchor at
+        prev's actual tail, so it is not misclassified as an echo."""
+        prev = (
+            "**Alice:**  \nRight.\n\n**Bob:**  \nThe vote finally passed today.\n\n"
+            "**Carol:**  \nA major milestone indeed."
+        )
+        nxt = "**Dave:**  \nRight.\n\n**Erin:**  \nOn to the next agenda item."
+        assert _dedup_seam_turns(prev, nxt) == nxt  # nothing dropped

--- a/tests/api/test_chunking.py
+++ b/tests/api/test_chunking.py
@@ -1,11 +1,15 @@
 """Tests for transcript chunking (split + merge)."""
 
 from api.services.chunking import (
+    _choose_break_idx,
+    _dedup_seam_turns,
+    _split_into_turns,
     _split_plain_text,
     _split_srt,
     merge_formatter_chunks,
     split_transcript,
 )
+from api.services.utils import parse_srt
 
 # ─── Helpers ───────────────────────────────────────────────────────────
 
@@ -41,6 +45,28 @@ def make_plain_text(num_paragraphs: int, words_per_paragraph: int = 100) -> str:
         words = [f"word{j}" for j in range(words_per_paragraph)]
         paragraphs.append(" ".join(words))
     return "\n\n".join(paragraphs)
+
+
+def make_turn_srt(num_captions: int, words_per_caption: int = 30, turn_every: int = 10) -> str:
+    """SRT where every ``turn_every``-th caption (0-based) opens a new turn (``>>``).
+
+    Mirrors a live-caption transcript after ``split_interior_speaker_changes``,
+    where every ``>>`` marker is caption-leading.
+    """
+    lines = []
+    for i in range(1, num_captions + 1):
+        start_ms = (i - 1) * 3000
+        end_ms = i * 3000
+        h1, m1, s1 = start_ms // 3600000, (start_ms % 3600000) // 60000, (start_ms % 60000) // 1000
+        h2, m2, s2 = end_ms // 3600000, (end_ms % 3600000) // 60000, (end_ms % 60000) // 1000
+        text = " ".join(f"word{j}" for j in range(words_per_caption))
+        if (i - 1) % turn_every == 0:  # caption opens a new speaker turn
+            text = ">> " + text
+        lines.append(str(i))
+        lines.append(f"{h1:02d}:{m1:02d}:{s1:02d},000 --> {h2:02d}:{m2:02d}:{s2:02d},000")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines)
 
 
 # ─── split_transcript tests ───────────────────────────────────────────
@@ -343,3 +369,81 @@ Second body."""
         assert "Here is the second chunk" not in result
         assert "Dialogue" in result
         assert "More dialogue" in result
+
+
+# ─── turn-boundary split tests ────────────────────────────────────────
+
+
+class TestTurnBoundarySplit:
+    def test_chunks_start_at_turn_boundary(self):
+        """The first continuation chunk begins cleanly on a new speaker turn."""
+        srt = make_turn_srt(40, words_per_caption=30, turn_every=10)
+        chunks = _split_srt(srt, target_chunk_words=500, overlap_captions=0)
+        assert chunks is not None and len(chunks) >= 2
+        first_caption = parse_srt(chunks[1].content)[0]
+        assert first_caption.text.lstrip().startswith(
+            ">>"
+        ), f"continuation chunk starts mid-turn: {first_caption.text!r}"
+
+    def test_choose_break_prefers_turn_boundary(self):
+        """_choose_break_idx ends just before the next >> caption."""
+        caps = parse_srt(make_turn_srt(30, words_per_caption=5, turn_every=6))
+        # Turn-start captions are 0-based indices 0, 6, 12, ... From i=2 the next
+        # turn start is index 6, so the break lands at 5 (its predecessor).
+        idx = _choose_break_idx(caps, 2)
+        assert idx == 5
+        assert caps[idx + 1].text.lstrip().startswith(">>")
+
+    def test_choose_break_falls_back_to_sentence(self):
+        """With no >> markers, fall back to sentence-ending punctuation."""
+        caps = parse_srt(make_srt(30, words_per_caption=5))  # 'end.' every 5th caption
+        idx = _choose_break_idx(caps, 1)
+        assert caps[idx].text.strip().endswith(".")
+
+    def test_scripted_no_markers_still_splits(self):
+        """Transcripts with zero >> markers still chunk (sentence fallback)."""
+        srt = make_srt(400, words_per_caption=10)  # 4000 words, no >>
+        chunks = _split_srt(srt, target_chunk_words=1500, overlap_captions=5)
+        assert chunks is not None and len(chunks) >= 2
+
+
+# ─── turn-aware seam dedup tests ──────────────────────────────────────
+
+
+class TestDedupSeamTurns:
+    def test_split_into_turns(self):
+        body = "leading note\n\n**Alice:**  \nHi there.\n\n**Bob:**  \nYo."
+        turns = _split_into_turns(body)
+        assert turns[0].strip() == "leading note"
+        assert turns[1].startswith("**Alice:**")
+        assert turns[2].startswith("**Bob:**")
+
+    def test_drops_echoed_leading_turn(self):
+        """A leading turn echoing the previous chunk's tail is dropped once."""
+        prev = "**Alice:**  \nHello there, everyone.\n\n**Bob:**  \nGood to be here."
+        nxt = "**Bob:**  \nGood to be here.\n\n**Alice:**  \nLet's begin the discussion."
+        merged = merge_formatter_chunks([prev, nxt])
+        assert merged.count("Good to be here") == 1
+        assert "Let's begin the discussion" in merged
+        assert "**Alice:**" in merged and "**Bob:**" in merged
+
+    def test_preserves_distinct_turns(self):
+        """No echo -> nothing dropped; all dialogue preserved."""
+        prev = "**Alice:**  \nFirst statement here.\n\n**Bob:**  \nSecond statement here."
+        nxt = "**Carol:**  \nThird distinct statement.\n\n**Dave:**  \nFourth distinct statement."
+        merged = merge_formatter_chunks([prev, nxt])
+        for snippet in ("First statement", "Second statement", "Third distinct", "Fourth distinct"):
+            assert snippet in merged
+
+    def test_never_flattens_structure(self):
+        """Kept turns retain label-on-line structure (regression: old trim flattened)."""
+        prev = "**Alice:**  \nEcho line one.\n\n**Bob:**  \nEcho line two."
+        nxt = "**Bob:**  \nEcho line two.\n\n**Carol:**  \nKept line with structure."
+        merged = merge_formatter_chunks([prev, nxt])
+        assert "**Carol:**  \nKept line with structure." in merged
+
+    def test_no_false_dedup_direct(self):
+        """_dedup_seam_turns returns next_body unchanged when no leading echo."""
+        prev = "**Alice:**  \nOne.\n\n**Bob:**  \nTwo."
+        nxt = "**Carol:**  \nThree.\n\n**Dave:**  \nFour."
+        assert _dedup_seam_turns(prev, nxt) == nxt

--- a/tests/api/test_worker.py
+++ b/tests/api/test_worker.py
@@ -965,6 +965,90 @@ class TestProcessJobSeamGap:
             "SEAM GAP DETECTED" in str(c.kwargs.get("error_message", "")) for c in paused
         ), "paused status should carry the SEAM GAP message"
 
+    def _formatter_output_gap_no_net_loss(self) -> str:
+        """Same dropped block, but padded so total content words exceed the
+        source — a reconstruction/expansion, not a real loss."""
+        kept = [t for i, t in enumerate(self._CAPTIONS) if i not in self._DROPPED]
+        body = "\n\n".join(f"**Speaker:** {t}." for t in kept)
+        padding = " ".join(["reconstructed"] * 60)
+        return (
+            "<!-- model: test -->\n# Formatted Transcript\n**Project:** Test\n---\n\n"
+            f"{body}\n\n**Speaker:** {padding}.\n\n**Status:** ready_for_editing"
+        )
+
+    @pytest.mark.asyncio
+    @patch("api.services.worker.get_llm_client")
+    @patch("api.services.worker.update_job_status")
+    @patch("api.services.worker.update_job_phase")
+    @patch("api.services.worker.update_job_heartbeat")
+    @patch("api.services.worker.log_event")
+    @patch("api.services.worker.start_run_tracking")
+    @patch("api.services.worker.end_run_tracking")
+    @patch("api.services.worker.TRANSCRIPTS_DIR")
+    @patch("api.services.worker.OUTPUT_DIR")
+    @patch("api.services.worker.AGENTS_DIR")
+    async def test_seam_gap_without_net_loss_does_not_pause(
+        self,
+        mock_agents_dir,
+        mock_output_dir,
+        mock_transcripts_dir,
+        mock_end_tracking,
+        mock_start_tracking,
+        mock_log_event,
+        mock_update_heartbeat,
+        mock_update_phase,
+        mock_update_status,
+        mock_get_llm,
+        mock_llm_client,
+        tmp_path,
+    ):
+        """A detected seam gap with NO net content loss (the garbled-ASR
+        reconstruction false positive) is non-blocking: the job must NOT be
+        paused with a SEAM GAP message. This is the exact behavior the blocking
+        guard adds — the unit-level coverage is in test_seam_coverage.py; this
+        asserts it end-to-end at the worker."""
+        mock_get_llm.return_value = mock_llm_client
+
+        response = MagicMock()
+        response.content = self._formatter_output_gap_no_net_loss()
+        response.cost = 0.001
+        response.total_tokens = 500
+        response.model = "test-model"
+        mock_llm_client.chat = AsyncMock(return_value=response)
+
+        mock_update_status.return_value = None
+        mock_update_phase.return_value = None
+        mock_update_heartbeat.return_value = None
+        mock_log_event.return_value = None
+        mock_start_tracking.return_value = MagicMock(total_cost=0, total_tokens=0)
+        mock_end_tracking.return_value = {"total_cost": 0.01, "total_tokens": 2000}
+
+        mock_transcripts_dir.__truediv__ = lambda self, name: tmp_path / name
+        mock_output_dir.__truediv__ = lambda self, name: tmp_path / name
+        mock_agents_dir.__truediv__ = lambda self, name: tmp_path / name
+
+        job = {
+            "id": 100,
+            "project_name": "Seam Nonblock",
+            "transcript_file": "seamtest.srt",
+            "status": "in_progress",
+            "priority": 10,
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "phases": [],
+        }
+        (tmp_path / job["transcript_file"]).write_text(self._source_srt(), encoding="utf-8")
+
+        worker = JobWorker()
+        await worker.process_job(job)
+
+        seam_pauses = [
+            c
+            for c in mock_update_status.call_args_list
+            if getattr(c.args[1], "value", c.args[1]) == "paused"
+            and "SEAM GAP" in str(c.kwargs.get("error_message", ""))
+        ]
+        assert not seam_pauses, "a corroboration-free seam gap must not pause the job"
+
 
 class TestProcessJobSpeakerSegmentation:
     """Worker-level test that interior `>>` markers are split before the formatter

--- a/tests/test_seam_coverage.py
+++ b/tests/test_seam_coverage.py
@@ -160,6 +160,41 @@ def test_recurring_topic_words_do_not_mask_a_drop():
     assert result.dropped_spans[0].caption_count == 4
 
 
+def test_gap_with_net_content_loss_is_blocking():
+    """A real dropped span (output shorter than source) blocks the job."""
+    src = _srt(CAPTIONS)
+    kept = [0, 1, 2, 3, 8, 9, 10, 11]  # drop the four middle captions (4,5,6,7)
+    out = _output_from(kept)  # no compensating content -> net loss
+
+    result = find_dropped_spans(src, out, is_srt=True, min_run=4)
+
+    assert result.has_gap is True
+    assert result.net_coverage_ratio < 1.0
+    assert result.blocking is True
+
+
+def test_gap_without_net_loss_is_detected_but_not_blocking():
+    """A gap the trigram check flags but with NO net content loss (the garbled-ASR
+    reconstruction false positive) is recorded but does not block the job."""
+    src = _srt(CAPTIONS)
+    kept = [0, 1, 2, 3, 8, 9, 10, 11]  # same 4-caption trigram gap
+    body = "\n\n".join(f"**Speaker:**\n{CAPTIONS[i]}." for i in kept)
+    # Pad so total content words exceed the source (formatter reconstructing /
+    # expanding rather than dropping) -- distinct filler that carries none of the
+    # dropped captions' trigrams, so detection still fires.
+    padding = " ".join(["reconstructed"] * 120)
+    out = (
+        "<!-- model: test -->\n# Formatted Transcript\n**Project:** Test\n---\n\n"
+        f"{body}\n\n**Speaker:**\n{padding}.\n\n**Status:** ready_for_editing"
+    )
+
+    result = find_dropped_spans(src, out, is_srt=True, min_run=4)
+
+    assert result.has_gap is True  # trigram detection still fires on the gap
+    assert result.net_coverage_ratio >= 1.0
+    assert result.blocking is False  # but no net loss -> non-blocking
+
+
 def test_non_srt_and_empty_input_are_graceful():
     """Non-SRT or empty source returns a no-gap result rather than raising."""
     assert find_dropped_spans("", "", is_srt=True).has_gap is False

--- a/tests/test_style_lint.py
+++ b/tests/test_style_lint.py
@@ -950,6 +950,7 @@ def _seam_coverage(
     has_gap: bool = True,
     dropped_spans: list[dict] | None = None,
     captions_checked: int = 120,
+    blocking: bool | None = None,
 ) -> dict:
     if dropped_spans is None:
         dropped_spans = [
@@ -960,8 +961,12 @@ def _seam_coverage(
                 "sample_text": "the budget conference committee reached agreement late",
             }
         ]
+    if blocking is None:
+        blocking = has_gap  # a real drop (net content loss) blocks by default
     return {
         "has_gap": has_gap,
+        "blocking": blocking,
+        "net_coverage_ratio": 0.9 if blocking else 1.05,
         "dropped_spans": dropped_spans,
         "captions_checked": captions_checked,
     }
@@ -992,6 +997,17 @@ class TestSeamCoverageGateConsumption:
         context = {
             "formatter_output": _formatter_output(),
             "seam_coverage": _seam_coverage(has_gap=False, dropped_spans=[]),
+        }
+        result = run_lint(context, rules)
+        assert _violations_for(result, "formatter", "lint.formatter.seam_gap") == []
+
+    def test_non_blocking_gap_does_not_fire(self):
+        """A detected but non-blocking gap (reconstruction, no net content loss)
+        must NOT surface as a validator flag — matches the worker's pause gate."""
+        rules = _rules()
+        context = {
+            "formatter_output": _formatter_output(),
+            "seam_coverage": _seam_coverage(has_gap=True, blocking=False),
         }
         result = run_lint(context, rules)
         assert _violations_for(result, "formatter", "lint.formatter.seam_gap") == []

--- a/tests/test_style_stages.py
+++ b/tests/test_style_stages.py
@@ -364,21 +364,6 @@ class TestPostStageEndToEndNormalize:
 
 
 class TestPostStageFlagTierNeverRewrites:
-    def test_over_limit_short_description_flagged_not_modified(self):
-        rules = _post_rules(short_max=90)
-        raw_title = "Wisconsin Governor signs new budget bill in Madison"
-        over_limit_short_desc = "x" * 150
-        raw_output = _seo_report(raw_title, short_description=over_limit_short_desc)
-
-        result = run_post_stage("seo", raw_output, {}, rules)
-
-        limit_violations = [v for v in result.check.violations if v.rule_id == "limits.short_description.max"]
-        assert len(limit_violations) == 1
-        assert limit_violations[0].severity == "error"
-
-        reparsed = extract_seo_fields(result.normalized_output)
-        assert reparsed.short_description.value == over_limit_short_desc
-
     def test_forbidden_phrase_in_title_flagged_but_word_kept(self):
         rules = _post_rules()
         raw_title = "Discover Wisconsin's Budget Story"
@@ -414,6 +399,62 @@ class TestPostStageFlagTierNeverRewrites:
         title_violations = [v for v in result.check.violations if v.rule_id == "limits.title.max"]
         assert len(title_violations) == 1
         assert "10" in title_violations[0].message
+
+
+class TestPostStageSeoLengthEnforcement:
+    """seo over-limit descriptions are truncated to fit (enforce tier), so the
+    Recommended value the SST write path consumes is always length-compliant."""
+
+    def test_over_limit_short_description_truncated(self):
+        rules = _post_rules(short_max=90)
+        over = (
+            "Ojibwe dancer and designer Aerius Benton-Banai shares how jingle dress dancing healed her whole community."
+        )
+        assert len(over) > 90
+        raw_output = _seo_report("A down-style title", short_description=over)
+
+        result = run_post_stage("seo", raw_output, {}, rules)
+
+        final = extract_seo_fields(result.normalized_output).short_description.value
+        assert len(final) <= 90
+        assert final.endswith("…")
+        assert final[:-1] in over  # a clean prefix of the original — never reworded
+        assert "limits.short_description.truncated" in [f.rule_id for f in result.check.fixes]
+        assert [v for v in result.check.violations if v.rule_id == "limits.short_description.max"] == []
+        assert result.changed is True
+
+    def test_over_limit_long_description_truncated(self):
+        rules = _post_rules(long_max=120)
+        over = ("word " * 40).strip()  # ~195 chars
+        raw_output = _seo_report("A title", long_description=over)
+
+        result = run_post_stage("seo", raw_output, {}, rules)
+
+        final = extract_seo_fields(result.normalized_output).long_description.value
+        assert len(final) <= 120
+        assert "limits.long_description.truncated" in [f.rule_id for f in result.check.fixes]
+        assert [v for v in result.check.violations if v.rule_id == "limits.long_description.max"] == []
+
+    def test_within_limit_description_untouched(self):
+        rules = _post_rules(short_max=90)
+        ok = "A short, compliant description of the episode."
+        raw_output = _seo_report("A title", short_description=ok)
+
+        result = run_post_stage("seo", raw_output, {}, rules)
+
+        final = extract_seo_fields(result.normalized_output).short_description.value
+        assert final == ok
+        assert [f for f in result.check.fixes if "truncated" in f.rule_id] == []
+
+    def test_single_long_token_hard_cut(self):
+        rules = _post_rules(short_max=20)
+        raw_output = _seo_report("A title", short_description="x" * 150)  # no word boundaries
+
+        result = run_post_stage("seo", raw_output, {}, rules)
+
+        final = extract_seo_fields(result.normalized_output).short_description.value
+        assert len(final) <= 20
+        assert final.endswith("…")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Hardens the chunked-formatter + style-engine pipeline against spurious job pauses
on long transcripts. Two failure modes were driving pauses:

1. **Seam-coverage false positives** — the trigram gate flagged "dropped" spans
   when the formatter legitimately reconstructed garbled ASR (word order changes),
   pausing good jobs. On `6POL0114CLEAN` this fired on every run.
2. **Over-limit SEO descriptions** — the LLM emits descriptions past the 90/350
   char SST limits, failing the validator.

## Changes

**Seam robustness** (`api/services/chunking.py`)
- Split chunks at speaker-turn boundaries (leading `>>`) instead of mid-turn, so a
  seam never forces the next chunk to re-guess the speaker (fixes speaker-label
  breakdown at seams). Sentence-boundary fallback for scripted transcripts.
- Replace the fuzzy word-window `_trim_overlap` (which flattened structure and
  could over-trim real dialogue) with a structural, turn-aware seam dedup.

**Seam-coverage blocking guard** (`api/services/seam_coverage.py`, `worker.py`)
- Detection is unchanged (still catches real drops, incl. recurring-topic-word
  cases). A gap now only **blocks** (pauses) when corroborated by net content loss
  (`output content words < source × blocking_ratio`, default `0.98`). A gap with no
  net loss — the garbled-reconstruction false positive — is recorded but
  non-blocking.

**SEO length enforcement** (`api/services/style_engine/post_stage.py`)
- Over-limit short/long `**Recommended:**` descriptions are truncated to their hard
  budget at a word boundary (+ `…`) and spliced back, so the value the SST write
  path consumes is always compliant. Raw archived via `keep_raw_on_fix`.

**Prevention layer** (`config/llm-config.json`)
- Enable the already-built pre-stages for all phases (`pre: true`) — hard budgets /
  authoritative names / voice rules are injected into every agent's prompt.
  Post/lint stay **off**; enforce activation remains a separate operational ramp.

## Verification

- Full suite: **1625 passed, 5 xfailed**. New tests cover turn-boundary split,
  structural dedup, blocking vs non-blocking gap, and description truncation.
- **E2E** (4 transcripts, real LLM): **0/4 paused on the seam gate** (vs
  `6POL0114CLEAN` pausing on it every prior run); all descriptions compliant
  (78–88 ≤ 90, 340–346 ≤ 350); `6POL0201` went paused → **completed**.

## Known follow-up — #309 (high priority)

Truncating the `Recommended` value does **not** by itself stop the validator QA
pause: the LLM's seo doc still carries stale self-annotations (Character-Count
lines, Note-on-Truncation, Alternatives, "revised" versions) that the validator
reads and fails on. Collapsing the seo doc to a single authoritative value is the
real fix and is tracked in #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
