### PR TITLE
fix(deps): pin mcp<2.0.0 to unbreak CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,9 @@ black>=23.12.0
 watchfiles>=1.2.0
 
 # MCP Server (for Claude Desktop integration)
-mcp>=1.27.0
+# Upper bound is load-bearing: 2.0.0 (2026-07-28) removed Server.list_tools.
+# Lift it only alongside the 2.x migration — see issue #321.
+mcp>=1.27.0,<2.0.0
 sse-starlette>=2.0.0
 
 # Google Drive integration (optional — only needed when Drive export is configured)


### PR DESCRIPTION
Closes the CI outage described in #321.

## What

One line in `requirements.txt`:

```diff
-mcp>=1.27.0
+mcp>=1.27.0,<2.0.0
```

plus a comment saying why the bound is load-bearing.

## Why

`mcp 2.0.0` was published **2026-07-28 13:45 UTC**. The pin had no upper bound, so every fresh CI install since then resolves to 2.0.0, which removed `Server.list_tools`. `Python Tests` currently fails on **every branch, main included** — three collection errors:

```
ERROR tests/mcp_server/test_mmingest_tools.py - AttributeError: 'Server' object has no attribute 'list_tools'
ERROR tests/test_mcp_tools.py                 - AttributeError: 'Server' object has no attribute 'list_tools'
ERROR tests/test_house_style_config.py        - ValueError: malformed node or string on line 172
```

The third is downstream of the first two: once `import mcp_server.server` fails, that test falls through to its AST-parsing path, which chokes on `WRITABLE_FIELDS` values (`_CHAR_LIMITS["title"]` is an `ast.Subscript`, not a literal — introduced by #295). That fallback path had never been exercised before.

## Verification

Environmental, not a code regression:

- All three files pass locally against `mcp 1.27.2` → **109 passed**
- PRs #302, #303, #301, #293 were all green when they merged — all before 2.0.0 shipped
- #316 was green 2026-07-27, went red 2026-07-29 on a base update, with a diff touching none of the three files nor `mcp_server/server.py`

## Scope

Deliberately a stopgap. Migrating to MCP SDK 2.x is a real breaking-API change and stays in #321. Also worth a separate look: other unbounded pins in `requirements.txt` will recur this way.

Found while trying to land #316, which this unblocks.