### PR TITLE
chore(agents): scaffold per-repo agent docs for the engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,22 @@ PBS Wisconsin content editors who use Cardigan as one tool among many in their d
 4. **Don't break the API contract** - OpenAPI spec is the source of truth (once defined)
 5. **Log feedback** - Append issues to `AGENT-FEEDBACK.md` if created
 6. **NEVER write to Airtable** - Read-only access for all AI agents
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `public-media-work/cardigan` (via the `gh` CLI).
+See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, used verbatim: `needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human`, `wontfix`. The repo's older
+`executor: *` pair is legacy and is being migrated off.
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` + `docs/adr/` at the repo root.
+See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,49 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+> **Note:** this repo's remote is `public-media-work/cardigan`, not `mriechers/cardigan`.
+> Any `gh --repo mriechers/cardigan` invocation is pointed at the wrong place. (The
+> GHCR image prefix `ghcr.io/mriechers/cardigan` is a separate, still-current path.)
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,32 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Legacy vocabulary (transitioning away)
+
+This repo predates these labels and carries its own routing pair —
+`executor: agent` / `executor: human`, plus `executor: either` — which overlaps
+`ready-for-agent` / `ready-for-human`.
+
+**The canonical five above are authoritative for new triage.** The `executor: *`
+labels are legacy: migrate off them as issues are touched, and don't apply them
+to new issues. `executor: either` has no canonical equivalent — an issue that
+could go either way is simply `ready-for-agent` (an agent may take it) or
+`ready-for-human` (it needs judgment), so pick the one that reflects the actual
+routing decision rather than deferring it.
+
+The repo's other label families are orthogonal to triage and stay as they are:
+`type: *`, `priority: *`, `review: *`, `ship: *`, and topic labels
+(`infrastructure`, `container`, `python`, `tech-debt`, …).


### PR DESCRIPTION
Scaffolds the per-repo configuration the mattpocock engineering skills expect, via `/setup-matt-pocock-skills`. Docs and one `CLAUDE.md` block — no code, no behavior change.

## What's here

| File | Contents |
|---|---|
| `docs/agents/issue-tracker.md` | GitHub via the `gh` CLI; PRs-as-request-surface **off** |
| `docs/agents/triage-labels.md` | The five canonical triage roles, verbatim |
| `docs/agents/domain.md` | Single-context layout — `CONTEXT.md` + `docs/adr/` at the root |
| `CLAUDE.md` | New `## Agent skills` section pointing at the three |

Exploration settled two of the three setup questions without asking: the GitHub remote picks the tracker, and the absence of any monorepo signal (`pnpm-workspace.yaml`, a `workspaces` field, `packages/*`) picks single-context. Both `CLAUDE.md` and `AGENTS.md` exist; per the skill's rule, only `CLAUDE.md` was edited.

## Decisions worth flagging

**Triage labels: the canonical five, not a mapping.** This repo already has 33 labels, including `executor: agent` / `executor: human` / `executor: either`, which overlap `ready-for-agent` / `ready-for-human`. Rather than map the skills onto the existing vocabulary, the decision was to adopt the standard five and treat `executor: *` as legacy to migrate off as issues are touched. That's recorded in `triage-labels.md` so the overlap isn't rediscovered later. The five labels were created on the repo to match.

**The remote is `public-media-work/cardigan`.** `issue-tracker.md` notes this explicitly, because the workspace `CLAUDE.md` maps this submodule to `mriechers/cardigan` (filed as public-media-work/pbswi#211) in the very table agents consult to get `gh --repo` right. The note also records that `ghcr.io/mriechers/cardigan` is a *separate, still-current* path, so nobody "fixes" the image prefix by mistake.

## Who reads these

`to-tickets`, `triage`, `to-spec`, `qa` → `issue-tracker.md` · `triage` → `triage-labels.md` · `domain-modeling`, `grill-with-docs`, `improve-codebase-architecture` → `domain.md`

`domain.md` tells agents to proceed silently when `CONTEXT.md` and `docs/adr/` don't exist — they're created lazily by `/domain-modeling` when terms actually get resolved. Neither exists in this repo yet; #337 flags the first natural ADR candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)