### PR TITLE
chore: gitignore per-machine Claude Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ logs/
 .worktrees/
 .claude/worktrees/
 
+# Per-machine Claude Code settings — local overrides, never shared
+.claude/settings.json
+.claude/settings.local.json
+
 # Database snapshots — keep directory, ignore contents except gitkeep and the v2.1 archive
 .snapshots/*
 !.snapshots/.gitkeep


### PR DESCRIPTION
Closes #325.

## What

Adds `.claude/settings.json` and `.claude/settings.local.json` to `.gitignore`.

## Why

`.gitignore` already covered `.claude/worktrees/` but not the settings files, so local Claude Code config showed up as an untracked file on every `git status`.

`/start` and `/wrap-up` both treat a dirty working tree as diagnostic signal that the previous session did not close cleanly. A file that is *permanently* untracked makes that signal noisy — every session opens with drift that is not drift, which trains the check to be ignored. This session hit exactly that: the invariant check flagged `?? .claude/` on a freshly-reconciled `main`.

## Scope

`.gitignore` only, 4 lines added. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)